### PR TITLE
Remove alwaysExecute from @BeforeAccess

### DIFF
--- a/code/app/be/objectify/deadbolt/java/actions/BeforeAccess.java
+++ b/code/app/be/objectify/deadbolt/java/actions/BeforeAccess.java
@@ -56,14 +56,6 @@ public @interface BeforeAccess
     String handlerKey() default ConfigKeys.DEFAULT_HANDLER_KEY;
 
     /**
-     * By default, if another Deadbolt action has already been executed in the same request and has allowed access,
-     * beforeAuthCheck will not be executed again.  Set this to true if you want it to execute unconditionally.
-     *
-     * @return true if beforeAuthCheck should always be executed, otherwise false
-     */
-    boolean alwaysExecute() default true;
-
-    /**
      * If true, the annotation will only be run if there is a {@link DeferredDeadbolt} annotation at the class level.
      *
      * @return true iff the associated action should be deferred until class-level annotations are applied.

--- a/code/app/be/objectify/deadbolt/java/actions/BeforeAccessAction.java
+++ b/code/app/be/objectify/deadbolt/java/actions/BeforeAccessAction.java
@@ -52,7 +52,7 @@ public class BeforeAccessAction extends AbstractDeadboltAction<BeforeAccess>
     public CompletionStage<Result> execute(final Http.Context ctx) throws Exception
     {
         final CompletionStage<Result> result;
-        if (isActionAuthorised(ctx) && !configuration.alwaysExecute())
+        if (isActionAuthorised(ctx))
         {
             result = delegate.call(ctx);
         }

--- a/code/test/be/objectify/deadbolt/java/actions/BeforeAccessActionTest.java
+++ b/code/test/be/objectify/deadbolt/java/actions/BeforeAccessActionTest.java
@@ -15,9 +15,7 @@
  */
 package be.objectify.deadbolt.java.actions;
 
-import be.objectify.deadbolt.java.DeadboltHandler;
 import be.objectify.deadbolt.java.cache.BeforeAuthCheckCache;
-import be.objectify.deadbolt.java.cache.DefaultBeforeAuthCheckCache;
 import be.objectify.deadbolt.java.cache.HandlerCache;
 import com.typesafe.config.ConfigFactory;
 import org.junit.Test;
@@ -26,8 +24,6 @@ import play.mvc.Action;
 import play.mvc.Http;
 
 import java.util.HashMap;
-import java.util.Optional;
-import java.util.concurrent.CompletableFuture;
 
 /**
  * @author Steve Chaloner (steve@objectify.be)
@@ -35,45 +31,12 @@ import java.util.concurrent.CompletableFuture;
 public class BeforeAccessActionTest
 {
     @Test
-    public void testExecute_alreadyAuthorised_alwaysExecuteTrue() throws Exception
-    {
-        final Http.Context ctx = Mockito.mock(Http.Context.class);
-        ctx.args = new HashMap<>();
-        ctx.args.put("deadbolt.action-authorised",
-                     true);
-
-        final DeadboltHandler handler = Mockito.mock(DeadboltHandler.class);
-        Mockito.when(handler.beforeAuthCheck(ctx, Optional.empty()))
-               .thenReturn(CompletableFuture.completedFuture(Optional.empty()));
-
-        final HandlerCache handlerCache = Mockito.mock(HandlerCache.class);
-        Mockito.when(handlerCache.get())
-               .thenReturn(handler);
-
-        final BeforeAuthCheckCache beforeAuthCheckCache = new DefaultBeforeAuthCheckCache(ConfigFactory.empty());
-
-        final BeforeAccessAction action = new BeforeAccessAction(handlerCache,
-                                                                 beforeAuthCheckCache,
-                                                                 ConfigFactory.empty());
-        action.configuration = Mockito.mock(BeforeAccess.class);
-        Mockito.when(action.configuration.alwaysExecute())
-               .thenReturn(true);
-        action.delegate = Mockito.mock(Action.class);
-
-        action.execute(ctx);
-
-        Mockito.verify(handler).beforeAuthCheck(ctx, Optional.empty());
-    }
-
-    @Test
     public void testExecute_alreadyAuthorised_alwaysExecuteFalse() throws Exception
     {
         final BeforeAccessAction action = new BeforeAccessAction(Mockito.mock(HandlerCache.class),
                                                                  Mockito.mock(BeforeAuthCheckCache.class),
                                                                  ConfigFactory.empty());
         action.configuration = Mockito.mock(BeforeAccess.class);
-        Mockito.when(action.configuration.alwaysExecute())
-               .thenReturn(false);
         action.delegate = Mockito.mock(Action.class);
 
         final Http.Context ctx = Mockito.mock(Http.Context.class);


### PR DESCRIPTION
First of all, the `alwaysExecute` param had the wrong default behaviour. It says:
>  **By default**, if another Deadbolt action has already been executed in the same request and has allowed access, beforeAuthCheck will **not** be executed again. (Set this to true if you want it to execute unconditionally.)

However, `alwaysExecute` *is* set to `true` by default, so the behaviour doesn't follow what the documentation says (And I think what the documentation suggests is correct and *should* have been the default behaviour).
So this param caused a behaviour that should have never been the default.

But what's more important for me is that I just can not think of **any** use case of this 6-year old "feature". Because if an action-method was marked as authorized already means that another constraint annotation has just run before - which at the time caused `beforeAuthCheck` to run already anyway. Why would I ever force `beforeAuthCheck` to run again now? It would just run the same check it ran before in the same request - successfully (otherwise we wouldn't come that far) - already once more... It just doesn't make any sense (And that's why I think the java docs default suggestion is sane).
The only use case for `@BeforeAccess` should be when I don't have any constraints on my action method or the controller class but I still want to check `beforeAuthCheck`... That is also what the docs says (https://leanpub.com/deadbolt-2/read#leanpub-auto-invoking-deadbolthandlerbeforeauthcheck-independently):
> ... The same logic can be invoked independently, using the @BeforeAccess annotation, in which case the call to beforeRoleCheck itself becomes the constraint ....

... and for that case I don't have to set `alwaysExecute` to `true` (an neither to `false`) because in such cases it will be executed anyway.

That will be the only breaking change for the next 2.6.x release, however I highly doubt somebody will actually be effected by this removal.