### PR TITLE
Alway use default execution context where necessary

### DIFF
--- a/code/app/be/objectify/deadbolt/java/AbstractDeadboltHandler.java
+++ b/code/app/be/objectify/deadbolt/java/AbstractDeadboltHandler.java
@@ -16,6 +16,7 @@
 package be.objectify.deadbolt.java;
 
 import be.objectify.deadbolt.core.models.Subject;
+import play.libs.concurrent.HttpExecution;
 import play.mvc.Http;
 import play.mvc.Result;
 import play.mvc.Results;
@@ -46,8 +47,8 @@ public abstract class AbstractDeadboltHandler extends Results implements Deadbol
     public CompletionStage<Result> onAuthFailure(final Http.Context context,
                                            final String content)
     {
-        return CompletableFuture.supplyAsync(unauthorized::render)
-                                .thenApply(Results::unauthorized);
+        return CompletableFuture.supplyAsync(unauthorized::render, HttpExecution.defaultContext())
+                                .thenApplyAsync(Results::unauthorized, HttpExecution.defaultContext());
     }
 
     /**

--- a/code/app/be/objectify/deadbolt/java/JavaAnalyzer.java
+++ b/code/app/be/objectify/deadbolt/java/JavaAnalyzer.java
@@ -16,6 +16,7 @@
 package be.objectify.deadbolt.java;
 
 import be.objectify.deadbolt.core.DeadboltAnalyzer;
+import play.libs.concurrent.HttpExecution;
 import play.mvc.Http;
 
 import javax.inject.Singleton;
@@ -40,9 +41,9 @@ public class JavaAnalyzer extends DeadboltAnalyzer
                                                        final String value)
     {
         return handler.getDynamicResourceHandler(context)
-                      .thenApply(option -> option.orElseGet(() -> ExceptionThrowingDynamicResourceHandler.INSTANCE))
-                      .thenCompose(drh -> drh.checkPermission(value,
+                      .thenApplyAsync(option -> option.orElseGet(() -> ExceptionThrowingDynamicResourceHandler.INSTANCE), HttpExecution.defaultContext())
+                      .thenComposeAsync(drh -> drh.checkPermission(value,
                                                               handler,
-                                                              context));
+                                                              context), HttpExecution.defaultContext());
     }
 }

--- a/code/app/be/objectify/deadbolt/java/actions/AbstractDeadboltAction.java
+++ b/code/app/be/objectify/deadbolt/java/actions/AbstractDeadboltAction.java
@@ -26,6 +26,7 @@ import be.objectify.deadbolt.java.cache.SubjectCache;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import play.Configuration;
+import play.libs.concurrent.HttpExecution;
 import play.mvc.Action;
 import play.mvc.Http;
 import play.mvc.Result;
@@ -214,14 +215,14 @@ public abstract class AbstractDeadboltAction<T> extends Action<T>
     {
         return subjectCache.apply(deadboltHandler,
                                   ctx)
-                           .thenApply(option -> {
+                           .thenApplyAsync(option -> {
                                if (!option.isPresent())
                                {
                                    LOGGER.info("Access to [{}] requires a subject, but no subject is present.",
                                                ctx.request().uri());
                                }
                                return option;
-                           });
+                           }, HttpExecution.defaultContext());
     }
 
     /**

--- a/code/app/be/objectify/deadbolt/java/actions/AbstractRestrictiveAction.java
+++ b/code/app/be/objectify/deadbolt/java/actions/AbstractRestrictiveAction.java
@@ -24,6 +24,8 @@ import be.objectify.deadbolt.java.JavaAnalyzer;
 import be.objectify.deadbolt.java.cache.HandlerCache;
 import be.objectify.deadbolt.java.cache.SubjectCache;
 import play.Configuration;
+import play.core.j.HttpExecutionContext;
+import play.libs.concurrent.HttpExecution;
 import play.mvc.Http;
 import play.mvc.Result;
 
@@ -61,9 +63,9 @@ public abstract class AbstractRestrictiveAction<T> extends AbstractDeadboltActio
             result = preAuth(true,
                              ctx,
                              deadboltHandler)
-                    .thenCompose(option -> option.map(value -> (CompletionStage<Result>)CompletableFuture.completedFuture(value))
+                    .thenComposeAsync(option -> option.map(value -> (CompletionStage<Result>)CompletableFuture.completedFuture(value))
                                                  .orElseGet(() -> applyRestriction(ctx,
-                                                                                   deadboltHandler)));
+                                                                                   deadboltHandler)), HttpExecution.defaultContext());
         }
         return result;
     }

--- a/code/app/be/objectify/deadbolt/java/actions/AbstractSubjectAction.java
+++ b/code/app/be/objectify/deadbolt/java/actions/AbstractSubjectAction.java
@@ -22,6 +22,7 @@ import be.objectify.deadbolt.java.JavaAnalyzer;
 import be.objectify.deadbolt.java.cache.HandlerCache;
 import be.objectify.deadbolt.java.cache.SubjectCache;
 import play.Configuration;
+import play.libs.concurrent.HttpExecution;
 import play.mvc.Http;
 import play.mvc.Result;
 
@@ -78,9 +79,9 @@ public abstract class AbstractSubjectAction<T>  extends AbstractDeadboltAction<T
             result = preAuth(config.forceBeforeAuthCheck,
                              ctx,
                              deadboltHandler)
-                    .thenCompose(preAuthResult -> new SubjectTest(ctx,
+                    .thenComposeAsync(preAuthResult -> new SubjectTest(ctx,
                                                                   deadboltHandler,
-                                                                  config).apply(preAuthResult));
+                                                                  config).apply(preAuthResult), HttpExecution.defaultContext());
         }
         return maybeBlock(result);
     }
@@ -109,7 +110,7 @@ public abstract class AbstractSubjectAction<T>  extends AbstractDeadboltAction<T
                                 .orElseGet(() -> {
                                     return getSubject(ctx,
                                                       deadboltHandler)
-                                            .thenCompose(subject -> {
+                                            .thenComposeAsync(subject -> {
                                                 final CompletionStage<Result> innerResult;
                                                 if (predicate.test(subject))
                                                 {
@@ -124,7 +125,7 @@ public abstract class AbstractSubjectAction<T>  extends AbstractDeadboltAction<T
                                                                                 ctx);
                                                 }
                                                 return innerResult;
-                                            });
+                                            }, HttpExecution.defaultContext());
                                 });
         }
     }

--- a/code/app/be/objectify/deadbolt/java/actions/BeforeAccessAction.java
+++ b/code/app/be/objectify/deadbolt/java/actions/BeforeAccessAction.java
@@ -21,6 +21,7 @@ import be.objectify.deadbolt.java.JavaAnalyzer;
 import be.objectify.deadbolt.java.cache.HandlerCache;
 import be.objectify.deadbolt.java.cache.SubjectCache;
 import play.Configuration;
+import play.libs.concurrent.HttpExecution;
 import play.mvc.Http;
 import play.mvc.Result;
 
@@ -67,8 +68,8 @@ public class BeforeAccessAction extends AbstractDeadboltAction<BeforeAccess>
             result = preAuth(true,
                              ctx,
                              deadboltHandler)
-                    .thenCompose(preAuthResult -> preAuthResult.map(r -> (CompletionStage<Result>)CompletableFuture.completedFuture(r))
-                                                               .orElseGet(() -> sneakyCall(delegate, ctx)));
+                    .thenComposeAsync(preAuthResult -> preAuthResult.map(r -> (CompletionStage<Result>)CompletableFuture.completedFuture(r))
+                                                               .orElseGet(() -> sneakyCall(delegate, ctx)), HttpExecution.defaultContext());
         }
         return maybeBlock(result);
     }

--- a/code/app/be/objectify/deadbolt/java/actions/DynamicAction.java
+++ b/code/app/be/objectify/deadbolt/java/actions/DynamicAction.java
@@ -22,6 +22,7 @@ import be.objectify.deadbolt.java.JavaAnalyzer;
 import be.objectify.deadbolt.java.cache.HandlerCache;
 import be.objectify.deadbolt.java.cache.SubjectCache;
 import play.Configuration;
+import play.libs.concurrent.HttpExecution;
 import play.mvc.Action;
 import play.mvc.Http;
 import play.mvc.Result;
@@ -75,12 +76,12 @@ public class DynamicAction extends AbstractRestrictiveAction<Dynamic>
                                                     final DeadboltHandler deadboltHandler)
     {
         final CompletionStage<Result> eventualResult = deadboltHandler.getDynamicResourceHandler(ctx)
-                                                                      .thenApply(option -> option.orElseGet(() -> ExceptionThrowingDynamicResourceHandler.INSTANCE))
-                                                                      .thenCompose(drh -> drh.isAllowed(getValue(),
+                                                                      .thenApplyAsync(option -> option.orElseGet(() -> ExceptionThrowingDynamicResourceHandler.INSTANCE), HttpExecution.defaultContext())
+                                                                      .thenComposeAsync(drh -> drh.isAllowed(getValue(),
                                                                                                         getMeta(),
                                                                                                         deadboltHandler,
-                                                                                                        ctx))
-                                                                      .thenCompose(allowed -> {
+                                                                                                        ctx), HttpExecution.defaultContext())
+                                                                      .thenComposeAsync(allowed -> {
                                                                           final CompletionStage<Result> result;
                                                                           if (allowed)
                                                                           {
@@ -95,7 +96,7 @@ public class DynamicAction extends AbstractRestrictiveAction<Dynamic>
                                                                                                      ctx);
                                                                           }
                                                                           return result;
-                                                                      });
+                                                                      }, HttpExecution.defaultContext());
 
         try
         {

--- a/code/app/be/objectify/deadbolt/java/actions/PatternAction.java
+++ b/code/app/be/objectify/deadbolt/java/actions/PatternAction.java
@@ -123,11 +123,11 @@ public class PatternAction extends AbstractRestrictiveAction<Pattern>
         ctx.args.put(ConfigKeys.PATTERN_INVERT,
                      invert);
         return deadboltHandler.getDynamicResourceHandler(ctx)
-                              .thenApply(option -> option.orElseGet(() -> ExceptionThrowingDynamicResourceHandler.INSTANCE))
-                              .thenCompose(resourceHandler -> resourceHandler.checkPermission(getValue(),
+                              .thenApplyAsync(option -> option.orElseGet(() -> ExceptionThrowingDynamicResourceHandler.INSTANCE), HttpExecution.defaultContext())
+                              .thenComposeAsync(resourceHandler -> resourceHandler.checkPermission(getValue(),
                                                                                               deadboltHandler,
-                                                                                              ctx))
-                              .thenCompose(allowed -> {
+                                                                                              ctx), HttpExecution.defaultContext())
+                              .thenComposeAsync(allowed -> {
                                   final CompletionStage<Result> innerResult;
                                   if (invert ? !allowed : allowed)
                                   {
@@ -142,7 +142,7 @@ public class PatternAction extends AbstractRestrictiveAction<Pattern>
                                                                   ctx);
                                   }
                                   return innerResult;
-                              });
+                              }, HttpExecution.defaultContext());
     }
 
     public String getValue()

--- a/code/app/be/objectify/deadbolt/java/actions/RestrictAction.java
+++ b/code/app/be/objectify/deadbolt/java/actions/RestrictAction.java
@@ -21,6 +21,7 @@ import be.objectify.deadbolt.java.JavaAnalyzer;
 import be.objectify.deadbolt.java.cache.HandlerCache;
 import be.objectify.deadbolt.java.cache.SubjectCache;
 import play.Configuration;
+import play.libs.concurrent.HttpExecution;
 import play.mvc.Action;
 import play.mvc.Http;
 import play.mvc.Result;
@@ -77,7 +78,7 @@ public class RestrictAction extends AbstractRestrictiveAction<Restrict>
     {
         final CompletionStage<Result> eventualResult = getSubject(ctx,
                                                                          deadboltHandler)
-                .thenApply(subjectOption -> {
+                .thenApplyAsync(subjectOption -> {
                     boolean roleOk = false;
                     if (subjectOption.isPresent())
                     {
@@ -90,8 +91,8 @@ public class RestrictAction extends AbstractRestrictiveAction<Restrict>
                         }
                     }
                     return roleOk;
-                })
-                .thenCompose(allowed -> {
+                }, HttpExecution.defaultContext())
+                .thenComposeAsync(allowed -> {
                     final CompletionStage<Result> result;
                     if (allowed)
                     {
@@ -106,7 +107,7 @@ public class RestrictAction extends AbstractRestrictiveAction<Restrict>
                                                ctx);
                     }
                     return result;
-                });
+                }, HttpExecution.defaultContext());
 
         try
         {

--- a/code/app/be/objectify/deadbolt/java/cache/DefaultSubjectCache.java
+++ b/code/app/be/objectify/deadbolt/java/cache/DefaultSubjectCache.java
@@ -19,6 +19,7 @@ import be.objectify.deadbolt.core.models.Subject;
 import be.objectify.deadbolt.java.ConfigKeys;
 import be.objectify.deadbolt.java.DeadboltHandler;
 import play.Configuration;
+import play.libs.concurrent.HttpExecution;
 import play.mvc.Http;
 
 import javax.inject.Inject;
@@ -57,11 +58,11 @@ public class DefaultSubjectCache implements SubjectCache
             else
             {
                 promise = deadboltHandler.getSubject(context)
-                                         .thenApply(subjectOption -> {
+                                         .thenApplyAsync(subjectOption -> {
                                              subjectOption.ifPresent(subject -> context.args.put(ConfigKeys.CACHE_DEADBOLT_USER_DEFAULT._1,
                                                                                                  subject));
                                              return subjectOption;
-                                         });
+                                         }, HttpExecution.defaultContext());
             }
         }
         else


### PR DESCRIPTION
Hi again,

in https://github.com/schaloner/deadbolt-2-java/commit/9b9f11e172084f62c9b1589b98032b7587898a15 (`"initial move to Play 2.5"`) you replaced
* `F.Promise.map(...)` with `CompletionStage.thenApply(...)`
* `F.Promise.flatMap(...)` with `CompletionStage.thenCompose(...)`

This isn't completely correct:
* To correctly replace `.map(..)` so it acts exactly the same as before you need to replace it with `.thenApplyAsync(..., HttpExecution.defaultContext())` - see [the docs](https://github.com/playframework/playframework/blob/2.5.0-M1/framework/src/play/src/main/java/play/libs/F.java#L351-L353) (and what the deprecated `map` function itself does...).
* To correctly replace `.flatMap(..)` so it acts exactly the same as before you need to replace it with `.thenComposeAsync(..., HttpExecution.defaultContext())` - see [the docs](https://github.com/playframework/playframework/blob/2.5.0-M1/framework/src/play/src/main/java/play/libs/F.java#L531-L532) (and what the deprecated `flatMap` function itself does...).

If you don't use the `...Async` methods then you use the same thread like the caller of the methods and you also don't pass the classloader and also not the HttpContext down the chain. Not so good...

You also replaced
*  `F.Promise.promise(...)` with `CompletableFuture.supplyAsync(...)`

Here you should also always pass `HttpExecution.defaultContext()`.

But surprise - this PR fixes these issues! :smile: 

Together with #19 this should fix all the execution context stuff.

(To avoid merging conflict please merge #19 before, there are some `import`s which this PR depends on. I want to make it easy :smile:)