### PR TITLE
Allow caching of multiple subjects per request

### DIFF
--- a/code/app/be/objectify/deadbolt/java/AbstractDeadboltHandler.java
+++ b/code/app/be/objectify/deadbolt/java/AbstractDeadboltHandler.java
@@ -25,6 +25,7 @@ import scala.concurrent.ExecutionContextExecutor;
 import views.html.defaultpages.unauthorized;
 
 import java.util.Optional;
+import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 
@@ -37,9 +38,19 @@ public abstract class AbstractDeadboltHandler extends Results implements Deadbol
 {
     protected final DeadboltExecutionContextProvider executionContextProvider;
 
+    private static final AtomicLong NEXT_ID = new AtomicLong(0);
+    private final long id = NEXT_ID.getAndIncrement();
+
     public AbstractDeadboltHandler(final ExecutionContextProvider ecProvider)
     {
         this.executionContextProvider = ecProvider.get();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public long getId() {
+        return this.id;
     }
 
     /**

--- a/code/app/be/objectify/deadbolt/java/DeadboltHandler.java
+++ b/code/app/be/objectify/deadbolt/java/DeadboltHandler.java
@@ -37,6 +37,14 @@ public interface DeadboltHandler
 {
 
     /**
+     * Gets the unique id of this DeadboltHandler instance. Each instance of a DeadboltHandler interface gets
+     * an application wide unique id.
+     *
+     * @return the application wide unique id of this DeadboltHandler instance.
+     */
+    long getId();
+
+    /**
      * Invoked immediately before controller or view restrictions are checked. This forms the integration with any
      * authentication actions that may need to occur.
      *

--- a/code/app/be/objectify/deadbolt/java/cache/DefaultSubjectCache.java
+++ b/code/app/be/objectify/deadbolt/java/cache/DefaultSubjectCache.java
@@ -62,7 +62,8 @@ public class DefaultSubjectCache implements SubjectCache
         final CompletionStage<Optional<? extends Subject>> promise;
         if (cacheUserPerRequestEnabled)
         {
-            final Optional<? extends Subject> cachedUser = Optional.ofNullable((Subject) context.args.get(ConfigKeys.CACHE_DEADBOLT_USER_DEFAULT._1));
+            final String deadboltHandlerCacheId = ConfigKeys.CACHE_DEADBOLT_USER_DEFAULT._1 + "." + deadboltHandler.getId(); // results into "deadbolt.java.cache-user.0"
+            final Optional<? extends Subject> cachedUser = Optional.ofNullable((Subject) context.args.get(deadboltHandlerCacheId));
             if (cachedUser.isPresent())
             {
                 promise = CompletableFuture.completedFuture(cachedUser);
@@ -74,7 +75,7 @@ public class DefaultSubjectCache implements SubjectCache
                 promise = deadboltHandler.getSubject(context)
                                          .thenApplyAsync(subjectOption ->
                                                          {
-                                                             subjectOption.ifPresent(subject -> context.args.put(ConfigKeys.CACHE_DEADBOLT_USER_DEFAULT._1,
+                                                             subjectOption.ifPresent(subject -> context.args.put(deadboltHandlerCacheId,
                                                                                                                  subject));
                                                              return subjectOption;
                                                          }, executor);

--- a/test-app-filters/conf/application.conf
+++ b/test-app-filters/conf/application.conf
@@ -18,7 +18,6 @@ play {
 
 deadbolt {
   java {
-    # cache-user is set to false, otherwise it's not possible to mix deadbolt handlers that do and don't have users in the template tests
     cache-user=false
     custom-execution-context {
       enable=true

--- a/test-app/conf/application.conf
+++ b/test-app/conf/application.conf
@@ -17,7 +17,6 @@ play {
 
 deadbolt {
   java {
-    # cache-user is set to false, otherwise it's not possible to mix deadbolt handlers that do and don't have users in the template tests
     cache-user=false
     custom-execution-context {
       enable=true


### PR DESCRIPTION
It is now possible to cache multiple subjects (each one from a different deadbolt handler) per request.

Problem was that we used the same key to store a subject into the request context args map - no matter from which deadbolt handler this subject came from - so multiple handlers would override each others cached subjects or we would fetch wrong subjects from the "cache".
Now each deadbolt handler **instance** will have an unique id that will be used to generate an unique key for it's subjects ctx map entry (taken from [this sof answer](https://stackoverflow.com/a/8939049/810109))
So we can store as many deadbolt-handler subjects as we like in the ctx args in parallel within the same context/request and never override each other or fetch the wrong one (ok to be fair it's `1,844674407×10¹⁹` subjects/deadbolt handlers in parallel for *each* request because that's what `abs(Long.MIN_VALUE)` + `Long.MAX_VALUE` is - if you ever hit that limit in my life time call me I invite you for a beer or two. If you use that many handlers within one request you face other issues...)

Steve, what do you think?