### PR TITLE
Disable PlayFilters auto-plugin

### DIFF
--- a/code/build.sbt
+++ b/code/build.sbt
@@ -1,6 +1,6 @@
 name := "deadbolt-java"
 
-lazy val root = (project in file(".")).enablePlugins(PlayJava)
+lazy val root = (project in file(".")).enablePlugins(PlayJava).disablePlugins(PlayFilters)
 
 scalaVersion := "2.11.11"
 


### PR DESCRIPTION
Have a look at [Play 2.6 migration guide](https://www.playframework.com/documentation/2.6.x/Migration26#Disabling-Default-Filters):
> If you want to remove **all filter classes**, you can disable it through the disablePlugins mechanism:
> `lazy val root = project.in(file(".")).enablePlugins(PlayScala).disablePlugins(PlayFilters)`

What does this solve?
If I have a project that depends on deadbolt and want to disable the filters in my project via `.disablePlugins(PlayFilters)` the filters would still be enabled because they are enabled in the deadbolt library...