### PR TITLE
Cache result of deadboltHandler.beforeAuthCheck()

### DIFF
--- a/code/app/be/objectify/deadbolt/java/ConfigKeys.java
+++ b/code/app/be/objectify/deadbolt/java/ConfigKeys.java
@@ -23,9 +23,15 @@ import play.libs.F;
 public class ConfigKeys
 {
     public static final String DEFAULT_HANDLER_KEY = "defaultHandler";
+
     public static final String CACHE_DEADBOLT_USER = "deadbolt.java.cache-user";
     public static final F.Tuple<String, Boolean> CACHE_DEADBOLT_USER_DEFAULT = new F.Tuple<>(CACHE_DEADBOLT_USER,
                                                                                              false);
+
+    public static final String CACHE_BEFORE_AUTH_CHECK = "deadbolt.java.cache-before-auth-check";
+    public static final F.Tuple<String, Boolean> CACHE_BEFORE_AUTH_CHECK_DEFAULT = new F.Tuple<>(CACHE_BEFORE_AUTH_CHECK,
+                                                                                             false);
+
     public static final String DEFAULT_VIEW_TIMEOUT = "deadbolt.java.view-timeout";
     public static final F.Tuple<String, Long> DEFAULT_VIEW_TIMEOUT_DEFAULT = new F.Tuple<>(DEFAULT_VIEW_TIMEOUT,
                                                                                            1000L);

--- a/code/app/be/objectify/deadbolt/java/DeadboltHandler.java
+++ b/code/app/be/objectify/deadbolt/java/DeadboltHandler.java
@@ -45,7 +45,7 @@ public interface DeadboltHandler
     long getId();
 
     /**
-     * Invoked immediately before controller or view restrictions are checked. This forms the integration with any
+     * Invoked immediately before controller restrictions are checked. This forms the integration with any
      * authentication actions that may need to occur.
      *
      * @param context the HTTP context

--- a/code/app/be/objectify/deadbolt/java/DeadboltModule.java
+++ b/code/app/be/objectify/deadbolt/java/DeadboltModule.java
@@ -19,8 +19,10 @@ import be.objectify.deadbolt.java.cache.CompositeCache;
 import be.objectify.deadbolt.java.cache.DefaultCompositeCache;
 import be.objectify.deadbolt.java.cache.DefaultPatternCache;
 import be.objectify.deadbolt.java.cache.DefaultSubjectCache;
+import be.objectify.deadbolt.java.cache.DefaultBeforeAuthCheckCache;
 import be.objectify.deadbolt.java.cache.PatternCache;
 import be.objectify.deadbolt.java.cache.SubjectCache;
+import be.objectify.deadbolt.java.cache.BeforeAuthCheckCache;
 import be.objectify.deadbolt.java.composite.ConstraintBuilders;
 import be.objectify.deadbolt.java.filters.FilterConstraints;
 import play.api.Configuration;
@@ -41,6 +43,7 @@ public class DeadboltModule extends Module
                                     final Configuration configuration)
     {
         return seq(subjectCache(),
+                   beforeAuthCheckCache(),
                    patternCache(),
                    analyzer(),
                    viewSupport(),
@@ -130,6 +133,16 @@ public class DeadboltModule extends Module
     public Binding<SubjectCache> subjectCache()
     {
         return bind(SubjectCache.class).to(DefaultSubjectCache.class).in(Singleton.class);
+    }
+
+    /**
+     * Create a binding for {@link BeforeAuthCheckCache}.
+     *
+     * @return the binding
+     */
+    public Binding<BeforeAuthCheckCache> beforeAuthCheckCache()
+    {
+        return bind(BeforeAuthCheckCache.class).to(DefaultBeforeAuthCheckCache.class).in(Singleton.class);
     }
 
     /**

--- a/code/app/be/objectify/deadbolt/java/actions/AbstractDeadboltAction.java
+++ b/code/app/be/objectify/deadbolt/java/actions/AbstractDeadboltAction.java
@@ -17,6 +17,7 @@ package be.objectify.deadbolt.java.actions;
 
 import be.objectify.deadbolt.java.ConfigKeys;
 import be.objectify.deadbolt.java.DeadboltHandler;
+import be.objectify.deadbolt.java.cache.BeforeAuthCheckCache;
 import be.objectify.deadbolt.java.cache.HandlerCache;
 import com.typesafe.config.Config;
 import com.typesafe.config.ConfigFactory;
@@ -54,15 +55,19 @@ public abstract class AbstractDeadboltAction<T> extends Action<T>
 
     final HandlerCache handlerCache;
 
+    final BeforeAuthCheckCache beforeAuthCheckCache;
+
     final Config config;
 
     public final boolean blocking;
     public final long blockingTimeout;
 
     protected AbstractDeadboltAction(final HandlerCache handlerCache,
+                                     final BeforeAuthCheckCache beforeAuthCheckCache,
                                      final Config config)
     {
         this.handlerCache = handlerCache;
+        this.beforeAuthCheckCache = beforeAuthCheckCache;
         this.config = config;
 
         final HashMap<String, Object> defaults = new HashMap<>();
@@ -268,7 +273,7 @@ public abstract class AbstractDeadboltAction<T> extends Action<T>
                                                      final Http.Context ctx,
                                                      final DeadboltHandler deadboltHandler)
     {
-        return forcePreAuthCheck ? deadboltHandler.beforeAuthCheck(ctx)
+        return forcePreAuthCheck ? beforeAuthCheckCache.apply(deadboltHandler, ctx)
                                  : CompletableFuture.completedFuture(Optional.empty());
     }
 

--- a/code/app/be/objectify/deadbolt/java/actions/AbstractRestrictiveAction.java
+++ b/code/app/be/objectify/deadbolt/java/actions/AbstractRestrictiveAction.java
@@ -17,6 +17,7 @@ package be.objectify.deadbolt.java.actions;
 
 import be.objectify.deadbolt.java.ConstraintLogic;
 import be.objectify.deadbolt.java.DeadboltHandler;
+import be.objectify.deadbolt.java.cache.BeforeAuthCheckCache;
 import be.objectify.deadbolt.java.cache.HandlerCache;
 import com.typesafe.config.Config;
 import play.mvc.Http;
@@ -35,10 +36,12 @@ public abstract class AbstractRestrictiveAction<T> extends AbstractDeadboltActio
     final ConstraintLogic constraintLogic;
 
     public AbstractRestrictiveAction(final HandlerCache handlerCache,
+                                     final BeforeAuthCheckCache beforeAuthCheckCache,
                                      final Config config,
                                      final ConstraintLogic constraintLogic)
     {
         super(handlerCache,
+              beforeAuthCheckCache,
               config);
         this.constraintLogic = constraintLogic;
     }

--- a/code/app/be/objectify/deadbolt/java/actions/AbstractSubjectAction.java
+++ b/code/app/be/objectify/deadbolt/java/actions/AbstractSubjectAction.java
@@ -17,6 +17,7 @@ package be.objectify.deadbolt.java.actions;
 
 import be.objectify.deadbolt.java.ConstraintLogic;
 import be.objectify.deadbolt.java.DeadboltHandler;
+import be.objectify.deadbolt.java.cache.BeforeAuthCheckCache;
 import be.objectify.deadbolt.java.cache.HandlerCache;
 import play.mvc.Http;
 import play.mvc.Result;
@@ -34,10 +35,12 @@ public abstract class AbstractSubjectAction<T> extends AbstractDeadboltAction<T>
     private final ConstraintLogic constraintLogic;
 
     AbstractSubjectAction(final HandlerCache handlerCache,
+                          final BeforeAuthCheckCache beforeAuthCheckCache,
                           final com.typesafe.config.Config config,
                           final ConstraintLogic constraintLogic)
     {
         super(handlerCache,
+              beforeAuthCheckCache,
               config);
         this.constraintLogic = constraintLogic;
     }

--- a/code/app/be/objectify/deadbolt/java/actions/BeforeAccessAction.java
+++ b/code/app/be/objectify/deadbolt/java/actions/BeforeAccessAction.java
@@ -16,6 +16,7 @@
 package be.objectify.deadbolt.java.actions;
 
 import be.objectify.deadbolt.java.DeadboltHandler;
+import be.objectify.deadbolt.java.cache.BeforeAuthCheckCache;
 import be.objectify.deadbolt.java.cache.HandlerCache;
 import com.typesafe.config.Config;
 import play.mvc.Http;
@@ -34,9 +35,11 @@ public class BeforeAccessAction extends AbstractDeadboltAction<BeforeAccess>
 {
     @Inject
     public BeforeAccessAction(final HandlerCache handlerCache,
+                              final BeforeAuthCheckCache beforeAuthCheckCache,
                               final Config config)
     {
         super(handlerCache,
+              beforeAuthCheckCache,
               config);
     }
 

--- a/code/app/be/objectify/deadbolt/java/actions/CompositeAction.java
+++ b/code/app/be/objectify/deadbolt/java/actions/CompositeAction.java
@@ -18,6 +18,7 @@ package be.objectify.deadbolt.java.actions;
 import be.objectify.deadbolt.java.ConstraintLogic;
 import be.objectify.deadbolt.java.ConstraintPoint;
 import be.objectify.deadbolt.java.DeadboltHandler;
+import be.objectify.deadbolt.java.cache.BeforeAuthCheckCache;
 import be.objectify.deadbolt.java.cache.CompositeCache;
 import be.objectify.deadbolt.java.cache.HandlerCache;
 import com.typesafe.config.Config;
@@ -37,11 +38,13 @@ public class CompositeAction extends AbstractRestrictiveAction<Composite>
 
     @Inject
     public CompositeAction(final HandlerCache handlerCache,
+                           final BeforeAuthCheckCache beforeAuthCheckCache,
                            final Config config,
                            final CompositeCache compositeCache,
                            final ConstraintLogic constraintLogic)
     {
         super(handlerCache,
+              beforeAuthCheckCache,
               config,
               constraintLogic);
         this.compositeCache = compositeCache;

--- a/code/app/be/objectify/deadbolt/java/actions/DeferredDeadboltAction.java
+++ b/code/app/be/objectify/deadbolt/java/actions/DeferredDeadboltAction.java
@@ -15,6 +15,7 @@
  */
 package be.objectify.deadbolt.java.actions;
 
+import be.objectify.deadbolt.java.cache.BeforeAuthCheckCache;
 import be.objectify.deadbolt.java.cache.HandlerCache;
 import com.typesafe.config.Config;
 import org.slf4j.Logger;
@@ -38,9 +39,11 @@ public class DeferredDeadboltAction extends AbstractDeadboltAction<DeferredDeadb
 
     @Inject
     public DeferredDeadboltAction(final HandlerCache handlerCache,
+                                  final BeforeAuthCheckCache beforeAuthCheckCache,
                                   final Config config)
     {
         super(handlerCache,
+              beforeAuthCheckCache,
               config);
     }
 

--- a/code/app/be/objectify/deadbolt/java/actions/DynamicAction.java
+++ b/code/app/be/objectify/deadbolt/java/actions/DynamicAction.java
@@ -18,6 +18,7 @@ package be.objectify.deadbolt.java.actions;
 import be.objectify.deadbolt.java.ConstraintLogic;
 import be.objectify.deadbolt.java.ConstraintPoint;
 import be.objectify.deadbolt.java.DeadboltHandler;
+import be.objectify.deadbolt.java.cache.BeforeAuthCheckCache;
 import be.objectify.deadbolt.java.cache.HandlerCache;
 import com.typesafe.config.Config;
 import play.mvc.Action;
@@ -38,21 +39,25 @@ public class DynamicAction extends AbstractRestrictiveAction<Dynamic>
 {
     @Inject
     public DynamicAction(final HandlerCache handlerCache,
+                         final BeforeAuthCheckCache beforeAuthCheckCache,
                          final Config config,
                          final ConstraintLogic constraintLogic)
     {
         super(handlerCache,
+              beforeAuthCheckCache,
               config,
               constraintLogic);
     }
 
     public DynamicAction(final HandlerCache handlerCache,
+                         final BeforeAuthCheckCache beforeAuthCheckCache,
                          final Config config,
                          final Dynamic configuration,
                          final Action<?> delegate,
                          final ConstraintLogic constraintLogic)
     {
         this(handlerCache,
+             beforeAuthCheckCache,
              config,
              constraintLogic);
         this.configuration = configuration;

--- a/code/app/be/objectify/deadbolt/java/actions/PatternAction.java
+++ b/code/app/be/objectify/deadbolt/java/actions/PatternAction.java
@@ -18,6 +18,7 @@ package be.objectify.deadbolt.java.actions;
 import be.objectify.deadbolt.java.ConstraintLogic;
 import be.objectify.deadbolt.java.ConstraintPoint;
 import be.objectify.deadbolt.java.DeadboltHandler;
+import be.objectify.deadbolt.java.cache.BeforeAuthCheckCache;
 import be.objectify.deadbolt.java.cache.HandlerCache;
 import com.typesafe.config.Config;
 import play.mvc.Action;
@@ -35,21 +36,25 @@ public class PatternAction extends AbstractRestrictiveAction<Pattern>
 {
     @Inject
     public PatternAction(final HandlerCache handlerCache,
+                         final BeforeAuthCheckCache beforeAuthCheckCache,
                          final Config config,
                          final ConstraintLogic constraintLogic)
     {
         super(handlerCache,
+              beforeAuthCheckCache,
               config,
               constraintLogic);
     }
 
     public PatternAction(final HandlerCache handlerCache,
+                         final BeforeAuthCheckCache beforeAuthCheckCache,
                          final Config config,
                          final Pattern configuration,
                          final Action<?> delegate,
                          final ConstraintLogic constraintLogic)
     {
         this(handlerCache,
+             beforeAuthCheckCache,
              config,
              constraintLogic);
         this.configuration = configuration;

--- a/code/app/be/objectify/deadbolt/java/actions/RestrictAction.java
+++ b/code/app/be/objectify/deadbolt/java/actions/RestrictAction.java
@@ -19,6 +19,7 @@ import be.objectify.deadbolt.java.ConstraintLogic;
 import be.objectify.deadbolt.java.ConstraintPoint;
 import be.objectify.deadbolt.java.DeadboltHandler;
 import be.objectify.deadbolt.java.ExecutionContextProvider;
+import be.objectify.deadbolt.java.cache.BeforeAuthCheckCache;
 import be.objectify.deadbolt.java.cache.HandlerCache;
 import com.typesafe.config.Config;
 import play.mvc.Action;
@@ -41,15 +42,18 @@ public class RestrictAction extends AbstractRestrictiveAction<Restrict>
 {
     @Inject
     public RestrictAction(final HandlerCache handlerCache,
+                          final BeforeAuthCheckCache beforeAuthCheckCache,
                           final Config config,
                           final ConstraintLogic constraintLogic)
     {
         super(handlerCache,
+              beforeAuthCheckCache,
               config,
               constraintLogic);
     }
 
     public RestrictAction(final HandlerCache handlerCache,
+                          final BeforeAuthCheckCache beforeAuthCheckCache,
                           final Config config,
                           final Restrict configuration,
                           final Action<?> delegate,
@@ -57,6 +61,7 @@ public class RestrictAction extends AbstractRestrictiveAction<Restrict>
                           final ConstraintLogic constraintLogic)
     {
         this(handlerCache,
+             beforeAuthCheckCache,
              config,
              constraintLogic);
         this.configuration = configuration;

--- a/code/app/be/objectify/deadbolt/java/actions/RoleBasedPermissionsAction.java
+++ b/code/app/be/objectify/deadbolt/java/actions/RoleBasedPermissionsAction.java
@@ -19,6 +19,7 @@ import be.objectify.deadbolt.java.ConstraintLogic;
 import be.objectify.deadbolt.java.ConstraintPoint;
 import be.objectify.deadbolt.java.DeadboltHandler;
 import be.objectify.deadbolt.java.ExecutionContextProvider;
+import be.objectify.deadbolt.java.cache.BeforeAuthCheckCache;
 import be.objectify.deadbolt.java.cache.HandlerCache;
 import com.typesafe.config.Config;
 import play.mvc.Action;
@@ -40,15 +41,18 @@ public class RoleBasedPermissionsAction extends AbstractRestrictiveAction<RoleBa
 {
     @Inject
     public RoleBasedPermissionsAction(final HandlerCache handlerCache,
+                                      final BeforeAuthCheckCache beforeAuthCheckCache,
                                       final Config config,
                                       final ConstraintLogic constraintLogic)
     {
         super(handlerCache,
+              beforeAuthCheckCache,
               config,
               constraintLogic);
     }
 
     public RoleBasedPermissionsAction(final HandlerCache handlerCache,
+                                      final BeforeAuthCheckCache beforeAuthCheckCache,
                                       final Config config,
                                       final RoleBasedPermissions configuration,
                                       final Action<?> delegate,
@@ -56,6 +60,7 @@ public class RoleBasedPermissionsAction extends AbstractRestrictiveAction<RoleBa
                                       final ConstraintLogic constraintLogic)
     {
         this(handlerCache,
+             beforeAuthCheckCache,
              config,
              constraintLogic);
         this.configuration = configuration;

--- a/code/app/be/objectify/deadbolt/java/actions/SubjectNotPresentAction.java
+++ b/code/app/be/objectify/deadbolt/java/actions/SubjectNotPresentAction.java
@@ -18,6 +18,7 @@ package be.objectify.deadbolt.java.actions;
 import be.objectify.deadbolt.java.ConstraintLogic;
 import be.objectify.deadbolt.java.ConstraintPoint;
 import be.objectify.deadbolt.java.DeadboltHandler;
+import be.objectify.deadbolt.java.cache.BeforeAuthCheckCache;
 import be.objectify.deadbolt.java.cache.HandlerCache;
 import play.mvc.Http;
 import play.mvc.Result;
@@ -39,10 +40,12 @@ public class SubjectNotPresentAction extends AbstractSubjectAction<SubjectNotPre
 {
     @Inject
     public SubjectNotPresentAction(final HandlerCache handlerCache,
+                                   final BeforeAuthCheckCache beforeAuthCheckCache,
                                    final com.typesafe.config.Config config,
                                    final ConstraintLogic constraintLogic)
     {
         super(handlerCache,
+              beforeAuthCheckCache,
               config,
               constraintLogic);
     }

--- a/code/app/be/objectify/deadbolt/java/actions/SubjectPresentAction.java
+++ b/code/app/be/objectify/deadbolt/java/actions/SubjectPresentAction.java
@@ -18,6 +18,7 @@ package be.objectify.deadbolt.java.actions;
 import be.objectify.deadbolt.java.ConstraintLogic;
 import be.objectify.deadbolt.java.ConstraintPoint;
 import be.objectify.deadbolt.java.DeadboltHandler;
+import be.objectify.deadbolt.java.cache.BeforeAuthCheckCache;
 import be.objectify.deadbolt.java.cache.HandlerCache;
 import play.mvc.Http;
 import play.mvc.Result;
@@ -38,10 +39,12 @@ public class SubjectPresentAction extends AbstractSubjectAction<SubjectPresent>
 {
     @Inject
     public SubjectPresentAction(final HandlerCache handlerCache,
+                                final BeforeAuthCheckCache beforeAuthCheckCache,
                                 final com.typesafe.config.Config config,
                                 final ConstraintLogic constraintLogic)
     {
         super(handlerCache,
+              beforeAuthCheckCache,
               config,
               constraintLogic);
     }

--- a/code/app/be/objectify/deadbolt/java/actions/UnrestrictedAction.java
+++ b/code/app/be/objectify/deadbolt/java/actions/UnrestrictedAction.java
@@ -15,6 +15,7 @@
  */
 package be.objectify.deadbolt.java.actions;
 
+import be.objectify.deadbolt.java.cache.BeforeAuthCheckCache;
 import be.objectify.deadbolt.java.cache.HandlerCache;
 import com.typesafe.config.Config;
 import play.mvc.Http;
@@ -34,9 +35,11 @@ public class UnrestrictedAction extends AbstractDeadboltAction<Unrestricted>
 {
     @Inject
     public UnrestrictedAction(final HandlerCache handlerCache,
+                              final BeforeAuthCheckCache beforeAuthCheckCache,
                               final Config config)
     {
         super(handlerCache,
+              beforeAuthCheckCache,
               config);
     }
 

--- a/code/app/be/objectify/deadbolt/java/cache/BeforeAuthCheckCache.java
+++ b/code/app/be/objectify/deadbolt/java/cache/BeforeAuthCheckCache.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2010-2016 Steve Chaloner
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package be.objectify.deadbolt.java.cache;
+
+import be.objectify.deadbolt.java.DeadboltHandler;
+import play.mvc.Http;
+import play.mvc.Result;
+
+import java.util.Optional;
+import java.util.concurrent.CompletionStage;
+import java.util.function.BiFunction;
+
+/**
+ * @author Matthias Kurz (m.kurz@irregular.at)
+ */
+public interface BeforeAuthCheckCache extends BiFunction<DeadboltHandler, Http.Context, CompletionStage<Optional<Result>>>
+{
+}

--- a/code/app/be/objectify/deadbolt/java/cache/DefaultBeforeAuthCheckCache.java
+++ b/code/app/be/objectify/deadbolt/java/cache/DefaultBeforeAuthCheckCache.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2010-2016 Steve Chaloner
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package be.objectify.deadbolt.java.cache;
+
+import be.objectify.deadbolt.java.ConfigKeys;
+import be.objectify.deadbolt.java.DeadboltHandler;
+import com.typesafe.config.Config;
+import com.typesafe.config.ConfigFactory;
+import play.mvc.Http;
+import play.mvc.Result;
+
+import javax.inject.Inject;
+import javax.inject.Singleton;
+import java.util.HashMap;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+
+/**
+ * @author Matthias Kurz (m.kurz@irregular.at)
+ */
+@Singleton
+public class DefaultBeforeAuthCheckCache implements BeforeAuthCheckCache
+{
+    private final boolean cacheBeforeAuthCheckPerRequestEnabled;
+
+    @Inject
+    public DefaultBeforeAuthCheckCache(final Config config)
+    {
+        final HashMap<String, Object> defaults = new HashMap<>();
+        defaults.put(ConfigKeys.CACHE_BEFORE_AUTH_CHECK_DEFAULT._1,
+                     ConfigKeys.CACHE_BEFORE_AUTH_CHECK_DEFAULT._2);
+        final Config configWithFallback = config.withFallback(ConfigFactory.parseMap(defaults));
+        this.cacheBeforeAuthCheckPerRequestEnabled = configWithFallback.getBoolean(ConfigKeys.CACHE_BEFORE_AUTH_CHECK_DEFAULT._1);
+    }
+
+    @Override
+    public CompletionStage<Optional<Result>> apply(final DeadboltHandler deadboltHandler,
+                                                              final Http.Context context)
+    {
+        final CompletionStage<Optional<Result>> promise;
+        if (cacheBeforeAuthCheckPerRequestEnabled)
+        {
+            final String deadboltHandlerCacheId = ConfigKeys.CACHE_BEFORE_AUTH_CHECK_DEFAULT._1 + "." + deadboltHandler.getId(); // results into "deadbolt.java.cache-before-auth-check.0"
+            if (context.args.containsKey(deadboltHandlerCacheId))
+            {
+                promise = CompletableFuture.completedFuture(Optional.empty());
+            }
+            else
+            {
+                promise = deadboltHandler.beforeAuthCheck(context)
+                                         .thenApply(beforeAuthCheckOption ->
+                                                         {
+                                                             if(!beforeAuthCheckOption.isPresent())
+                                                             {
+                                                                 context.args.put(deadboltHandlerCacheId, true);
+                                                             }
+                                                             return beforeAuthCheckOption;
+                                                         });
+            }
+        }
+        else
+        {
+            promise = deadboltHandler.beforeAuthCheck(context);
+        }
+
+        return promise;
+    }
+}

--- a/code/app/be/objectify/deadbolt/java/filters/FilterConstraints.java
+++ b/code/app/be/objectify/deadbolt/java/filters/FilterConstraints.java
@@ -18,6 +18,7 @@ package be.objectify.deadbolt.java.filters;
 import be.objectify.deadbolt.java.ConstraintLogic;
 import be.objectify.deadbolt.java.ConstraintPoint;
 import be.objectify.deadbolt.java.DeadboltHandler;
+import be.objectify.deadbolt.java.cache.BeforeAuthCheckCache;
 import be.objectify.deadbolt.java.cache.CompositeCache;
 import be.objectify.deadbolt.java.composite.Constraint;
 import be.objectify.deadbolt.java.models.PatternType;
@@ -43,13 +44,16 @@ public class FilterConstraints
 {
     private final ConstraintLogic constraintLogic;
     private final CompositeCache compositeCache;
+    private final BeforeAuthCheckCache beforeAuthCheckCache;
 
     @Inject
     public FilterConstraints(final ConstraintLogic constraintLogic,
-                             final CompositeCache compositeCache)
+                             final CompositeCache compositeCache,
+                             final BeforeAuthCheckCache beforeAuthCheckCache)
     {
         this.constraintLogic = constraintLogic;
         this.compositeCache = compositeCache;
+        this.beforeAuthCheckCache = beforeAuthCheckCache;
     }
 
     /**
@@ -76,7 +80,7 @@ public class FilterConstraints
                 Http.RequestHeader requestHeader,
                 DeadboltHandler handler,
                 Function<Http.RequestHeader, CompletionStage<Result>> next) ->
-                handler.beforeAuthCheck(context)
+                beforeAuthCheckCache.apply(handler, context)
                        .thenCompose(maybePreAuth -> maybePreAuth.map(preAuthResult -> (CompletionStage<Result>) CompletableFuture.completedFuture(preAuthResult))
                                                                 .orElseGet(() -> constraintLogic.subjectPresent(context,
                                                                                                                 handler,
@@ -111,7 +115,7 @@ public class FilterConstraints
                 Http.RequestHeader requestHeader,
                 DeadboltHandler handler,
                 Function<Http.RequestHeader, CompletionStage<Result>> next) ->
-                handler.beforeAuthCheck(context)
+                beforeAuthCheckCache.apply(handler, context)
                        .thenCompose(maybePreAuth -> maybePreAuth.map(preAuthResult -> (CompletionStage<Result>) CompletableFuture.completedFuture(preAuthResult))
                                                                 .orElseGet(() -> constraintLogic.subjectNotPresent(context,
                                                                                                                    handler,
@@ -150,7 +154,7 @@ public class FilterConstraints
                 Http.RequestHeader requestHeader,
                 DeadboltHandler handler,
                 Function<Http.RequestHeader, CompletionStage<Result>> next) ->
-                handler.beforeAuthCheck(context)
+                beforeAuthCheckCache.apply(handler, context)
                        .thenCompose(maybePreAuth -> maybePreAuth.map(preAuthResult -> (CompletionStage<Result>) CompletableFuture.completedFuture(preAuthResult))
                                                                 .orElseGet(() -> constraintLogic.restrict(context,
                                                                                                           handler,
@@ -247,7 +251,7 @@ public class FilterConstraints
                 Http.RequestHeader requestHeader,
                 DeadboltHandler handler,
                 Function<Http.RequestHeader, CompletionStage<Result>> next) ->
-                handler.beforeAuthCheck(context)
+                beforeAuthCheckCache.apply(handler, context)
                        .thenCompose(maybePreAuth -> maybePreAuth.map(preAuthResult -> (CompletionStage<Result>) CompletableFuture.completedFuture(preAuthResult))
                                                                 .orElseGet(() -> constraintLogic.pattern(context,
                                                                                                          handler,
@@ -311,7 +315,7 @@ public class FilterConstraints
                 Http.RequestHeader requestHeader,
                 DeadboltHandler handler,
                 Function<Http.RequestHeader, CompletionStage<Result>> next) ->
-                handler.beforeAuthCheck(context)
+                beforeAuthCheckCache.apply(handler, context)
                        .thenCompose(maybePreAuth -> maybePreAuth.map(preAuthResult -> (CompletionStage<Result>) CompletableFuture.completedFuture(preAuthResult))
                                                                 .orElseGet(() -> constraintLogic.dynamic(context,
                                                                                                          handler,
@@ -384,7 +388,7 @@ public class FilterConstraints
                 Http.RequestHeader requestHeader,
                 DeadboltHandler handler,
                 Function<Http.RequestHeader, CompletionStage<Result>> next) ->
-                handler.beforeAuthCheck(context)
+                beforeAuthCheckCache.apply(handler, context)
                        .thenCompose(maybePreAuth -> maybePreAuth.map(preAuthResult -> (CompletionStage<Result>) CompletableFuture.completedFuture(preAuthResult))
                                                                 .orElseGet(() -> constraint.test(context,
                                                                                                  handler)
@@ -411,7 +415,7 @@ public class FilterConstraints
                 Http.RequestHeader requestHeader,
                 DeadboltHandler handler,
                 Function<Http.RequestHeader, CompletionStage<Result>> next) ->
-                handler.beforeAuthCheck(context)
+                beforeAuthCheckCache.apply(handler, context)
                        .thenCompose(maybePreAuth -> maybePreAuth.map(preAuthResult -> (CompletionStage<Result>) CompletableFuture.completedFuture(preAuthResult))
                                                                 .orElseGet(() -> constraintLogic.roleBasedPermissions(context,
                                                                                                                       handler,


### PR DESCRIPTION
Like #48 but for `beforeAuthCheck` - introduces `deadbolt.java.cache-before-auth-check` config.

See [this comment](https://github.com/schaloner/deadbolt-2-java/pull/48#issuecomment-339015564) for explanation.