### PR TITLE
Always check all constraints

### DIFF
--- a/code/app/be/objectify/deadbolt/java/ConfigKeys.java
+++ b/code/app/be/objectify/deadbolt/java/ConfigKeys.java
@@ -39,6 +39,10 @@ public class ConfigKeys
     public static final F.Tuple<String, Boolean> CUSTOM_EC_DEFAULT = new F.Tuple<>(CUSTOM_EC,
                                                                                    false);
 
+    public static final String ALWAYS_CHECK_ALL_CONSTRAINTS = "deadbolt.java.always-check-all-constraints";
+    public static final F.Tuple<String, Boolean> ALWAYS_CHECK_ALL_CONSTRAINTS_DEFAULT = new F.Tuple<>(ALWAYS_CHECK_ALL_CONSTRAINTS,
+                                                                                   false);
+
     public static final String PATTERN_INVERT = "deadbolt.pattern.invert";
 
     private ConfigKeys()

--- a/code/app/be/objectify/deadbolt/java/ConfigKeys.java
+++ b/code/app/be/objectify/deadbolt/java/ConfigKeys.java
@@ -39,9 +39,9 @@ public class ConfigKeys
     public static final F.Tuple<String, Boolean> CUSTOM_EC_DEFAULT = new F.Tuple<>(CUSTOM_EC,
                                                                                    false);
 
-    public static final String ALWAYS_CHECK_ALL_CONSTRAINTS = "deadbolt.java.always-check-all-constraints";
-    public static final F.Tuple<String, Boolean> ALWAYS_CHECK_ALL_CONSTRAINTS_DEFAULT = new F.Tuple<>(ALWAYS_CHECK_ALL_CONSTRAINTS,
-                                                                                   false);
+    public static final String CONSTRAINT_MODE = "deadbolt.java.constraint-mode";
+    public static final F.Tuple<String, String> CONSTRAINT_MODE_DEFAULT = new F.Tuple<>(CONSTRAINT_MODE,
+                                                                                   ConstraintMode.PROCESS_FIRST_CONSTRAINT_ONLY.toString());
 
     public static final String PATTERN_INVERT = "deadbolt.pattern.invert";
 

--- a/code/app/be/objectify/deadbolt/java/ConstraintMode.java
+++ b/code/app/be/objectify/deadbolt/java/ConstraintMode.java
@@ -1,0 +1,12 @@
+package be.objectify.deadbolt.java;
+
+public enum ConstraintMode {
+
+	// Only the first constraint in the action composition chain will ever be checked (the remaining ones will always be skipped and NEVER be executed).
+	// The default (because of backward compatibility).
+    PROCESS_FIRST_CONSTRAINT_ONLY,
+
+    // All constraints in the action composition chain have to be successful.
+    AND
+
+}

--- a/code/app/be/objectify/deadbolt/java/ConstraintMode.java
+++ b/code/app/be/objectify/deadbolt/java/ConstraintMode.java
@@ -7,6 +7,9 @@ public enum ConstraintMode {
     PROCESS_FIRST_CONSTRAINT_ONLY,
 
     // All constraints in the action composition chain have to be successful.
-    AND
+    AND,
+
+    // All constraints in the the action composition chain will be checked until one is successful (in that case the remaining constraint will be skipped).
+    OR
 
 }

--- a/code/app/be/objectify/deadbolt/java/actions/AbstractDeadboltAction.java
+++ b/code/app/be/objectify/deadbolt/java/actions/AbstractDeadboltAction.java
@@ -16,6 +16,7 @@
 package be.objectify.deadbolt.java.actions;
 
 import be.objectify.deadbolt.java.ConfigKeys;
+import be.objectify.deadbolt.java.ConstraintMode;
 import be.objectify.deadbolt.java.DeadboltHandler;
 import be.objectify.deadbolt.java.cache.HandlerCache;
 import com.typesafe.config.Config;
@@ -58,7 +59,7 @@ public abstract class AbstractDeadboltAction<T> extends Action<T>
 
     public final boolean blocking;
     public final long blockingTimeout;
-    public final boolean alwaysCheckAllConstraints;
+    public final ConstraintMode constraintMode;
 
     protected AbstractDeadboltAction(final HandlerCache handlerCache,
                                      final Config config)
@@ -71,12 +72,12 @@ public abstract class AbstractDeadboltAction<T> extends Action<T>
                      ConfigKeys.BLOCKING_DEFAULT._2);
         defaults.put(ConfigKeys.DEFAULT_BLOCKING_TIMEOUT_DEFAULT._1,
                      ConfigKeys.DEFAULT_BLOCKING_TIMEOUT_DEFAULT._2);
-        defaults.put(ConfigKeys.ALWAYS_CHECK_ALL_CONSTRAINTS_DEFAULT._1,
-                     ConfigKeys.ALWAYS_CHECK_ALL_CONSTRAINTS_DEFAULT._2);
+        defaults.put(ConfigKeys.CONSTRAINT_MODE_DEFAULT._1,
+                     ConfigKeys.CONSTRAINT_MODE_DEFAULT._2);
         final Config configWithFallback = config.withFallback(ConfigFactory.parseMap(defaults));
         this.blocking = configWithFallback.getBoolean(ConfigKeys.BLOCKING_DEFAULT._1);
         this.blockingTimeout = configWithFallback.getLong(ConfigKeys.DEFAULT_BLOCKING_TIMEOUT_DEFAULT._1);
-        this.alwaysCheckAllConstraints = configWithFallback.getBoolean(ConfigKeys.ALWAYS_CHECK_ALL_CONSTRAINTS_DEFAULT._1);
+        this.constraintMode = ConstraintMode.valueOf(configWithFallback.getString(ConfigKeys.CONSTRAINT_MODE_DEFAULT._1));
     }
 
     /**
@@ -179,11 +180,6 @@ public abstract class AbstractDeadboltAction<T> extends Action<T>
      */
     protected void markActionAsAuthorised(final Http.Context ctx)
     {
-        if(alwaysCheckAllConstraints)
-        {
-            // Don't mark an action as authorised, we want the other constraints to get evaluated as well!
-            return;
-        }
         ctx.args.put(ACTION_AUTHORISED,
                      true);
     }
@@ -207,11 +203,6 @@ public abstract class AbstractDeadboltAction<T> extends Action<T>
      */
     protected boolean isActionAuthorised(final Http.Context ctx)
     {
-        if(alwaysCheckAllConstraints)
-        {
-            // Never say an action is authorised, we want all constraints to be evaluated
-            return false;
-        }
         final Object o = ctx.args.get(ACTION_AUTHORISED);
         return o != null && (Boolean) o;
     }
@@ -295,7 +286,11 @@ public abstract class AbstractDeadboltAction<T> extends Action<T>
      */
     protected CompletionStage<Result> authorizeAndExecute(final Http.Context context)
     {
-        markActionAsAuthorised(context);
+        if(constraintMode != ConstraintMode.AND)
+        {
+            // In AND mode we don't mark an action as authorised because we want ALL (remaining) constraints to be evaluated as well!
+            markActionAsAuthorised(context);
+        }
         return delegate.call(context);
     }
 

--- a/code/app/be/objectify/deadbolt/java/actions/AbstractDeadboltAction.java
+++ b/code/app/be/objectify/deadbolt/java/actions/AbstractDeadboltAction.java
@@ -178,7 +178,7 @@ public abstract class AbstractDeadboltAction<T> extends Action<T>
      *
      * @param ctx the request context
      */
-    protected void markActionAsAuthorised(final Http.Context ctx)
+    private void markActionAsAuthorised(final Http.Context ctx)
     {
         ctx.args.put(ACTION_AUTHORISED,
                      true);
@@ -189,7 +189,7 @@ public abstract class AbstractDeadboltAction<T> extends Action<T>
      *
      * @param ctx the request context
      */
-    protected void markActionAsUnauthorised(final Http.Context ctx)
+    private void markActionAsUnauthorised(final Http.Context ctx)
     {
         ctx.args.put(ACTION_UNAUTHORISED,
                      true);

--- a/code/app/be/objectify/deadbolt/java/actions/AbstractDeadboltAction.java
+++ b/code/app/be/objectify/deadbolt/java/actions/AbstractDeadboltAction.java
@@ -58,6 +58,7 @@ public abstract class AbstractDeadboltAction<T> extends Action<T>
 
     public final boolean blocking;
     public final long blockingTimeout;
+    public final boolean alwaysCheckAllConstraints;
 
     protected AbstractDeadboltAction(final HandlerCache handlerCache,
                                      final Config config)
@@ -70,9 +71,12 @@ public abstract class AbstractDeadboltAction<T> extends Action<T>
                      ConfigKeys.BLOCKING_DEFAULT._2);
         defaults.put(ConfigKeys.DEFAULT_BLOCKING_TIMEOUT_DEFAULT._1,
                      ConfigKeys.DEFAULT_BLOCKING_TIMEOUT_DEFAULT._2);
+        defaults.put(ConfigKeys.ALWAYS_CHECK_ALL_CONSTRAINTS_DEFAULT._1,
+                     ConfigKeys.ALWAYS_CHECK_ALL_CONSTRAINTS_DEFAULT._2);
         final Config configWithFallback = config.withFallback(ConfigFactory.parseMap(defaults));
         this.blocking = configWithFallback.getBoolean(ConfigKeys.BLOCKING_DEFAULT._1);
         this.blockingTimeout = configWithFallback.getLong(ConfigKeys.DEFAULT_BLOCKING_TIMEOUT_DEFAULT._1);
+        this.alwaysCheckAllConstraints = configWithFallback.getBoolean(ConfigKeys.ALWAYS_CHECK_ALL_CONSTRAINTS_DEFAULT._1);
     }
 
     /**
@@ -175,6 +179,11 @@ public abstract class AbstractDeadboltAction<T> extends Action<T>
      */
     protected void markActionAsAuthorised(final Http.Context ctx)
     {
+        if(alwaysCheckAllConstraints)
+        {
+            // Don't mark an action as authorised, we want the other constraints to get evaluated as well!
+            return;
+        }
         ctx.args.put(ACTION_AUTHORISED,
                      true);
     }
@@ -198,6 +207,11 @@ public abstract class AbstractDeadboltAction<T> extends Action<T>
      */
     protected boolean isActionAuthorised(final Http.Context ctx)
     {
+        if(alwaysCheckAllConstraints)
+        {
+            // Never say an action is authorised, we want all constraints to be evaluated
+            return false;
+        }
         final Object o = ctx.args.get(ACTION_AUTHORISED);
         return o != null && (Boolean) o;
     }

--- a/code/app/be/objectify/deadbolt/java/actions/CompositeAction.java
+++ b/code/app/be/objectify/deadbolt/java/actions/CompositeAction.java
@@ -66,13 +66,9 @@ public class CompositeAction extends AbstractRestrictiveAction<Composite>
                                                                                                             handler,
                                                                                                             Optional.ofNullable(configuration.content())));
                                   })
-                             .orElseGet(() ->
-                                        {
-                                            markActionAsUnauthorised(ctx);
-                                            return onAuthFailure(handler,
-                                                                 Optional.ofNullable(configuration.content()),
-                                                                 ctx);
-                                        });
+                             .orElseGet(() -> unauthorizeAndFail(ctx,
+                            		                             handler,
+                            		                             Optional.ofNullable(configuration.content())));
     }
 
     public String getMeta()


### PR DESCRIPTION
**Following situation:**
We have two roles. Therefore our users belong to either role1 (BACKOFFICE) or role2 (SALES) - but that two roles share (better: can have) the same permissions. Because of that we don't use the deadbolt role-based-permissions feature - since an admin user is able to assign each permission to each user separately (doesn't matter which role a user belongs to), so a (set of) permission(s) is **not** bound to a specific role.
Like this:

| (user)    | (role)     | write_post | send_newsletter | add_new_user |
|-----------|------------|------------|-----------------|--------------|
| mkurz     | BACKOFFICE |            | [x]             | [x]          |
| schaloner | SALES      | [x]        | [x]             |              |
| ltorvalds | BACKOFFICE |            |                 | [x]          |
| swozniak | SALES |  [x]            |                 | [x]          |

As you can see the permissions are assigned randomly to the users (and therefore to the roles).

We now have two controllers:
```java
@Restrict(@Group("BACKOFFICE"))
public class Controller1 extends Controller {

	@Pattern("send_newsletter")
	public CompletionStage<Result> someAction() {
		// ...
	}
}
```
```java
@Restrict(@Group("SALES"))
public class Controller2 extends Controller {

	@Pattern("send_newsletter")
	public CompletionStage<Result> someOtherAction() {
		// ...
	}
}
```
**What is the problem we are facing?**

If `mkurz` - a `BACKOFFICE` user - accesses `Controller2.someOtherAction` he is allowed to do so. WAT? I thought only `SALES` people are allowed to access `Controller2`? Why? I can tell you why: Because as soon as deadbolt encounters a succesfull constraint check (in this case `@Pattern("send_newsletter")` on `someOtherAction` - `mkurz` does have this permission) it marks the action method "authorised". Which means any constraint checks that come later (in our case - because by default action method annotations are executed before controller annotations -   `@Restrict(@Group("SALES"))` on the `Controller2` class itself) don't even bother checking their constraints but just continue execution the action composition chain (by checking `isActionAuthorised` [here](https://github.com/schaloner/deadbolt-2-java/blob/v2.6.3/code/app/be/objectify/deadbolt/java/actions/AbstractRestrictiveAction.java#L50), [here](https://github.com/schaloner/deadbolt-2-java/blob/v2.6.3/code/app/be/objectify/deadbolt/java/actions/BeforeAccessAction.java#L50) and [here](https://github.com/schaloner/deadbolt-2-java/blob/v2.6.3/code/app/be/objectify/deadbolt/java/actions/AbstractSubjectAction.java#L59)).

So I am asking myself: **Is this a feature or a bug?**

Because we do **not** want that an action gets executed as soon as **only one** constraint passes its check - we want that **every** restriction and pattern (and other constraints) *which are in the current action composition chain* pass before an action is allowed to be executed.

Steve, do you get my thoughts?

So what this pull request does it introduces a `deadbolt.java.always-check-all-constraints` boolean setting (which is `false` by default to keep backward compatibility), which - when enabled - just ensures that an action never gets marked as "authorised" meaning that every subsequent constraint in the action composition chain has to really do it's check. (If you come up with a better name for the config flag tell me).

If you ask me I find the current behaviour a bit unsafe... I definitely would expect that all restrict, pattern, etc, of an action AND its controller (and superclass controller) pass before executing the action method....

This behaviour even results in weirdness like this:
```java
	@Restrict(@Group("SALES"))
	@Pattern("send_newsletter")
	public CompletionStage<Result> someSuperMegaSafeAction() {
		// ...
	}
```
So in this example we would now only check if a user has the `SALES` group (because that one comes first) but wouldn't care about the `send_newsletter` permission because the action would be "authorised" by the first check already. So even `swozniak` - which is defined as a sales guy but doesn't have the `send_newsletter` permission would nevertheless get access to this `someSuperMegaSafeAction` (to maybe send out some sneaky newsletters he isn't supposed to do?).

We could go even further and change the [Play default behaviour](https://github.com/playframework/playframework/blob/2.6.6/framework/src/play/src/main/resources/reference.conf#L114-L115) so controller annotations come before action methods annotations. For our `Controller1` and `Controller2` above that of course would result into that we would just care about the role on the controller-level but not about the permission on the action-method-level.

If you ask me again I would say just completely remove [markActionAsAuthorised](https://github.com/schaloner/deadbolt-2-java/blob/v2.6.3/code/app/be/objectify/deadbolt/java/actions/AbstractDeadboltAction.java#L176) and [isActionAuthorised](https://github.com/schaloner/deadbolt-2-java/blob/v2.6.3/code/app/be/objectify/deadbolt/java/actions/AbstractDeadboltAction.java#L199) and never ever mark an action "authorised".
Or maybe I just don't get that there is a deeper sense behind this methods...