### PR TITLE
Replace "class Config" with simple methods

### DIFF
--- a/code/app/be/objectify/deadbolt/java/actions/AbstractSubjectAction.java
+++ b/code/app/be/objectify/deadbolt/java/actions/AbstractSubjectAction.java
@@ -52,11 +52,10 @@ public abstract class AbstractSubjectAction<T> extends AbstractDeadboltAction<T>
     public CompletionStage<Result> execute(final Http.Context ctx) throws Exception
     {
         final CompletionStage<Result> result;
-        final Config config = config();
         if (isActionUnauthorised(ctx))
         {
-            result = onAuthFailure(getDeadboltHandler(config.handlerKey),
-                                   config.content,
+            result = onAuthFailure(getDeadboltHandler(getHandlerKey()),
+                                   getContent(),
                                    ctx);
         }
         else if (isActionAuthorised(ctx))
@@ -65,15 +64,14 @@ public abstract class AbstractSubjectAction<T> extends AbstractDeadboltAction<T>
         }
         else
         {
-            final DeadboltHandler deadboltHandler = getDeadboltHandler(config.handlerKey);
-            result = preAuth(config.forceBeforeAuthCheck,
+            final DeadboltHandler deadboltHandler = getDeadboltHandler(getHandlerKey());
+            result = preAuth(isForceBeforeAuthCheck(),
                              ctx,
-                             config.content,
+                             getContent(),
                              deadboltHandler)
                     .thenCompose(maybePreAuth -> maybePreAuth.map(CompletableFuture::completedFuture)
                                                              .orElseGet(testSubject(constraintLogic,
                                                                                     ctx,
-                                                                                    config,
                                                                                     deadboltHandler)));
         }
         return maybeBlock(result);
@@ -81,10 +79,7 @@ public abstract class AbstractSubjectAction<T> extends AbstractDeadboltAction<T>
 
     abstract Supplier<CompletableFuture<Result>> testSubject(final ConstraintLogic constraintLogic,
                                                               final Http.Context context,
-                                                              final Config config,
                                                               final DeadboltHandler deadboltHandler);
-
-    abstract Config config();
 
     abstract CompletionStage<Result> present(Http.Context context,
                                              DeadboltHandler handler,
@@ -94,19 +89,9 @@ public abstract class AbstractSubjectAction<T> extends AbstractDeadboltAction<T>
                                                 DeadboltHandler handler,
                                                 Optional<String> content);
 
-    class Config
-    {
-        public final boolean forceBeforeAuthCheck;
-        public final String handlerKey;
-        public final Optional<String> content;
+    public abstract Optional<String> getContent();
 
-        Config(final boolean forceBeforeAuthCheck,
-               final String handlerKey,
-               final String content)
-        {
-            this.forceBeforeAuthCheck = forceBeforeAuthCheck;
-            this.handlerKey = handlerKey;
-            this.content = Optional.ofNullable(content);
-        }
-    }
+    public abstract String getHandlerKey();
+
+    public abstract boolean isForceBeforeAuthCheck();
 }

--- a/code/app/be/objectify/deadbolt/java/actions/SubjectNotPresentAction.java
+++ b/code/app/be/objectify/deadbolt/java/actions/SubjectNotPresentAction.java
@@ -54,17 +54,6 @@ public class SubjectNotPresentAction extends AbstractSubjectAction<SubjectNotPre
      * {@inheritDoc}
      */
     @Override
-    Config config()
-    {
-        return new Config(configuration.forceBeforeAuthCheck(),
-                          configuration.handlerKey(),
-                          configuration.content());
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
     CompletionStage<Result> present(final Http.Context context,
                                     final DeadboltHandler handler,
                                     final Optional<String> content)
@@ -88,12 +77,11 @@ public class SubjectNotPresentAction extends AbstractSubjectAction<SubjectNotPre
     @Override
     protected Supplier<CompletableFuture<Result>> testSubject(final ConstraintLogic constraintLogic,
                                                               final Http.Context context,
-                                                              final Config config,
                                                               final DeadboltHandler deadboltHandler)
     {
         return () -> constraintLogic.subjectNotPresent(context,
                                                         deadboltHandler,
-                                                        config.content,
+                                                        getContent(),
                                                         this::present,
                                                         this::notPresent,
                                                         ConstraintPoint.CONTROLLER).toCompletableFuture();
@@ -105,5 +93,23 @@ public class SubjectNotPresentAction extends AbstractSubjectAction<SubjectNotPre
     @Override
     protected boolean deferred() {
         return configuration.deferred();
+    }
+
+    @Override
+    public Optional<String> getContent()
+    {
+        return Optional.ofNullable(configuration.content());
+    }
+
+    @Override
+    public String getHandlerKey()
+    {
+        return configuration.handlerKey();
+    }
+
+    @Override
+    public boolean isForceBeforeAuthCheck()
+    {
+        return configuration.forceBeforeAuthCheck();
     }
 }

--- a/code/app/be/objectify/deadbolt/java/actions/SubjectPresentAction.java
+++ b/code/app/be/objectify/deadbolt/java/actions/SubjectPresentAction.java
@@ -53,17 +53,6 @@ public class SubjectPresentAction extends AbstractSubjectAction<SubjectPresent>
      * {@inheritDoc}
      */
     @Override
-    Config config()
-    {
-        return new Config(configuration.forceBeforeAuthCheck(),
-                          configuration.handlerKey(),
-                          configuration.content());
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
     CompletionStage<Result> present(final Http.Context context,
                                     final DeadboltHandler handler,
                                     final Optional<String> content)
@@ -87,12 +76,11 @@ public class SubjectPresentAction extends AbstractSubjectAction<SubjectPresent>
     @Override
     protected Supplier<CompletableFuture<Result>> testSubject(final ConstraintLogic constraintLogic,
                                                               final Http.Context context,
-                                                              final Config config,
                                                               final DeadboltHandler deadboltHandler)
     {
         return () -> constraintLogic.subjectPresent(context,
                                                      deadboltHandler,
-                                                     config.content,
+                                                     getContent(),
                                                      this::present,
                                                      this::notPresent,
                                                      ConstraintPoint.CONTROLLER).toCompletableFuture();
@@ -106,4 +94,21 @@ public class SubjectPresentAction extends AbstractSubjectAction<SubjectPresent>
         return configuration.deferred();
     }
 
+    @Override
+    public Optional<String> getContent()
+    {
+        return Optional.ofNullable(configuration.content());
+    }
+
+    @Override
+    public String getHandlerKey()
+    {
+        return configuration.handlerKey();
+    }
+
+    @Override
+    public boolean isForceBeforeAuthCheck()
+    {
+        return configuration.forceBeforeAuthCheck();
+    }
 }

--- a/code/test/be/objectify/deadbolt/java/actions/SubjectNotPresentActionTest.java
+++ b/code/test/be/objectify/deadbolt/java/actions/SubjectNotPresentActionTest.java
@@ -54,12 +54,11 @@ public class SubjectNotPresentActionTest {
                                                                            Mockito.mock(ConstraintLogic.class));
         action.configuration = subjectNotPresent;
 
-        final AbstractSubjectAction<SubjectNotPresent>.Config config = action.config();
-        Assert.assertTrue(config.forceBeforeAuthCheck);
+        Assert.assertTrue(action.isForceBeforeAuthCheck());
         Assert.assertEquals("foo",
-                            config.handlerKey);
+                            action.getHandlerKey());
         Assert.assertEquals("x/y",
-                            config.content.orElse(null));
+                            action.getContent().orElse(null));
     }
 
     @Test
@@ -128,7 +127,6 @@ public class SubjectNotPresentActionTest {
 
         action.testSubject(constraintLogic,
                            Mockito.mock(Http.Context.class),
-                           action.config(),
                            Mockito.mock(DeadboltHandler.class)).get();
         Mockito.verify(constraintLogic).subjectNotPresent(Mockito.any(Http.Context.class),
                                                           Mockito.any(DeadboltHandler.class),

--- a/code/test/be/objectify/deadbolt/java/actions/SubjectPresentActionTest.java
+++ b/code/test/be/objectify/deadbolt/java/actions/SubjectPresentActionTest.java
@@ -54,12 +54,11 @@ public class SubjectPresentActionTest {
                                                                      Mockito.mock(ConstraintLogic.class));
         action.configuration = subjectPresent;
 
-        final AbstractSubjectAction<SubjectPresent>.Config config = action.config();
-        Assert.assertTrue(config.forceBeforeAuthCheck);
+        Assert.assertTrue(action.isForceBeforeAuthCheck());
         Assert.assertEquals("foo",
-                            config.handlerKey);
+                            action.getHandlerKey());
         Assert.assertEquals("x/y",
-                            config.content.orElse(null));
+                            action.getContent().orElse(null));
     }
 
     @Test
@@ -126,7 +125,6 @@ public class SubjectPresentActionTest {
 
         action.testSubject(constraintLogic,
                            Mockito.mock(Http.Context.class),
-                           action.config(),
                            Mockito.mock(DeadboltHandler.class)).get();
         Mockito.verify(constraintLogic).subjectPresent(Mockito.any(Http.Context.class),
                                                        Mockito.any(DeadboltHandler.class),


### PR DESCRIPTION
Use `abstract` methods which have to be overridden instead of objects to "pass" data to the super class.
That is how it is done in the rest of the codebase as well (e.g. see [`RoleBasedPermissionsAction` here](https://github.com/schaloner/deadbolt-2-java/blob/v2.6.3/code/app/be/objectify/deadbolt/java/actions/RoleBasedPermissionsAction.java#L78-L82)).
I think that is what inheritance is about, I can't really see the advantage of using objects here...