### PR TITLE
Pass content to DeadboltHandler.beforeAuthCheck as well

### DIFF
--- a/code/app/be/objectify/deadbolt/java/AbstractDeadboltHandler.java
+++ b/code/app/be/objectify/deadbolt/java/AbstractDeadboltHandler.java
@@ -54,7 +54,7 @@ public abstract class AbstractDeadboltHandler extends Results implements Deadbol
      * {@inheritDoc}
      */
     @Override
-    public CompletionStage<Optional<Result>> beforeAuthCheck(Http.Context context)
+    public CompletionStage<Optional<Result>> beforeAuthCheck(Http.Context context, Optional<String> content)
     {
         return CompletableFuture.completedFuture(Optional.empty());
     }

--- a/code/app/be/objectify/deadbolt/java/DeadboltHandler.java
+++ b/code/app/be/objectify/deadbolt/java/DeadboltHandler.java
@@ -53,7 +53,7 @@ public interface DeadboltHandler
      * the user is authenticated (or whatever your test condition is), this will be null otherwise the restriction
      * won't be applied.
      */
-    CompletionStage<Optional<Result>> beforeAuthCheck(Http.Context context);
+    CompletionStage<Optional<Result>> beforeAuthCheck(Http.Context context, Optional<String> content);
 
     /**
      * Gets the current {@link Subject}, e.g. the current user.

--- a/code/app/be/objectify/deadbolt/java/actions/AbstractDeadboltAction.java
+++ b/code/app/be/objectify/deadbolt/java/actions/AbstractDeadboltAction.java
@@ -280,9 +280,10 @@ public abstract class AbstractDeadboltAction<T> extends Action<T>
 
     public CompletionStage<Optional<Result>> preAuth(final boolean forcePreAuthCheck,
                                                      final Http.Context ctx,
+                                                     final Optional<String> content,
                                                      final DeadboltHandler deadboltHandler)
     {
-        return forcePreAuthCheck ? beforeAuthCheckCache.apply(deadboltHandler, ctx)
+        return forcePreAuthCheck ? beforeAuthCheckCache.apply(deadboltHandler, ctx, content)
                                  : CompletableFuture.completedFuture(Optional.empty());
     }
 

--- a/code/app/be/objectify/deadbolt/java/actions/AbstractRestrictiveAction.java
+++ b/code/app/be/objectify/deadbolt/java/actions/AbstractRestrictiveAction.java
@@ -23,6 +23,7 @@ import com.typesafe.config.Config;
 import play.mvc.Http;
 import play.mvc.Result;
 
+import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 
@@ -59,6 +60,7 @@ public abstract class AbstractRestrictiveAction<T> extends AbstractDeadboltActio
             final DeadboltHandler deadboltHandler = getDeadboltHandler(getHandlerKey());
             result = preAuth(true,
                              ctx,
+                             getContent(),
                              deadboltHandler)
                     .thenCompose(option -> option.map(value -> (CompletionStage<Result>) CompletableFuture.completedFuture(value))
                                                       .orElseGet(() -> applyRestriction(ctx,
@@ -66,6 +68,8 @@ public abstract class AbstractRestrictiveAction<T> extends AbstractDeadboltActio
         }
         return maybeBlock(result);
     }
+
+    public abstract Optional<String> getContent();
 
     /**
      * Get the key of a specific DeadboltHandler instance.

--- a/code/app/be/objectify/deadbolt/java/actions/AbstractSubjectAction.java
+++ b/code/app/be/objectify/deadbolt/java/actions/AbstractSubjectAction.java
@@ -68,6 +68,7 @@ public abstract class AbstractSubjectAction<T> extends AbstractDeadboltAction<T>
             final DeadboltHandler deadboltHandler = getDeadboltHandler(config.handlerKey);
             result = preAuth(config.forceBeforeAuthCheck,
                              ctx,
+                             config.content,
                              deadboltHandler)
                     .thenCompose(maybePreAuth -> maybePreAuth.map(CompletableFuture::completedFuture)
                                                              .orElseGet(testSubject(constraintLogic,

--- a/code/app/be/objectify/deadbolt/java/actions/BeforeAccess.java
+++ b/code/app/be/objectify/deadbolt/java/actions/BeforeAccess.java
@@ -16,6 +16,7 @@
 package be.objectify.deadbolt.java.actions;
 
 import be.objectify.deadbolt.java.ConfigKeys;
+import be.objectify.deadbolt.java.DeadboltHandler;
 import play.mvc.With;
 
 import java.lang.annotation.Documented;
@@ -38,6 +39,14 @@ import java.lang.annotation.Target;
 @Documented
 public @interface BeforeAccess
 {
+    /**
+     * Indicates the expected response type.  Useful when working with non-HTML responses.  This is free text, which you
+     * can use in {@link DeadboltHandler#onAuthFailure} to decide on how to handle the response.
+     *
+     * @return a content indicator
+     */
+    String content() default "";
+
     /**
      * Use a specific {@link be.objectify.deadbolt.java.DeadboltHandler} for this restriction in place of the global
      * one, identified by a key.

--- a/code/app/be/objectify/deadbolt/java/actions/BeforeAccessAction.java
+++ b/code/app/be/objectify/deadbolt/java/actions/BeforeAccessAction.java
@@ -23,6 +23,8 @@ import play.mvc.Http;
 import play.mvc.Result;
 
 import javax.inject.Inject;
+
+import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 
@@ -59,6 +61,7 @@ public class BeforeAccessAction extends AbstractDeadboltAction<BeforeAccess>
             final DeadboltHandler deadboltHandler = getDeadboltHandler(configuration.handlerKey());
             result = preAuth(true,
                              ctx,
+                             Optional.ofNullable(configuration.content()),
                              deadboltHandler)
                     .thenCompose(preAuthResult -> preAuthResult.map(r -> (CompletionStage<Result>) CompletableFuture.completedFuture(r))
                                                                .orElseGet(() -> sneakyCall(delegate, ctx)));

--- a/code/app/be/objectify/deadbolt/java/actions/CompositeAction.java
+++ b/code/app/be/objectify/deadbolt/java/actions/CompositeAction.java
@@ -102,6 +102,12 @@ public class CompositeAction extends AbstractRestrictiveAction<Composite>
     }
 
     @Override
+    public Optional<String> getContent()
+    {
+        return Optional.ofNullable(configuration.content());
+    }
+
+    @Override
     public String getHandlerKey()
     {
         return configuration.handlerKey();

--- a/code/app/be/objectify/deadbolt/java/actions/DynamicAction.java
+++ b/code/app/be/objectify/deadbolt/java/actions/DynamicAction.java
@@ -97,6 +97,12 @@ public class DynamicAction extends AbstractRestrictiveAction<Dynamic>
     }
 
     @Override
+    public Optional<String> getContent()
+    {
+        return Optional.ofNullable(configuration.content());
+    }
+
+    @Override
     public String getHandlerKey()
     {
         return configuration.handlerKey();

--- a/code/app/be/objectify/deadbolt/java/actions/PatternAction.java
+++ b/code/app/be/objectify/deadbolt/java/actions/PatternAction.java
@@ -77,6 +77,12 @@ public class PatternAction extends AbstractRestrictiveAction<Pattern>
                                        ConstraintPoint.CONTROLLER);
     }
 
+    @Override
+    public Optional<String> getContent()
+    {
+        return Optional.ofNullable(configuration.content());
+    }
+
     /**
      * {@inheritDoc}
      */

--- a/code/app/be/objectify/deadbolt/java/actions/RestrictAction.java
+++ b/code/app/be/objectify/deadbolt/java/actions/RestrictAction.java
@@ -100,6 +100,12 @@ public class RestrictAction extends AbstractRestrictiveAction<Restrict>
     }
 
     @Override
+    public Optional<String> getContent()
+    {
+        return Optional.ofNullable(configuration.content());
+    }
+
+    @Override
     public String getHandlerKey()
     {
         return configuration.handlerKey();

--- a/code/app/be/objectify/deadbolt/java/actions/RoleBasedPermissionsAction.java
+++ b/code/app/be/objectify/deadbolt/java/actions/RoleBasedPermissionsAction.java
@@ -89,6 +89,12 @@ public class RoleBasedPermissionsAction extends AbstractRestrictiveAction<RoleBa
     }
 
     @Override
+    public Optional<String> getContent()
+    {
+        return Optional.ofNullable(configuration.content());
+    }
+
+    @Override
     public String getHandlerKey()
     {
         return configuration.handlerKey();

--- a/code/app/be/objectify/deadbolt/java/cache/BeforeAuthCheckCache.java
+++ b/code/app/be/objectify/deadbolt/java/cache/BeforeAuthCheckCache.java
@@ -21,11 +21,15 @@ import play.mvc.Result;
 
 import java.util.Optional;
 import java.util.concurrent.CompletionStage;
-import java.util.function.BiFunction;
 
 /**
  * @author Matthias Kurz (m.kurz@irregular.at)
  */
-public interface BeforeAuthCheckCache extends BiFunction<DeadboltHandler, Http.Context, CompletionStage<Optional<Result>>>
+public interface BeforeAuthCheckCache extends Function3<DeadboltHandler, Http.Context, Optional<String>, CompletionStage<Optional<Result>>>
 {
+}
+
+// Can be replaced with scala.Function3 when dropping support for Scala 2.11 (probably in Play 2.7)
+interface Function3<A,B,C,R> {
+    R apply(A a, B b, C c);
 }

--- a/code/app/be/objectify/deadbolt/java/cache/DefaultBeforeAuthCheckCache.java
+++ b/code/app/be/objectify/deadbolt/java/cache/DefaultBeforeAuthCheckCache.java
@@ -49,7 +49,8 @@ public class DefaultBeforeAuthCheckCache implements BeforeAuthCheckCache
 
     @Override
     public CompletionStage<Optional<Result>> apply(final DeadboltHandler deadboltHandler,
-                                                              final Http.Context context)
+                                                              final Http.Context context,
+                                                              final Optional<String> content)
     {
         final CompletionStage<Optional<Result>> promise;
         if (cacheBeforeAuthCheckPerRequestEnabled)
@@ -61,7 +62,7 @@ public class DefaultBeforeAuthCheckCache implements BeforeAuthCheckCache
             }
             else
             {
-                promise = deadboltHandler.beforeAuthCheck(context)
+                promise = deadboltHandler.beforeAuthCheck(context, content)
                                          .thenApply(beforeAuthCheckOption ->
                                                          {
                                                              if(!beforeAuthCheckOption.isPresent())
@@ -74,7 +75,7 @@ public class DefaultBeforeAuthCheckCache implements BeforeAuthCheckCache
         }
         else
         {
-            promise = deadboltHandler.beforeAuthCheck(context);
+            promise = deadboltHandler.beforeAuthCheck(context, content);
         }
 
         return promise;

--- a/code/app/be/objectify/deadbolt/java/filters/FilterConstraints.java
+++ b/code/app/be/objectify/deadbolt/java/filters/FilterConstraints.java
@@ -80,7 +80,7 @@ public class FilterConstraints
                 Http.RequestHeader requestHeader,
                 DeadboltHandler handler,
                 Function<Http.RequestHeader, CompletionStage<Result>> next) ->
-                beforeAuthCheckCache.apply(handler, context)
+                beforeAuthCheckCache.apply(handler, context, content)
                        .thenCompose(maybePreAuth -> maybePreAuth.map(preAuthResult -> (CompletionStage<Result>) CompletableFuture.completedFuture(preAuthResult))
                                                                 .orElseGet(() -> constraintLogic.subjectPresent(context,
                                                                                                                 handler,
@@ -115,7 +115,7 @@ public class FilterConstraints
                 Http.RequestHeader requestHeader,
                 DeadboltHandler handler,
                 Function<Http.RequestHeader, CompletionStage<Result>> next) ->
-                beforeAuthCheckCache.apply(handler, context)
+                beforeAuthCheckCache.apply(handler, context, content)
                        .thenCompose(maybePreAuth -> maybePreAuth.map(preAuthResult -> (CompletionStage<Result>) CompletableFuture.completedFuture(preAuthResult))
                                                                 .orElseGet(() -> constraintLogic.subjectNotPresent(context,
                                                                                                                    handler,
@@ -154,7 +154,7 @@ public class FilterConstraints
                 Http.RequestHeader requestHeader,
                 DeadboltHandler handler,
                 Function<Http.RequestHeader, CompletionStage<Result>> next) ->
-                beforeAuthCheckCache.apply(handler, context)
+                beforeAuthCheckCache.apply(handler, context, content)
                        .thenCompose(maybePreAuth -> maybePreAuth.map(preAuthResult -> (CompletionStage<Result>) CompletableFuture.completedFuture(preAuthResult))
                                                                 .orElseGet(() -> constraintLogic.restrict(context,
                                                                                                           handler,
@@ -251,7 +251,7 @@ public class FilterConstraints
                 Http.RequestHeader requestHeader,
                 DeadboltHandler handler,
                 Function<Http.RequestHeader, CompletionStage<Result>> next) ->
-                beforeAuthCheckCache.apply(handler, context)
+                beforeAuthCheckCache.apply(handler, context, content)
                        .thenCompose(maybePreAuth -> maybePreAuth.map(preAuthResult -> (CompletionStage<Result>) CompletableFuture.completedFuture(preAuthResult))
                                                                 .orElseGet(() -> constraintLogic.pattern(context,
                                                                                                          handler,
@@ -315,7 +315,7 @@ public class FilterConstraints
                 Http.RequestHeader requestHeader,
                 DeadboltHandler handler,
                 Function<Http.RequestHeader, CompletionStage<Result>> next) ->
-                beforeAuthCheckCache.apply(handler, context)
+                beforeAuthCheckCache.apply(handler, context, content)
                        .thenCompose(maybePreAuth -> maybePreAuth.map(preAuthResult -> (CompletionStage<Result>) CompletableFuture.completedFuture(preAuthResult))
                                                                 .orElseGet(() -> constraintLogic.dynamic(context,
                                                                                                          handler,
@@ -388,7 +388,7 @@ public class FilterConstraints
                 Http.RequestHeader requestHeader,
                 DeadboltHandler handler,
                 Function<Http.RequestHeader, CompletionStage<Result>> next) ->
-                beforeAuthCheckCache.apply(handler, context)
+                beforeAuthCheckCache.apply(handler, context, content)
                        .thenCompose(maybePreAuth -> maybePreAuth.map(preAuthResult -> (CompletionStage<Result>) CompletableFuture.completedFuture(preAuthResult))
                                                                 .orElseGet(() -> constraint.test(context,
                                                                                                  handler)
@@ -415,7 +415,7 @@ public class FilterConstraints
                 Http.RequestHeader requestHeader,
                 DeadboltHandler handler,
                 Function<Http.RequestHeader, CompletionStage<Result>> next) ->
-                beforeAuthCheckCache.apply(handler, context)
+                beforeAuthCheckCache.apply(handler, context, content)
                        .thenCompose(maybePreAuth -> maybePreAuth.map(preAuthResult -> (CompletionStage<Result>) CompletableFuture.completedFuture(preAuthResult))
                                                                 .orElseGet(() -> constraintLogic.roleBasedPermissions(context,
                                                                                                                       handler,

--- a/code/project/plugins.sbt
+++ b/code/project/plugins.sbt
@@ -1,5 +1,3 @@
-resolvers += "Typesafe repository" at "http://repo.typesafe.com/typesafe/releases/"
-
 addSbtPlugin("com.typesafe.play" % "sbt-plugin" % Option(System.getProperty("play.version")).getOrElse("2.6.0"))
 addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.0.0")
 addSbtPlugin("com.github.gseitz" % "sbt-release" % "1.0.5")

--- a/code/test/be/objectify/deadbolt/java/AbstractDeadboltHandlerTest.java
+++ b/code/test/be/objectify/deadbolt/java/AbstractDeadboltHandlerTest.java
@@ -44,7 +44,7 @@ public class AbstractDeadboltHandlerTest
         DeadboltHandler deadboltHandler = new AbstractDeadboltHandler(ecProvider)
         {
             @Override
-            public CompletionStage<Optional<Result>> beforeAuthCheck(final Http.Context context)
+            public CompletionStage<Optional<Result>> beforeAuthCheck(final Http.Context context, final Optional<String> content)
             {
                 return CompletableFuture.completedFuture(Optional.empty());
             }
@@ -69,7 +69,7 @@ public class AbstractDeadboltHandlerTest
         DeadboltHandler deadboltHandler = new AbstractDeadboltHandler(ecProvider)
         {
             @Override
-            public CompletionStage<Optional<Result>> beforeAuthCheck(final Http.Context context)
+            public CompletionStage<Optional<Result>> beforeAuthCheck(final Http.Context context, final Optional<String> content)
             {
                 return CompletableFuture.completedFuture(Optional.empty());
             }
@@ -96,7 +96,7 @@ public class AbstractDeadboltHandlerTest
         DeadboltHandler deadboltHandler = new AbstractDeadboltHandler(ecProvider)
         {
             @Override
-            public CompletionStage<Optional<Result>> beforeAuthCheck(final Http.Context context)
+            public CompletionStage<Optional<Result>> beforeAuthCheck(final Http.Context context, final Optional<String> content)
             {
                 return CompletableFuture.completedFuture(Optional.empty());
             }

--- a/code/test/be/objectify/deadbolt/java/NoPreAuthDeadboltHandler.java
+++ b/code/test/be/objectify/deadbolt/java/NoPreAuthDeadboltHandler.java
@@ -33,7 +33,7 @@ public class NoPreAuthDeadboltHandler extends AbstractDeadboltHandler
     }
 
     @Override
-    public CompletionStage<Optional<Result>> beforeAuthCheck(final Http.Context context)
+    public CompletionStage<Optional<Result>> beforeAuthCheck(final Http.Context context, final Optional<String> content)
     {
         return CompletableFuture.completedFuture(Optional.empty());
     }

--- a/code/test/be/objectify/deadbolt/java/actions/BeforeAccessActionTest.java
+++ b/code/test/be/objectify/deadbolt/java/actions/BeforeAccessActionTest.java
@@ -16,6 +16,8 @@
 package be.objectify.deadbolt.java.actions;
 
 import be.objectify.deadbolt.java.DeadboltHandler;
+import be.objectify.deadbolt.java.cache.BeforeAuthCheckCache;
+import be.objectify.deadbolt.java.cache.DefaultBeforeAuthCheckCache;
 import be.objectify.deadbolt.java.cache.HandlerCache;
 import com.typesafe.config.ConfigFactory;
 import org.junit.Test;
@@ -41,14 +43,17 @@ public class BeforeAccessActionTest
                      true);
 
         final DeadboltHandler handler = Mockito.mock(DeadboltHandler.class);
-        Mockito.when(handler.beforeAuthCheck(ctx))
+        Mockito.when(handler.beforeAuthCheck(ctx, Optional.empty()))
                .thenReturn(CompletableFuture.completedFuture(Optional.empty()));
 
         final HandlerCache handlerCache = Mockito.mock(HandlerCache.class);
         Mockito.when(handlerCache.get())
                .thenReturn(handler);
 
+        final BeforeAuthCheckCache beforeAuthCheckCache = new DefaultBeforeAuthCheckCache(ConfigFactory.empty());
+
         final BeforeAccessAction action = new BeforeAccessAction(handlerCache,
+                                                                 beforeAuthCheckCache,
                                                                  ConfigFactory.empty());
         action.configuration = Mockito.mock(BeforeAccess.class);
         Mockito.when(action.configuration.alwaysExecute())
@@ -57,13 +62,14 @@ public class BeforeAccessActionTest
 
         action.execute(ctx);
 
-        Mockito.verify(handler).beforeAuthCheck(ctx);
+        Mockito.verify(handler).beforeAuthCheck(ctx, Optional.empty());
     }
 
     @Test
     public void testExecute_alreadyAuthorised_alwaysExecuteFalse() throws Exception
     {
         final BeforeAccessAction action = new BeforeAccessAction(Mockito.mock(HandlerCache.class),
+                                                                 Mockito.mock(BeforeAuthCheckCache.class),
                                                                  ConfigFactory.empty());
         action.configuration = Mockito.mock(BeforeAccess.class);
         Mockito.when(action.configuration.alwaysExecute())

--- a/code/test/be/objectify/deadbolt/java/actions/CompositeActionTest.java
+++ b/code/test/be/objectify/deadbolt/java/actions/CompositeActionTest.java
@@ -17,6 +17,7 @@ package be.objectify.deadbolt.java.actions;
 
 import be.objectify.deadbolt.java.ConstraintLogic;
 import be.objectify.deadbolt.java.DeadboltHandler;
+import be.objectify.deadbolt.java.cache.BeforeAuthCheckCache;
 import be.objectify.deadbolt.java.cache.CompositeCache;
 import be.objectify.deadbolt.java.cache.HandlerCache;
 import be.objectify.deadbolt.java.composite.Constraint;
@@ -60,6 +61,7 @@ public class CompositeActionTest
                .thenReturn(Optional.of(constraint));
 
         final CompositeAction action = new CompositeAction(Mockito.mock(HandlerCache.class),
+                                                           Mockito.mock(BeforeAuthCheckCache.class),
                                                            ConfigFactory.empty(),
                                                            compositeCache,
                                                            Mockito.mock(ConstraintLogic.class));
@@ -83,6 +85,7 @@ public class CompositeActionTest
         Mockito.when(composite.meta())
                .thenReturn("foo");
         final CompositeAction action = new CompositeAction(Mockito.mock(HandlerCache.class),
+                                                           Mockito.mock(BeforeAuthCheckCache.class),
                                                            ConfigFactory.empty(),
                                                            Mockito.mock(CompositeCache.class),
                                                            Mockito.mock(ConstraintLogic.class));
@@ -99,6 +102,7 @@ public class CompositeActionTest
         Mockito.when(composite.value())
                .thenReturn("foo");
         final CompositeAction action = new CompositeAction(Mockito.mock(HandlerCache.class),
+                                                           Mockito.mock(BeforeAuthCheckCache.class),
                                                            ConfigFactory.empty(),
                                                            Mockito.mock(CompositeCache.class),
                                                            Mockito.mock(ConstraintLogic.class));
@@ -115,6 +119,7 @@ public class CompositeActionTest
         Mockito.when(composite.handlerKey())
                .thenReturn("foo");
         final CompositeAction action = new CompositeAction(Mockito.mock(HandlerCache.class),
+                                                           Mockito.mock(BeforeAuthCheckCache.class),
                                                            ConfigFactory.empty(),
                                                            Mockito.mock(CompositeCache.class),
                                                            Mockito.mock(ConstraintLogic.class));

--- a/code/test/be/objectify/deadbolt/java/actions/DynamicActionTest.java
+++ b/code/test/be/objectify/deadbolt/java/actions/DynamicActionTest.java
@@ -18,6 +18,7 @@ package be.objectify.deadbolt.java.actions;
 import be.objectify.deadbolt.java.ConstraintLogic;
 import be.objectify.deadbolt.java.ConstraintPoint;
 import be.objectify.deadbolt.java.DeadboltHandler;
+import be.objectify.deadbolt.java.cache.BeforeAuthCheckCache;
 import be.objectify.deadbolt.java.cache.HandlerCache;
 import be.objectify.deadbolt.java.utils.TriFunction;
 import com.typesafe.config.ConfigFactory;
@@ -47,6 +48,7 @@ public class DynamicActionTest
                .thenReturn("x/y");
         final ConstraintLogic constraintLogic = Mockito.mock(ConstraintLogic.class);
         final DynamicAction action = new DynamicAction(Mockito.mock(HandlerCache.class),
+                                                       Mockito.mock(BeforeAuthCheckCache.class),
                                                        ConfigFactory.empty(),
                                                        dynamic,
                                                        Mockito.mock(Action.class),
@@ -74,6 +76,7 @@ public class DynamicActionTest
         Mockito.when(dynamic.meta())
                .thenReturn("foo");
         final DynamicAction action = new DynamicAction(Mockito.mock(HandlerCache.class),
+                                                       Mockito.mock(BeforeAuthCheckCache.class),
                                                        ConfigFactory.empty(),
                                                        dynamic,
                                                        Mockito.mock(Action.class),
@@ -91,6 +94,7 @@ public class DynamicActionTest
         Mockito.when(dynamic.value())
                .thenReturn("foo");
         final DynamicAction action = new DynamicAction(Mockito.mock(HandlerCache.class),
+                                                       Mockito.mock(BeforeAuthCheckCache.class),
                                                        ConfigFactory.empty(),
                                                        dynamic,
                                                        Mockito.mock(Action.class),
@@ -107,6 +111,7 @@ public class DynamicActionTest
         Mockito.when(dynamic.handlerKey())
                .thenReturn("foo");
         final DynamicAction action = new DynamicAction(Mockito.mock(HandlerCache.class),
+                                                       Mockito.mock(BeforeAuthCheckCache.class),
                                                        ConfigFactory.empty(),
                                                        dynamic,
                                                        Mockito.mock(Action.class),

--- a/code/test/be/objectify/deadbolt/java/actions/PatternActionTest.java
+++ b/code/test/be/objectify/deadbolt/java/actions/PatternActionTest.java
@@ -18,6 +18,7 @@ package be.objectify.deadbolt.java.actions;
 import be.objectify.deadbolt.java.ConstraintLogic;
 import be.objectify.deadbolt.java.ConstraintPoint;
 import be.objectify.deadbolt.java.DeadboltHandler;
+import be.objectify.deadbolt.java.cache.BeforeAuthCheckCache;
 import be.objectify.deadbolt.java.cache.HandlerCache;
 import be.objectify.deadbolt.java.models.PatternType;
 import be.objectify.deadbolt.java.utils.TriFunction;
@@ -52,6 +53,7 @@ public class PatternActionTest
                .thenReturn(PatternType.EQUALITY);
         final ConstraintLogic constraintLogic = Mockito.mock(ConstraintLogic.class);
         final PatternAction action = new PatternAction(Mockito.mock(HandlerCache.class),
+                                                       Mockito.mock(BeforeAuthCheckCache.class),
                                                        ConfigFactory.empty(),
                                                        pattern,
                                                        Mockito.mock(Action.class),
@@ -81,6 +83,7 @@ public class PatternActionTest
         Mockito.when(pattern.value())
                .thenReturn("foo");
         final PatternAction action = new PatternAction(Mockito.mock(HandlerCache.class),
+                                                       Mockito.mock(BeforeAuthCheckCache.class),
                                                        ConfigFactory.empty(),
                                                        pattern,
                                                        Mockito.mock(Action.class),
@@ -97,6 +100,7 @@ public class PatternActionTest
         Mockito.when(pattern.meta())
                .thenReturn("foo");
         final PatternAction action = new PatternAction(Mockito.mock(HandlerCache.class),
+                                                       Mockito.mock(BeforeAuthCheckCache.class),
                                                        ConfigFactory.empty(),
                                                        pattern,
                                                        Mockito.mock(Action.class),
@@ -115,6 +119,7 @@ public class PatternActionTest
         Mockito.when(pattern.handlerKey())
                .thenReturn("foo");
         final PatternAction action = new PatternAction(Mockito.mock(HandlerCache.class),
+                                                       Mockito.mock(BeforeAuthCheckCache.class),
                                                        ConfigFactory.empty(),
                                                        pattern,
                                                        Mockito.mock(Action.class),

--- a/code/test/be/objectify/deadbolt/java/actions/SubjectNotPresentActionTest.java
+++ b/code/test/be/objectify/deadbolt/java/actions/SubjectNotPresentActionTest.java
@@ -18,6 +18,7 @@ package be.objectify.deadbolt.java.actions;
 import be.objectify.deadbolt.java.ConstraintLogic;
 import be.objectify.deadbolt.java.ConstraintPoint;
 import be.objectify.deadbolt.java.DeadboltHandler;
+import be.objectify.deadbolt.java.cache.BeforeAuthCheckCache;
 import be.objectify.deadbolt.java.cache.HandlerCache;
 import be.objectify.deadbolt.java.utils.TriFunction;
 import com.typesafe.config.ConfigFactory;
@@ -48,6 +49,7 @@ public class SubjectNotPresentActionTest {
         Mockito.when(subjectNotPresent.content())
                .thenReturn("x/y");
         final SubjectNotPresentAction action = new SubjectNotPresentAction(Mockito.mock(HandlerCache.class),
+                                                                           Mockito.mock(BeforeAuthCheckCache.class),
                                                                            ConfigFactory.empty(),
                                                                            Mockito.mock(ConstraintLogic.class));
         action.configuration = subjectNotPresent;
@@ -64,6 +66,7 @@ public class SubjectNotPresentActionTest {
     public void testPresent() throws Exception
     {
         final SubjectNotPresentAction action = new SubjectNotPresentAction(Mockito.mock(HandlerCache.class),
+                                                                           Mockito.mock(BeforeAuthCheckCache.class),
                                                                            ConfigFactory.empty(),
                                                                            Mockito.mock(ConstraintLogic.class));
 
@@ -89,6 +92,7 @@ public class SubjectNotPresentActionTest {
     public void testNotPresent() throws Exception
     {
         final SubjectNotPresentAction action = new SubjectNotPresentAction(Mockito.mock(HandlerCache.class),
+                                                                           Mockito.mock(BeforeAuthCheckCache.class),
                                                                            ConfigFactory.empty(),
                                                                            Mockito.mock(ConstraintLogic.class));
         action.delegate = Mockito.mock(Action.class);
@@ -117,6 +121,7 @@ public class SubjectNotPresentActionTest {
                .thenReturn(CompletableFuture.completedFuture(Results.TODO));
 
         final SubjectNotPresentAction action = new SubjectNotPresentAction(Mockito.mock(HandlerCache.class),
+                                                                           Mockito.mock(BeforeAuthCheckCache.class),
                                                                            ConfigFactory.empty(),
                                                                            constraintLogic);
         action.configuration = Mockito.mock(SubjectNotPresent.class);

--- a/code/test/be/objectify/deadbolt/java/actions/SubjectPresentActionTest.java
+++ b/code/test/be/objectify/deadbolt/java/actions/SubjectPresentActionTest.java
@@ -18,6 +18,7 @@ package be.objectify.deadbolt.java.actions;
 import be.objectify.deadbolt.java.ConstraintLogic;
 import be.objectify.deadbolt.java.ConstraintPoint;
 import be.objectify.deadbolt.java.DeadboltHandler;
+import be.objectify.deadbolt.java.cache.BeforeAuthCheckCache;
 import be.objectify.deadbolt.java.cache.HandlerCache;
 import be.objectify.deadbolt.java.utils.TriFunction;
 import com.typesafe.config.ConfigFactory;
@@ -48,6 +49,7 @@ public class SubjectPresentActionTest {
         Mockito.when(subjectPresent.content())
                .thenReturn("x/y");
         final SubjectPresentAction action = new SubjectPresentAction(Mockito.mock(HandlerCache.class),
+                                                                     Mockito.mock(BeforeAuthCheckCache.class),
                                                                      ConfigFactory.empty(),
                                                                      Mockito.mock(ConstraintLogic.class));
         action.configuration = subjectPresent;
@@ -64,6 +66,7 @@ public class SubjectPresentActionTest {
     public void testPresent() throws Exception
     {
         final SubjectPresentAction action = new SubjectPresentAction(Mockito.mock(HandlerCache.class),
+                                                                     Mockito.mock(BeforeAuthCheckCache.class),
                                                                      ConfigFactory.empty(),
                                                                      Mockito.mock(ConstraintLogic.class));
         action.delegate = Mockito.mock(Action.class);
@@ -82,6 +85,7 @@ public class SubjectPresentActionTest {
     public void testNotPresent() throws Exception
     {
         final SubjectPresentAction action = new SubjectPresentAction(Mockito.mock(HandlerCache.class),
+                                                                     Mockito.mock(BeforeAuthCheckCache.class),
                                                                      ConfigFactory.empty(),
                                                                      Mockito.mock(ConstraintLogic.class));
 
@@ -115,6 +119,7 @@ public class SubjectPresentActionTest {
                .thenReturn(CompletableFuture.completedFuture(Results.TODO));
 
         final SubjectPresentAction action = new SubjectPresentAction(Mockito.mock(HandlerCache.class),
+                                                                     Mockito.mock(BeforeAuthCheckCache.class),
                                                                      ConfigFactory.empty(),
                                                                      constraintLogic);
         action.configuration = Mockito.mock(SubjectPresent.class);

--- a/code/test/be/objectify/deadbolt/java/composite/AbstractCompositeTest.java
+++ b/code/test/be/objectify/deadbolt/java/composite/AbstractCompositeTest.java
@@ -45,7 +45,7 @@ public abstract class AbstractCompositeTest
         return new AbstractDeadboltHandler(ecp)
         {
             @Override
-            public CompletionStage<Optional<Result>> beforeAuthCheck(Http.Context context)
+            public CompletionStage<Optional<Result>> beforeAuthCheck(Http.Context context, Optional<String> content)
             {
                 return CompletableFuture.completedFuture(Optional.empty());
             }
@@ -64,7 +64,7 @@ public abstract class AbstractCompositeTest
         return new AbstractDeadboltHandler(ecp)
         {
             @Override
-            public CompletionStage<Optional<Result>> beforeAuthCheck(final Http.Context context)
+            public CompletionStage<Optional<Result>> beforeAuthCheck(final Http.Context context, final Optional<String> content)
             {
                 return CompletableFuture.completedFuture(Optional.empty());
             }

--- a/code/test/be/objectify/deadbolt/java/filters/AbstractDeadboltFilterTest.java
+++ b/code/test/be/objectify/deadbolt/java/filters/AbstractDeadboltFilterTest.java
@@ -2,12 +2,16 @@ package be.objectify.deadbolt.java.filters;
 
 import be.objectify.deadbolt.java.ConstraintLogic;
 import be.objectify.deadbolt.java.DeadboltAnalyzer;
+import be.objectify.deadbolt.java.cache.BeforeAuthCheckCache;
 import be.objectify.deadbolt.java.cache.CompositeCache;
+import be.objectify.deadbolt.java.cache.DefaultBeforeAuthCheckCache;
 import be.objectify.deadbolt.java.cache.DefaultPatternCache;
 import be.objectify.deadbolt.java.cache.SubjectCache;
 import org.junit.After;
 import org.junit.Before;
 import org.mockito.Mockito;
+
+import com.typesafe.config.ConfigFactory;
 
 /**
  * @author Steve Chaloner (steve@objectify.be)
@@ -26,8 +30,12 @@ public abstract class AbstractDeadboltFilterTest {
         final ConstraintLogic constraintLogic = new ConstraintLogic(analyzer,
                                                                     subjectCache,
                                                                     new DefaultPatternCache());
+
+        final BeforeAuthCheckCache beforeAuthCheckCache = new DefaultBeforeAuthCheckCache(ConfigFactory.empty());
+
         filterConstraints = new FilterConstraints(constraintLogic,
-                                                  Mockito.mock(CompositeCache.class));
+                                                  Mockito.mock(CompositeCache.class),
+                                                  beforeAuthCheckCache);
     }
 
     @After

--- a/code/test/be/objectify/deadbolt/java/filters/DeadboltRouteCommentFilterTest.java
+++ b/code/test/be/objectify/deadbolt/java/filters/DeadboltRouteCommentFilterTest.java
@@ -59,7 +59,7 @@ public class DeadboltRouteCommentFilterTest extends AbstractDeadboltFilterTest
                .thenReturn(handler);
         Mockito.when(handler.getSubject(Mockito.any(Http.Context.class)))
                .thenReturn(CompletableFuture.completedFuture(Optional.of(Mockito.mock(Subject.class))));
-        Mockito.when(handler.beforeAuthCheck(Mockito.any(Http.Context.class)))
+        Mockito.when(handler.beforeAuthCheck(Mockito.any(Http.Context.class), Mockito.any(Optional.class)))
                .thenReturn(CompletableFuture.completedFuture(Optional.empty()));
 
         final Filter filter = new DeadboltRouteCommentFilter(Mockito.mock(Materializer.class),
@@ -91,7 +91,7 @@ public class DeadboltRouteCommentFilterTest extends AbstractDeadboltFilterTest
                .thenReturn(handler);
         Mockito.when(handler.getSubject(Mockito.any(Http.Context.class)))
                .thenReturn(CompletableFuture.completedFuture(Optional.empty()));
-        Mockito.when(handler.beforeAuthCheck(Mockito.any(Http.Context.class)))
+        Mockito.when(handler.beforeAuthCheck(Mockito.any(Http.Context.class), Mockito.any(Optional.class)))
                .thenReturn(CompletableFuture.completedFuture(Optional.empty()));
         Mockito.when(handler.onAuthFailure(Mockito.any(Http.Context.class),
                                            Mockito.eq(Optional.empty())))
@@ -130,7 +130,7 @@ public class DeadboltRouteCommentFilterTest extends AbstractDeadboltFilterTest
                .thenReturn(handler);
         Mockito.when(handler.getSubject(Mockito.any(Http.Context.class)))
                .thenReturn(CompletableFuture.completedFuture(Optional.empty()));
-        Mockito.when(handler.beforeAuthCheck(Mockito.any(Http.Context.class)))
+        Mockito.when(handler.beforeAuthCheck(Mockito.any(Http.Context.class), Mockito.any(Optional.class)))
                .thenReturn(CompletableFuture.completedFuture(Optional.empty()));
         Mockito.when(handler.onAuthFailure(Mockito.any(Http.Context.class),
                                            Mockito.eq(Optional.of("bar"))))
@@ -170,7 +170,7 @@ public class DeadboltRouteCommentFilterTest extends AbstractDeadboltFilterTest
                                                                                         specificHandler));
         Mockito.when(specificHandler.getSubject(Mockito.any(Http.Context.class)))
                .thenReturn(CompletableFuture.completedFuture(Optional.of(Mockito.mock(Subject.class))));
-        Mockito.when(specificHandler.beforeAuthCheck(Mockito.any(Http.Context.class)))
+        Mockito.when(specificHandler.beforeAuthCheck(Mockito.any(Http.Context.class), Mockito.any(Optional.class)))
                .thenReturn(CompletableFuture.completedFuture(Optional.empty()));
 
         final Filter filter = new DeadboltRouteCommentFilter(Mockito.mock(Materializer.class),
@@ -204,7 +204,7 @@ public class DeadboltRouteCommentFilterTest extends AbstractDeadboltFilterTest
                                                                                         specificHandler));
         Mockito.when(specificHandler.getSubject(Mockito.any(Http.Context.class)))
                .thenReturn(CompletableFuture.completedFuture(Optional.empty()));
-        Mockito.when(specificHandler.beforeAuthCheck(Mockito.any(Http.Context.class)))
+        Mockito.when(specificHandler.beforeAuthCheck(Mockito.any(Http.Context.class), Mockito.any(Optional.class)))
                .thenReturn(CompletableFuture.completedFuture(Optional.empty()));
         Mockito.when(specificHandler.onAuthFailure(Mockito.any(Http.Context.class),
                                                    Mockito.eq(Optional.empty())))
@@ -245,7 +245,7 @@ public class DeadboltRouteCommentFilterTest extends AbstractDeadboltFilterTest
                                                                                         specificHandler));
         Mockito.when(specificHandler.getSubject(Mockito.any(Http.Context.class)))
                .thenReturn(CompletableFuture.completedFuture(Optional.empty()));
-        Mockito.when(specificHandler.beforeAuthCheck(Mockito.any(Http.Context.class)))
+        Mockito.when(specificHandler.beforeAuthCheck(Mockito.any(Http.Context.class), Mockito.any(Optional.class)))
                .thenReturn(CompletableFuture.completedFuture(Optional.empty()));
         Mockito.when(specificHandler.onAuthFailure(Mockito.any(Http.Context.class),
                                                    Mockito.eq(Optional.of("bar"))))
@@ -286,7 +286,7 @@ public class DeadboltRouteCommentFilterTest extends AbstractDeadboltFilterTest
                .thenReturn(handler);
         Mockito.when(handler.getSubject(Mockito.any(Http.Context.class)))
                .thenReturn(CompletableFuture.completedFuture(Optional.of(Mockito.mock(Subject.class))));
-        Mockito.when(handler.beforeAuthCheck(Mockito.any(Http.Context.class)))
+        Mockito.when(handler.beforeAuthCheck(Mockito.any(Http.Context.class), Mockito.any(Optional.class)))
                .thenReturn(CompletableFuture.completedFuture(Optional.empty()));
         Mockito.when(handler.onAuthFailure(Mockito.any(Http.Context.class),
                                            Mockito.eq(Optional.empty())))
@@ -326,7 +326,7 @@ public class DeadboltRouteCommentFilterTest extends AbstractDeadboltFilterTest
                .thenReturn(handler);
         Mockito.when(handler.getSubject(Mockito.any(Http.Context.class)))
                .thenReturn(CompletableFuture.completedFuture(Optional.of(Mockito.mock(Subject.class))));
-        Mockito.when(handler.beforeAuthCheck(Mockito.any(Http.Context.class)))
+        Mockito.when(handler.beforeAuthCheck(Mockito.any(Http.Context.class), Mockito.any(Optional.class)))
                .thenReturn(CompletableFuture.completedFuture(Optional.empty()));
         Mockito.when(handler.onAuthFailure(Mockito.any(Http.Context.class),
                                            Mockito.eq(Optional.of("bar"))))
@@ -366,7 +366,7 @@ public class DeadboltRouteCommentFilterTest extends AbstractDeadboltFilterTest
                .thenReturn(handler);
         Mockito.when(handler.getSubject(Mockito.any(Http.Context.class)))
                .thenReturn(CompletableFuture.completedFuture(Optional.empty()));
-        Mockito.when(handler.beforeAuthCheck(Mockito.any(Http.Context.class)))
+        Mockito.when(handler.beforeAuthCheck(Mockito.any(Http.Context.class), Mockito.any(Optional.class)))
                .thenReturn(CompletableFuture.completedFuture(Optional.empty()));
 
         final Filter filter = new DeadboltRouteCommentFilter(Mockito.mock(Materializer.class),
@@ -399,7 +399,7 @@ public class DeadboltRouteCommentFilterTest extends AbstractDeadboltFilterTest
                                                                                         specificHandler));
         Mockito.when(specificHandler.getSubject(Mockito.any(Http.Context.class)))
                .thenReturn(CompletableFuture.completedFuture(Optional.of(Mockito.mock(Subject.class))));
-        Mockito.when(specificHandler.beforeAuthCheck(Mockito.any(Http.Context.class)))
+        Mockito.when(specificHandler.beforeAuthCheck(Mockito.any(Http.Context.class), Mockito.any(Optional.class)))
                .thenReturn(CompletableFuture.completedFuture(Optional.empty()));
         Mockito.when(specificHandler.onAuthFailure(Mockito.any(Http.Context.class),
                                                    Mockito.eq(Optional.empty())))
@@ -440,7 +440,7 @@ public class DeadboltRouteCommentFilterTest extends AbstractDeadboltFilterTest
                                                                                         specificHandler));
         Mockito.when(specificHandler.getSubject(Mockito.any(Http.Context.class)))
                .thenReturn(CompletableFuture.completedFuture(Optional.of(Mockito.mock(Subject.class))));
-        Mockito.when(specificHandler.beforeAuthCheck(Mockito.any(Http.Context.class)))
+        Mockito.when(specificHandler.beforeAuthCheck(Mockito.any(Http.Context.class), Mockito.any(Optional.class)))
                .thenReturn(CompletableFuture.completedFuture(Optional.empty()));
         Mockito.when(specificHandler.onAuthFailure(Mockito.any(Http.Context.class),
                                                    Mockito.eq(Optional.of("bar"))))
@@ -481,7 +481,7 @@ public class DeadboltRouteCommentFilterTest extends AbstractDeadboltFilterTest
                                                                                         specificHandler));
         Mockito.when(specificHandler.getSubject(Mockito.any(Http.Context.class)))
                .thenReturn(CompletableFuture.completedFuture(Optional.empty()));
-        Mockito.when(specificHandler.beforeAuthCheck(Mockito.any(Http.Context.class)))
+        Mockito.when(specificHandler.beforeAuthCheck(Mockito.any(Http.Context.class), Mockito.any(Optional.class)))
                .thenReturn(CompletableFuture.completedFuture(Optional.empty()));
         Mockito.when(specificHandler.onAuthFailure(Mockito.any(Http.Context.class),
                                                    Mockito.eq(Optional.empty())))
@@ -516,7 +516,7 @@ public class DeadboltRouteCommentFilterTest extends AbstractDeadboltFilterTest
         final DynamicResourceHandler drh = Mockito.mock(DynamicResourceHandler.class);
         Mockito.when(handlerCache.get())
                .thenReturn(handler);
-        Mockito.when(handler.beforeAuthCheck(Mockito.any(Http.Context.class)))
+        Mockito.when(handler.beforeAuthCheck(Mockito.any(Http.Context.class), Mockito.any(Optional.class)))
                .thenReturn(CompletableFuture.completedFuture(Optional.empty()));
         Mockito.when(handler.getDynamicResourceHandler(Mockito.any(Http.Context.class)))
                .thenReturn(CompletableFuture.completedFuture(Optional.of(drh)));
@@ -554,7 +554,7 @@ public class DeadboltRouteCommentFilterTest extends AbstractDeadboltFilterTest
         final DynamicResourceHandler drh = Mockito.mock(DynamicResourceHandler.class);
         Mockito.when(handlerCache.get())
                .thenReturn(handler);
-        Mockito.when(handler.beforeAuthCheck(Mockito.any(Http.Context.class)))
+        Mockito.when(handler.beforeAuthCheck(Mockito.any(Http.Context.class), Mockito.any(Optional.class)))
                .thenReturn(CompletableFuture.completedFuture(Optional.empty()));
         Mockito.when(handler.getDynamicResourceHandler(Mockito.any(Http.Context.class)))
                .thenReturn(CompletableFuture.completedFuture(Optional.of(drh)));
@@ -599,7 +599,7 @@ public class DeadboltRouteCommentFilterTest extends AbstractDeadboltFilterTest
         final DynamicResourceHandler drh = Mockito.mock(DynamicResourceHandler.class);
         Mockito.when(handlerCache.get())
                .thenReturn(handler);
-        Mockito.when(handler.beforeAuthCheck(Mockito.any(Http.Context.class)))
+        Mockito.when(handler.beforeAuthCheck(Mockito.any(Http.Context.class), Mockito.any(Optional.class)))
                .thenReturn(CompletableFuture.completedFuture(Optional.empty()));
         Mockito.when(handler.getDynamicResourceHandler(Mockito.any(Http.Context.class)))
                .thenReturn(CompletableFuture.completedFuture(Optional.of(drh)));
@@ -645,7 +645,7 @@ public class DeadboltRouteCommentFilterTest extends AbstractDeadboltFilterTest
         final HandlerCache handlerCache = new TestHandlerCache(defaultHandler,
                                                                Collections.singletonMap("gurdy",
                                                                                         specificHandler));
-        Mockito.when(specificHandler.beforeAuthCheck(Mockito.any(Http.Context.class)))
+        Mockito.when(specificHandler.beforeAuthCheck(Mockito.any(Http.Context.class), Mockito.any(Optional.class)))
                .thenReturn(CompletableFuture.completedFuture(Optional.empty()));
         Mockito.when(specificHandler.getDynamicResourceHandler(Mockito.any(Http.Context.class)))
                .thenReturn(CompletableFuture.completedFuture(Optional.of(drh)));
@@ -685,7 +685,7 @@ public class DeadboltRouteCommentFilterTest extends AbstractDeadboltFilterTest
         final HandlerCache handlerCache = new TestHandlerCache(defaultHandler,
                                                                Collections.singletonMap("gurdy",
                                                                                         specificHandler));
-        Mockito.when(specificHandler.beforeAuthCheck(Mockito.any(Http.Context.class)))
+        Mockito.when(specificHandler.beforeAuthCheck(Mockito.any(Http.Context.class), Mockito.any(Optional.class)))
                .thenReturn(CompletableFuture.completedFuture(Optional.empty()));
         Mockito.when(specificHandler.getDynamicResourceHandler(Mockito.any(Http.Context.class)))
                .thenReturn(CompletableFuture.completedFuture(Optional.of(drh)));
@@ -732,7 +732,7 @@ public class DeadboltRouteCommentFilterTest extends AbstractDeadboltFilterTest
         final HandlerCache handlerCache = new TestHandlerCache(defaultHandler,
                                                                Collections.singletonMap("gurdy",
                                                                                         specificHandler));
-        Mockito.when(specificHandler.beforeAuthCheck(Mockito.any(Http.Context.class)))
+        Mockito.when(specificHandler.beforeAuthCheck(Mockito.any(Http.Context.class), Mockito.any(Optional.class)))
                .thenReturn(CompletableFuture.completedFuture(Optional.empty()));
         Mockito.when(specificHandler.getDynamicResourceHandler(Mockito.any(Http.Context.class)))
                .thenReturn(CompletableFuture.completedFuture(Optional.of(drh)));
@@ -814,7 +814,7 @@ public class DeadboltRouteCommentFilterTest extends AbstractDeadboltFilterTest
                .thenReturn(CompletableFuture.completedFuture(Optional.of(subject)));
         Mockito.when(handler.getPermissionsForRole("foo"))
                .then(invocation -> CompletableFuture.completedFuture(Collections.singletonList(new TestPermission("bar"))));
-        Mockito.when(handler.beforeAuthCheck(Mockito.any(Http.Context.class)))
+        Mockito.when(handler.beforeAuthCheck(Mockito.any(Http.Context.class), Mockito.any(Optional.class)))
                .thenReturn(CompletableFuture.completedFuture(Optional.empty()));
 
         final Filter filter = new DeadboltRouteCommentFilter(Mockito.mock(Materializer.class),
@@ -847,7 +847,7 @@ public class DeadboltRouteCommentFilterTest extends AbstractDeadboltFilterTest
                .thenReturn(handler);
         Mockito.when(handler.getSubject(Mockito.any(Http.Context.class)))
                .thenReturn(CompletableFuture.completedFuture(Optional.empty()));
-        Mockito.when(handler.beforeAuthCheck(Mockito.any(Http.Context.class)))
+        Mockito.when(handler.beforeAuthCheck(Mockito.any(Http.Context.class), Mockito.any(Optional.class)))
                .thenReturn(CompletableFuture.completedFuture(Optional.empty()));
         Mockito.when(handler.getPermissionsForRole("foo"))
                .then(invocation -> CompletableFuture.completedFuture(Collections.singletonList(new TestPermission("bar"))));
@@ -890,7 +890,7 @@ public class DeadboltRouteCommentFilterTest extends AbstractDeadboltFilterTest
                .thenReturn(handler);
         Mockito.when(handler.getSubject(Mockito.any(Http.Context.class)))
                .thenReturn(CompletableFuture.completedFuture(Optional.empty()));
-        Mockito.when(handler.beforeAuthCheck(Mockito.any(Http.Context.class)))
+        Mockito.when(handler.beforeAuthCheck(Mockito.any(Http.Context.class), Mockito.any(Optional.class)))
                .thenReturn(CompletableFuture.completedFuture(Optional.empty()));
         Mockito.when(handler.getPermissionsForRole("foo"))
                .then(invocation -> CompletableFuture.completedFuture(Collections.singletonList(new TestPermission("bar"))));
@@ -934,7 +934,7 @@ public class DeadboltRouteCommentFilterTest extends AbstractDeadboltFilterTest
                                                                                         specificHandler));
         Mockito.when(specificHandler.getSubject(Mockito.any(Http.Context.class)))
                .thenReturn(CompletableFuture.completedFuture(Optional.of(Mockito.mock(Subject.class))));
-        Mockito.when(specificHandler.beforeAuthCheck(Mockito.any(Http.Context.class)))
+        Mockito.when(specificHandler.beforeAuthCheck(Mockito.any(Http.Context.class), Mockito.any(Optional.class)))
                .thenReturn(CompletableFuture.completedFuture(Optional.empty()));
         Mockito.when(specificHandler.getPermissionsForRole("foo"))
                .then(invocation -> CompletableFuture.completedFuture(Collections.singletonList(new TestPermission("bar"))));
@@ -972,7 +972,7 @@ public class DeadboltRouteCommentFilterTest extends AbstractDeadboltFilterTest
                                                                                         specificHandler));
         Mockito.when(specificHandler.getSubject(Mockito.any(Http.Context.class)))
                .thenReturn(CompletableFuture.completedFuture(Optional.empty()));
-        Mockito.when(specificHandler.beforeAuthCheck(Mockito.any(Http.Context.class)))
+        Mockito.when(specificHandler.beforeAuthCheck(Mockito.any(Http.Context.class), Mockito.any(Optional.class)))
                .thenReturn(CompletableFuture.completedFuture(Optional.empty()));
         Mockito.when(specificHandler.onAuthFailure(Mockito.any(Http.Context.class),
                                                    Mockito.eq(Optional.empty())))
@@ -1016,7 +1016,7 @@ public class DeadboltRouteCommentFilterTest extends AbstractDeadboltFilterTest
                                                                                         specificHandler));
         Mockito.when(specificHandler.getSubject(Mockito.any(Http.Context.class)))
                .thenReturn(CompletableFuture.completedFuture(Optional.empty()));
-        Mockito.when(specificHandler.beforeAuthCheck(Mockito.any(Http.Context.class)))
+        Mockito.when(specificHandler.beforeAuthCheck(Mockito.any(Http.Context.class), Mockito.any(Optional.class)))
                .thenReturn(CompletableFuture.completedFuture(Optional.empty()));
         Mockito.when(specificHandler.onAuthFailure(Mockito.any(Http.Context.class),
                                                    Mockito.eq(Optional.of("bar"))))

--- a/code/test/be/objectify/deadbolt/java/filters/DeadboltRoutePathFilterTest.java
+++ b/code/test/be/objectify/deadbolt/java/filters/DeadboltRoutePathFilterTest.java
@@ -54,7 +54,7 @@ public class DeadboltRoutePathFilterTest extends AbstractDeadboltFilterTest
                .thenReturn(handler);
         Mockito.when(handler.getSubject(Mockito.any(Http.Context.class)))
                .thenReturn(CompletableFuture.completedFuture(Optional.of(Mockito.mock(Subject.class))));
-        Mockito.when(handler.beforeAuthCheck(Mockito.any(Http.Context.class)))
+        Mockito.when(handler.beforeAuthCheck(Mockito.any(Http.Context.class), Mockito.any(Optional.class)))
                .thenReturn(CompletableFuture.completedFuture(Optional.empty()));
         final DeadboltRoutePathFilter filter = new DeadboltRoutePathFilter(Mockito.mock(Materializer.class),
                                                                            Mockito.mock(JavaContextComponents.class),
@@ -93,7 +93,7 @@ public class DeadboltRoutePathFilterTest extends AbstractDeadboltFilterTest
                .thenReturn(handler);
         Mockito.when(handler.getSubject(Mockito.any(Http.Context.class)))
                .thenReturn(CompletableFuture.completedFuture(Optional.empty()));
-        Mockito.when(handler.beforeAuthCheck(Mockito.any(Http.Context.class)))
+        Mockito.when(handler.beforeAuthCheck(Mockito.any(Http.Context.class), Mockito.any(Optional.class)))
                .thenReturn(CompletableFuture.completedFuture(Optional.empty()));
         Mockito.when(handler.onAuthFailure(Mockito.any(Http.Context.class),
                                            Mockito.eq(Optional.empty())))
@@ -139,7 +139,7 @@ public class DeadboltRoutePathFilterTest extends AbstractDeadboltFilterTest
                .thenReturn(handler);
         Mockito.when(handler.getSubject(Mockito.any(Http.Context.class)))
                .thenReturn(CompletableFuture.completedFuture(Optional.empty()));
-        Mockito.when(handler.beforeAuthCheck(Mockito.any(Http.Context.class)))
+        Mockito.when(handler.beforeAuthCheck(Mockito.any(Http.Context.class), Mockito.any(Optional.class)))
                .thenReturn(CompletableFuture.completedFuture(Optional.empty()));
         Mockito.when(handler.onAuthFailure(Mockito.any(Http.Context.class),
                                            Mockito.eq(Optional.of("foo"))))
@@ -186,7 +186,7 @@ public class DeadboltRoutePathFilterTest extends AbstractDeadboltFilterTest
                .thenReturn(defaultHandler);
         Mockito.when(specificHandler.getSubject(Mockito.any(Http.Context.class)))
                .thenReturn(CompletableFuture.completedFuture(Optional.of(Mockito.mock(Subject.class))));
-        Mockito.when(specificHandler.beforeAuthCheck(Mockito.any(Http.Context.class)))
+        Mockito.when(specificHandler.beforeAuthCheck(Mockito.any(Http.Context.class), Mockito.any(Optional.class)))
                .thenReturn(CompletableFuture.completedFuture(Optional.empty()));
         final DeadboltRoutePathFilter filter = new DeadboltRoutePathFilter(Mockito.mock(Materializer.class),
                                                                            Mockito.mock(JavaContextComponents.class),
@@ -228,7 +228,7 @@ public class DeadboltRoutePathFilterTest extends AbstractDeadboltFilterTest
                .thenReturn(defaultHandler);
         Mockito.when(specificHandler.getSubject(Mockito.any(Http.Context.class)))
                .thenReturn(CompletableFuture.completedFuture(Optional.empty()));
-        Mockito.when(specificHandler.beforeAuthCheck(Mockito.any(Http.Context.class)))
+        Mockito.when(specificHandler.beforeAuthCheck(Mockito.any(Http.Context.class), Mockito.any(Optional.class)))
                .thenReturn(CompletableFuture.completedFuture(Optional.empty()));
         Mockito.when(specificHandler.onAuthFailure(Mockito.any(Http.Context.class),
                                                    Mockito.eq(Optional.empty())))
@@ -277,7 +277,7 @@ public class DeadboltRoutePathFilterTest extends AbstractDeadboltFilterTest
                .thenReturn(defaultHandler);
         Mockito.when(specificHandler.getSubject(Mockito.any(Http.Context.class)))
                .thenReturn(CompletableFuture.completedFuture(Optional.empty()));
-        Mockito.when(specificHandler.beforeAuthCheck(Mockito.any(Http.Context.class)))
+        Mockito.when(specificHandler.beforeAuthCheck(Mockito.any(Http.Context.class), Mockito.any(Optional.class)))
                .thenReturn(CompletableFuture.completedFuture(Optional.empty()));
         Mockito.when(specificHandler.onAuthFailure(Mockito.any(Http.Context.class),
                                                    Mockito.eq(Optional.of("foo"))))

--- a/code/test/be/objectify/deadbolt/java/filters/FilterConstraintsTest.java
+++ b/code/test/be/objectify/deadbolt/java/filters/FilterConstraintsTest.java
@@ -21,7 +21,9 @@ import be.objectify.deadbolt.java.DeadboltAnalyzer;
 import be.objectify.deadbolt.java.DeadboltHandler;
 import be.objectify.deadbolt.java.DefaultDeadboltExecutionContextProvider;
 import be.objectify.deadbolt.java.ExecutionContextProvider;
+import be.objectify.deadbolt.java.cache.BeforeAuthCheckCache;
 import be.objectify.deadbolt.java.cache.CompositeCache;
+import be.objectify.deadbolt.java.cache.DefaultBeforeAuthCheckCache;
 import be.objectify.deadbolt.java.cache.DefaultCompositeCache;
 import be.objectify.deadbolt.java.cache.DefaultPatternCache;
 import be.objectify.deadbolt.java.cache.DefaultSubjectCache;
@@ -76,7 +78,7 @@ public class FilterConstraintsTest
                .thenReturn(new DefaultDeadboltExecutionContextProvider(HttpExecutionContext.fromThread(Executors.newSingleThreadExecutor())));
 
         handler = Mockito.mock(DeadboltHandler.class);
-        Mockito.when(handler.beforeAuthCheck(Mockito.any(Http.Context.class)))
+        Mockito.when(handler.beforeAuthCheck(Mockito.any(Http.Context.class), Mockito.any(Optional.class)))
                .thenReturn(CompletableFuture.completedFuture(Optional.empty()));
         Mockito.when(handler.onAuthFailure(Mockito.any(Http.Context.class),
                                            Mockito.any(Optional.class)))
@@ -95,8 +97,11 @@ public class FilterConstraintsTest
                                 new SubjectPresentConstraint(Optional.empty(),
                                                              constraintLogic));
 
+        final BeforeAuthCheckCache beforeAuthCheckCache = new DefaultBeforeAuthCheckCache(ConfigFactory.empty());
+
         filterConstraints = new FilterConstraints(constraintLogic,
-                                                  compositeCache);
+                                                  compositeCache,
+                                                  beforeAuthCheckCache);
 
         requestHeader = Mockito.mock(Http.RequestHeader.class);
 

--- a/test-app-filters/app/be/objectify/deadbolt/java/test/security/MyDeadboltHandler.java
+++ b/test-app-filters/app/be/objectify/deadbolt/java/test/security/MyDeadboltHandler.java
@@ -64,7 +64,7 @@ public class MyDeadboltHandler extends AbstractDeadboltHandler
     }
 
     @Override
-    public CompletionStage<Optional<Result>> beforeAuthCheck(final Http.Context context)
+    public CompletionStage<Optional<Result>> beforeAuthCheck(final Http.Context context, final Optional<String> content)
     {
         return CompletableFuture.completedFuture(Optional.empty());
     }

--- a/test-app-filters/app/be/objectify/deadbolt/java/test/security/SomeOtherDeadboltHandler.java
+++ b/test-app-filters/app/be/objectify/deadbolt/java/test/security/SomeOtherDeadboltHandler.java
@@ -48,7 +48,7 @@ public class SomeOtherDeadboltHandler extends AbstractDeadboltHandler
     }
 
     @Override
-    public CompletionStage<Optional<Result>> beforeAuthCheck(final Http.Context context)
+    public CompletionStage<Optional<Result>> beforeAuthCheck(final Http.Context context, final Optional<String> content)
     {
         return CompletableFuture.completedFuture(Optional.empty());
     }

--- a/test-app/app/be/objectify/deadbolt/java/test/security/MyDeadboltHandler.java
+++ b/test-app/app/be/objectify/deadbolt/java/test/security/MyDeadboltHandler.java
@@ -69,7 +69,7 @@ public class MyDeadboltHandler extends AbstractDeadboltHandler
     }
 
     @Override
-    public CompletionStage<Optional<Result>> beforeAuthCheck(final Http.Context context)
+    public CompletionStage<Optional<Result>> beforeAuthCheck(final Http.Context context, final Optional<String> content)
     {
         return CompletableFuture.completedFuture(Optional.empty());
     }

--- a/test-app/app/be/objectify/deadbolt/java/test/security/SomeOtherDeadboltHandler.java
+++ b/test-app/app/be/objectify/deadbolt/java/test/security/SomeOtherDeadboltHandler.java
@@ -53,7 +53,7 @@ public class SomeOtherDeadboltHandler extends AbstractDeadboltHandler
     }
 
     @Override
-    public CompletionStage<Optional<Result>> beforeAuthCheck(final Http.Context context)
+    public CompletionStage<Optional<Result>> beforeAuthCheck(final Http.Context context, final Optional<String> content)
     {
         return CompletableFuture.completedFuture(Optional.empty());
     }


### PR DESCRIPTION
We should also be able to react to the `content` when returning a non-empty result in `beforeAuthCheck` (not just in `onAuthFailure`).

The `content` is the one passed to the `@Constraint`.
For `@BeforeAccess` this means it now also has a `content` parameter. Makes sense to me.

This enhancement allows me to generalise the code even better in one of my next pull requests (and therefore make the code safer).