### PR TITLE
DeferredDeadbolt.execute should just pass through

### DIFF
--- a/code/app/be/objectify/deadbolt/java/actions/AbstractDeadboltAction.java
+++ b/code/app/be/objectify/deadbolt/java/actions/AbstractDeadboltAction.java
@@ -114,7 +114,9 @@ public abstract class AbstractDeadboltAction<T> extends Action<T>
         {
             if (isDeferred(ctx))
             {
-                result = getDeferredAction(ctx).call(ctx);
+                final AbstractDeadboltAction<?> deferredAction = getDeferredAction(ctx);
+                LOGGER.debug("Executing deferred action [{}]", deferredAction.getClass().getName());
+                result = deferredAction.call(ctx);
             }
             else if (!ctx.args.containsKey(IGNORE_DEFERRED_FLAG)
                     && deferred())

--- a/code/app/be/objectify/deadbolt/java/actions/DeferredDeadboltAction.java
+++ b/code/app/be/objectify/deadbolt/java/actions/DeferredDeadboltAction.java
@@ -50,22 +50,8 @@ public class DeferredDeadboltAction extends AbstractDeadboltAction<DeferredDeadb
     @Override
     public CompletionStage<Result> execute(final Http.Context ctx) throws Exception
     {
-        final CompletableFuture<Result> eventualResult = CompletableFuture.completedFuture(getDeferredAction(ctx))
-                                                                          .thenCompose(deferredAction ->
-                                                                                            {
-                                                                                                final CompletionStage<Result> result;
-                                                                                                if (deferredAction == null)
-                                                                                                {
-                                                                                                    result = delegate.call(ctx);
-                                                                                                }
-                                                                                                else
-                                                                                                {
-                                                                                                    LOGGER.debug("Executing deferred action [{}]",
-                                                                                                                 deferredAction.getClass().getName());
-                                                                                                    result = deferredAction.call(ctx);
-                                                                                                }
-                                                                                                return result;
-                                                                                            });
+        final CompletionStage<Result> eventualResult = delegate.call(ctx);
+
         return maybeBlock(eventualResult);
     }
 


### PR DESCRIPTION
`getDeferredAction(ctx)` inside `DeferredDeadboltAction.execute(...)` will **never** return a defered action (and therefore `delegate.call(ctx)` will **always** be called)
Why? Because `DeferredDeadboltAction.execute(...)` will only be called from within `AbstractDeadboltAction.call(...)` always *after* `if (isDeferred(ctx))` was checked already and if so then in that `if` branch `getDeferredAction` will be called and the defered actions call method gets executed.
So at the time when `DeferredDeadbolt.execute` will run there will never ever be a defered action saved anymore... because it was clean up by `getDeferredAction` long before already :wink: 