### PR TITLE
Add generic DefaultSubject

### DIFF
--- a/code/app/be/objectify/deadbolt/java/models/DefaultSubject.java
+++ b/code/app/be/objectify/deadbolt/java/models/DefaultSubject.java
@@ -38,8 +38,8 @@ public class DefaultSubject implements Subject, Serializable
     public DefaultSubject(final String identifier, final List<String> roles, final List<String> permissions)
     {
         this.identifier = identifier;
-        this.roles = (roles != null) ? Collections.unmodifiableList(roles.stream().<Role>map(role -> () -> role).collect(Collectors.toCollection(() -> new ArrayList<>()))) : null;
-        this.permissions = (permissions != null) ? Collections.unmodifiableList(permissions.stream().<Permission>map(permission -> () -> permission).collect(Collectors.toCollection(() -> new ArrayList<>()))) : null;
+        this.roles = (roles != null) ? Collections.unmodifiableList(roles.stream().map(role -> (Role & Serializable)() -> role).collect(Collectors.toCollection(() -> new ArrayList<>()))) : null;
+        this.permissions = (permissions != null) ? Collections.unmodifiableList(permissions.stream().map(permission -> (Permission & Serializable)() -> permission).collect(Collectors.toCollection(() -> new ArrayList<>()))) : null;
     }
 
     @Override

--- a/code/app/be/objectify/deadbolt/java/models/DefaultSubject.java
+++ b/code/app/be/objectify/deadbolt/java/models/DefaultSubject.java
@@ -24,7 +24,7 @@ import java.util.stream.Collectors;
 /**
  * Default implementation of a Subject.
  *
- * @author Steve Chaloner (steve@objectify.be)
+ * @author Matthias Kurz (m.kurz@irregular.at)
  */
 public class DefaultSubject implements Subject, Serializable
 {

--- a/code/app/be/objectify/deadbolt/java/models/DefaultSubject.java
+++ b/code/app/be/objectify/deadbolt/java/models/DefaultSubject.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2010-2016 Steve Chaloner
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package be.objectify.deadbolt.java.models;
+
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * Default implementation of a Subject.
+ *
+ * @author Steve Chaloner (steve@objectify.be)
+ */
+public class DefaultSubject implements Subject, Serializable
+{
+
+    private static final long serialVersionUID = 4340914517470685171L;
+
+    private final String identifier;
+    private final List<? extends Role> roles;
+    private final List<? extends Permission> permissions;
+
+    public DefaultSubject(final String identifier, final List<String> roles, final List<String> permissions)
+    {
+        this.identifier = identifier;
+        this.roles = (roles != null) ? Collections.unmodifiableList(roles.stream().<Role>map(role -> () -> role).collect(Collectors.toCollection(() -> new ArrayList<>()))) : null;
+        this.permissions = (permissions != null) ? Collections.unmodifiableList(permissions.stream().<Permission>map(permission -> () -> permission).collect(Collectors.toCollection(() -> new ArrayList<>()))) : null;
+    }
+
+    @Override
+    public String getIdentifier()
+    {
+        return this.identifier;
+    }
+
+    @Override
+    public List<? extends Role> getRoles()
+    {
+        return this.roles;
+    }
+
+    @Override
+    public List<? extends Permission> getPermissions()
+    {
+        return this.permissions;
+    }
+}

--- a/code/test/be/objectify/deadbolt/java/models/DefaultSubjectTest.java
+++ b/code/test/be/objectify/deadbolt/java/models/DefaultSubjectTest.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2013 Steve Chaloner
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package be.objectify.deadbolt.java;
+
+import java.io.Serializable;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import be.objectify.deadbolt.java.models.DefaultSubject;
+import be.objectify.deadbolt.java.models.Permission;
+import be.objectify.deadbolt.java.models.Role;
+import be.objectify.deadbolt.java.models.Subject;
+
+/**
+ * @author Matthias Kurz (m.kurz@irregular.at)
+ */
+public class DefaultSubjectTest
+{
+    private final static List<String> ROLES = Arrays.asList("admin", "support");
+    private final static List<String> PERMISSIONS = Arrays.asList("createuser", "dropuser", "createdocument", "dropdocument");
+
+    private Subject testSubject;
+
+    @Before
+    public void setUp()
+    {
+        this.testSubject = new DefaultSubject("9876", ROLES, PERMISSIONS);
+    }
+
+    @Test
+    public void testDefaultSubjectInstance()
+    {
+        Assert.assertTrue(this.testSubject instanceof DefaultSubject);
+        Assert.assertTrue(this.testSubject instanceof Serializable);
+        Assert.assertTrue(this.testSubject.getIdentifier().equals("9876"));
+    }
+
+    @Test
+    public void testRoleInstances()
+    {
+        Assert.assertTrue(this.testSubject.getRoles().size() == 2);
+        final List<String> rolesFromSubject = this.testSubject.getRoles().stream().peek(role -> Assert.assertTrue(role instanceof Role && role instanceof Serializable))
+            .map(role -> role.getName()).collect(Collectors.toList());
+        ROLES.stream().forEach(role -> Assert.assertTrue(rolesFromSubject.contains(role)));
+    }
+
+    @Test
+    public void testPermissionsInstances()
+    {
+        Assert.assertTrue(this.testSubject.getPermissions().size() == 4);
+        final List<String> permissionsFromSubject = this.testSubject.getPermissions().stream().peek(permission -> Assert.assertTrue(permission instanceof Permission && permission instanceof Serializable))
+            .map(permission -> permission.getValue()).collect(Collectors.toList());
+        PERMISSIONS.stream().forEach(permission -> Assert.assertTrue(permissionsFromSubject.contains(permission)));
+    }
+
+}


### PR DESCRIPTION
Hi Steve,

we use a very generic `Subject` and I thought it's so generic it might should live upstream so other people can use it as well:

```java
String userId = ....;
List<String> roles = ...
List<String> permissions = ...
//...
new DefaultSubject(userId, roles, permissions);
```
I also made it serializable just in case someone wants to cache such a subject instance (that's why i explicitly use `ArrayList` in the implementation because that one is serializabe - not all `List`s are).
I made it immutable as well.

I think adding such a default subject makes sense since the `Role` and `Permission` interface just forces you to back a `String` method/field.

If you don't think thats a good idea just close this PR.
If you merge a minor release would be appreciated :wink: