### PR TITLE
Move maybeBlock to superclass

### DIFF
--- a/code/app/be/objectify/deadbolt/java/actions/AbstractRestrictiveAction.java
+++ b/code/app/be/objectify/deadbolt/java/actions/AbstractRestrictiveAction.java
@@ -67,7 +67,7 @@ public abstract class AbstractRestrictiveAction<T> extends AbstractDeadboltActio
                                                  .orElseGet(() -> applyRestriction(ctx,
                                                                                    deadboltHandler)), HttpExecution.defaultContext());
         }
-        return result;
+        return maybeBlock(result);
     }
 
     /**

--- a/code/app/be/objectify/deadbolt/java/actions/PatternAction.java
+++ b/code/app/be/objectify/deadbolt/java/actions/PatternAction.java
@@ -35,8 +35,6 @@ import javax.inject.Inject;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.TimeoutException;
 
 /**
  * @author Steve Chaloner (steve@objectify.be)
@@ -106,16 +104,8 @@ public class PatternAction extends AbstractRestrictiveAction<Pattern>
             default:
                 throw new RuntimeException("Unknown pattern type: " + configuration.patternType());
         }
-
-        try
-        {
-            return maybeBlock(result);
-        }
-        catch (InterruptedException | ExecutionException | TimeoutException e)
-        {
-            throw new RuntimeException("Failed to apply pattern constraint",
-                                       e);
-        }
+        
+        return result;
     }
 
     private CompletionStage<Result> custom(final Http.Context ctx,

--- a/code/app/be/objectify/deadbolt/java/actions/RestrictAction.java
+++ b/code/app/be/objectify/deadbolt/java/actions/RestrictAction.java
@@ -30,8 +30,6 @@ import javax.inject.Inject;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.CompletionStage;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.TimeoutException;
 
 /**
  * Implements the {@link Restrict} functionality, i.e. within an {@link Group} roles are ANDed, and between
@@ -76,8 +74,8 @@ public class RestrictAction extends AbstractRestrictiveAction<Restrict>
     public CompletionStage<Result> applyRestriction(final Http.Context ctx,
                                                     final DeadboltHandler deadboltHandler)
     {
-        final CompletionStage<Result> eventualResult = getSubject(ctx,
-                                                                         deadboltHandler)
+        return getSubject(ctx,
+                          deadboltHandler)
                 .thenApplyAsync(subjectOption -> {
                     boolean roleOk = false;
                     if (subjectOption.isPresent())
@@ -108,16 +106,6 @@ public class RestrictAction extends AbstractRestrictiveAction<Restrict>
                     }
                     return result;
                 }, HttpExecution.defaultContext());
-
-        try
-        {
-            return maybeBlock(eventualResult);
-        }
-        catch (InterruptedException | ExecutionException | TimeoutException e)
-        {
-            throw new RuntimeException("Failed to apply restrict constraint",
-                                       e);
-        }
     }
 
     public List<String[]> getRoleGroups()


### PR DESCRIPTION
Fixes an issue introduced with 1ef488847ce8009a590f14825f6e4020dcaaf210:

`AbstractRestrictiveAction` is the superclass of `DynamicAction`, `PatternAction` and `RestrictAction`. Therefore we have to call `maybeBlock` from within the superclass `execute()` method - otherwise blocking won't work because blocking in the subclass would be to late (we would be inside the async thread already). That's because all of the three subclasses' `applyRestriction` methods are always invoked by the superclass' `execute()` method - so that's were to start blocking. We therefore can also remove `maybeBlock` from the subclasses.

With this PR we are now on par with the original #14. (Only in `DefaultSubjectCache` we don't need extra blocking anymore because the views have a blocking mechanism [already](https://github.com/mkurz/deadbolt-2-java/blob/7acc660a3d99f4b038cc05f83e1dbd1a254a2bff/code/app/be/objectify/deadbolt/java/ViewSupport.java#L124-L126)).