### PR TITLE
Remove last two *Async() calls

### DIFF
--- a/code/app/be/objectify/deadbolt/java/AbstractDeadboltHandler.java
+++ b/code/app/be/objectify/deadbolt/java/AbstractDeadboltHandler.java
@@ -16,12 +16,9 @@
 package be.objectify.deadbolt.java;
 
 import be.objectify.deadbolt.java.models.Subject;
-import play.libs.concurrent.HttpExecution;
 import play.mvc.Http;
 import play.mvc.Result;
 import play.mvc.Results;
-import scala.concurrent.ExecutionContext;
-import scala.concurrent.ExecutionContextExecutor;
 import views.html.defaultpages.unauthorized;
 
 import java.util.Optional;
@@ -78,10 +75,7 @@ public abstract class AbstractDeadboltHandler extends Results implements Deadbol
     public CompletionStage<Result> onAuthFailure(final Http.Context context,
                                                  final Optional<String> content)
     {
-        final ExecutionContext executionContext = executionContextProvider.get();
-        final ExecutionContextExecutor executor = HttpExecution.fromThread(executionContext);
-        return CompletableFuture.supplyAsync(unauthorized::render,
-                                             executor)
+        return CompletableFuture.completedFuture(unauthorized.render())
                                 .thenApply(Results::unauthorized);
     }
 

--- a/code/app/be/objectify/deadbolt/java/cache/DefaultSubjectCache.java
+++ b/code/app/be/objectify/deadbolt/java/cache/DefaultSubjectCache.java
@@ -22,10 +22,7 @@ import be.objectify.deadbolt.java.ExecutionContextProvider;
 import be.objectify.deadbolt.java.models.Subject;
 import com.typesafe.config.Config;
 import com.typesafe.config.ConfigFactory;
-import play.libs.concurrent.HttpExecution;
 import play.mvc.Http;
-import scala.concurrent.ExecutionContext;
-import scala.concurrent.ExecutionContextExecutor;
 
 import javax.inject.Inject;
 import javax.inject.Singleton;
@@ -70,15 +67,13 @@ public class DefaultSubjectCache implements SubjectCache
             }
             else
             {
-                final ExecutionContext executionContext = executionContextProvider.get();
-                final ExecutionContextExecutor executor = HttpExecution.fromThread(executionContext);
                 promise = deadboltHandler.getSubject(context)
-                                         .thenApplyAsync(subjectOption ->
+                                         .thenApply(subjectOption ->
                                                          {
                                                              subjectOption.ifPresent(subject -> context.args.put(deadboltHandlerCacheId,
                                                                                                                  subject));
                                                              return subjectOption;
-                                                         }, executor);
+                                                         });
             }
         }
         else


### PR DESCRIPTION
This keeps `ExecutionContextProvider` but removes the last `supplyAsync` and `thenApplyAsync` calls. It makes absolutely no sense to render Play's default `unauthorized` page within a different executioncontext, same for putting something in a map.

We still keep `ExecutionContextProvider` even it is used exactly nowhere right now so in case people defined their own executioncontexts their projects still compile when upgrading deadbolt.

This is basically just a part taken from #46.