### PR TITLE
Make lib code guice free

### DIFF
--- a/code/app/be/objectify/deadbolt/java/ConstraintLogic.java
+++ b/code/app/be/objectify/deadbolt/java/ConstraintLogic.java
@@ -20,7 +20,7 @@ import be.objectify.deadbolt.java.cache.SubjectCache;
 import be.objectify.deadbolt.java.models.PatternType;
 import be.objectify.deadbolt.java.models.Subject;
 import be.objectify.deadbolt.java.utils.TriFunction;
-import com.google.inject.Singleton;
+import javax.inject.Singleton;
 import play.libs.concurrent.HttpExecution;
 import play.mvc.Http;
 import scala.concurrent.ExecutionContext;

--- a/test-app-filters/build.sbt
+++ b/test-app-filters/build.sbt
@@ -7,6 +7,7 @@ scalaVersion := "2.11.11"
 testOptions += Tests.Argument(TestFrameworks.JUnit, "-v", "-a")
 
 libraryDependencies ++= Seq(
+  guice,
   "be.objectify" %% "deadbolt-java" % "2.6.0-M5-SNAPSHOT",
   "com.jayway.restassured" % "rest-assured" % "2.4.0" % "test"
 )

--- a/test-app/build.sbt
+++ b/test-app/build.sbt
@@ -7,6 +7,7 @@ scalaVersion := "2.11.11"
 testOptions += Tests.Argument(TestFrameworks.JUnit, "-v", "-a")
 
 libraryDependencies ++= Seq(
+  guice,
   "be.objectify" %% "deadbolt-java" % "2.6.0-M5-SNAPSHOT",
   "com.jayway.restassured" % "rest-assured" % "2.4.0" % "test"
 )


### PR DESCRIPTION
Play 2.6 removed guice by default.
`ConstraintLogic.java` - probably unintentionally - used the guice `Singleton`.

To make the test apps work you now need to add the `guice` dependency explicitly because these apps make use of `com.google.inject.BindingAnnotation`.