### PR TITLE
Generalize some methods + add content & handlerKey param on @DeferredDeadbolt

### DIFF
--- a/code/app/be/objectify/deadbolt/java/actions/AbstractDeadboltAction.java
+++ b/code/app/be/objectify/deadbolt/java/actions/AbstractDeadboltAction.java
@@ -353,4 +353,9 @@ public abstract class AbstractDeadboltAction<T> extends Action<T>
         }
         return false;
     }
+
+    public abstract Optional<String> getContent();
+
+    public abstract String getHandlerKey();
+
 }

--- a/code/app/be/objectify/deadbolt/java/actions/AbstractSubjectAction.java
+++ b/code/app/be/objectify/deadbolt/java/actions/AbstractSubjectAction.java
@@ -89,9 +89,5 @@ public abstract class AbstractSubjectAction<T> extends AbstractDeadboltAction<T>
                                                 DeadboltHandler handler,
                                                 Optional<String> content);
 
-    public abstract Optional<String> getContent();
-
-    public abstract String getHandlerKey();
-
     public abstract boolean isForceBeforeAuthCheck();
 }

--- a/code/app/be/objectify/deadbolt/java/actions/BeforeAccessAction.java
+++ b/code/app/be/objectify/deadbolt/java/actions/BeforeAccessAction.java
@@ -58,10 +58,10 @@ public class BeforeAccessAction extends AbstractDeadboltAction<BeforeAccess>
         }
         else
         {
-            final DeadboltHandler deadboltHandler = getDeadboltHandler(configuration.handlerKey());
+            final DeadboltHandler deadboltHandler = getDeadboltHandler(getHandlerKey());
             result = preAuth(true,
                              ctx,
-                             Optional.ofNullable(configuration.content()),
+                             getContent(),
                              deadboltHandler)
                     .thenCompose(preAuthResult -> preAuthResult.map(r -> (CompletionStage<Result>) CompletableFuture.completedFuture(r))
                                                                .orElseGet(() -> delegate.call(ctx)));
@@ -75,6 +75,18 @@ public class BeforeAccessAction extends AbstractDeadboltAction<BeforeAccess>
     @Override
     protected boolean deferred() {
         return configuration.deferred();
+    }
+
+    @Override
+    public Optional<String> getContent()
+    {
+        return Optional.ofNullable(configuration.content());
+    }
+
+    @Override
+    public String getHandlerKey()
+    {
+        return configuration.handlerKey();
     }
 
 }

--- a/code/app/be/objectify/deadbolt/java/actions/CompositeAction.java
+++ b/code/app/be/objectify/deadbolt/java/actions/CompositeAction.java
@@ -54,24 +54,24 @@ public class CompositeAction extends AbstractRestrictiveAction<Composite>
     public CompletionStage<Result> applyRestriction(final Http.Context ctx,
                                                     final DeadboltHandler handler)
     {
-        return compositeCache.apply(getValue())
+        return compositeCache.apply(configuration.value())
                              .map(constraint ->
                                   {
                                       final boolean preferGlobalMeta = configuration.preferGlobalMeta();
                                       return constraint.test(ctx,
                                                              handler,
-                                                             Optional.ofNullable(getMeta()),
+                                                             Optional.ofNullable(configuration.meta()),
                                                              (globalMd, localMd) -> preferGlobalMeta ? globalMd.isPresent() ? globalMd : localMd
                                                                                                      : localMd.isPresent() ? localMd : globalMd)
                                                        .thenCompose(allowed -> allowed ? authorizeAndExecute(ctx,
                                                                                                              handler)
                                                                                        : unauthorizeAndFail(ctx,
                                                                                                             handler,
-                                                                                                            Optional.ofNullable(configuration.content())));
+                                                                                                            getContent()));
                                   })
                              .orElseGet(() -> unauthorizeAndFail(ctx,
                             		                             handler,
-                            		                             Optional.ofNullable(configuration.content())));
+                            		                             getContent()));
     }
 
     /**
@@ -80,16 +80,6 @@ public class CompositeAction extends AbstractRestrictiveAction<Composite>
     @Override
     protected boolean deferred() {
         return configuration.deferred();
-    }
-
-    public String getMeta()
-    {
-        return configuration.meta();
-    }
-
-    public String getValue()
-    {
-        return configuration.value();
     }
 
     private CompletionStage<Result> authorizeAndExecute(final Http.Context context,

--- a/code/app/be/objectify/deadbolt/java/actions/DeferredDeadbolt.java
+++ b/code/app/be/objectify/deadbolt/java/actions/DeferredDeadbolt.java
@@ -24,6 +24,8 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
+import be.objectify.deadbolt.java.ConfigKeys;
+
 /**
  * If a method-level Deadbolt annotation is marked as deferred, it can be run by adding this annotation to the class level.
  * This is useful if you have, for example, a class-level @Security.Authenticated(Secured.class) or similar.
@@ -38,4 +40,19 @@ import java.lang.annotation.Target;
 @Inherited
 public @interface DeferredDeadbolt
 {
+    /**
+     * Indicates the expected response type.  Useful when working with non-HTML responses.  This is free text, which you
+     * can use in {@link be.objectify.deadbolt.java.DeadboltHandler#onAuthFailure} to decide on how to handle the response.
+     *
+     * @return a content indicator
+     */
+    String content() default "";
+
+    /**
+     * Use a specific {@link be.objectify.deadbolt.java.DeadboltHandler} for this restriction in place of the global
+     * one, identified by a key.
+     *
+     * @return the ky of the handler
+     */
+    String handlerKey() default ConfigKeys.DEFAULT_HANDLER_KEY;
 }

--- a/code/app/be/objectify/deadbolt/java/actions/DeferredDeadboltAction.java
+++ b/code/app/be/objectify/deadbolt/java/actions/DeferredDeadboltAction.java
@@ -24,6 +24,8 @@ import play.mvc.Http;
 import play.mvc.Result;
 
 import javax.inject.Inject;
+
+import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 
@@ -60,7 +62,19 @@ public class DeferredDeadboltAction extends AbstractDeadboltAction<DeferredDeadb
      */
     @Override
     protected boolean deferred() {
-        return false;
+        return false; // you can't defer a DeferredDeadboltAction, makes absolutely no sense
+    }
+
+    @Override
+    public Optional<String> getContent()
+    {
+        return Optional.ofNullable(configuration.content());
+    }
+
+    @Override
+    public String getHandlerKey()
+    {
+        return configuration.handlerKey();
     }
 
 }

--- a/code/app/be/objectify/deadbolt/java/actions/DynamicAction.java
+++ b/code/app/be/objectify/deadbolt/java/actions/DynamicAction.java
@@ -70,9 +70,9 @@ public class DynamicAction extends AbstractRestrictiveAction<Dynamic>
     {
         return constraintLogic.dynamic(ctx,
                                        deadboltHandler,
-                                       Optional.ofNullable(configuration.content()),
-                                       getValue(),
-                                       getMeta(),
+                                       getContent(),
+                                       configuration.value(),
+                                       Optional.ofNullable(configuration.meta()),
                                        this::authorizeAndExecute,
                                        this::unauthorizeAndFail,
                                        ConstraintPoint.CONTROLLER);
@@ -84,16 +84,6 @@ public class DynamicAction extends AbstractRestrictiveAction<Dynamic>
     @Override
     protected boolean deferred() {
         return configuration.deferred();
-    }
-
-    public Optional<String> getMeta()
-    {
-        return Optional.ofNullable(configuration.meta());
-    }
-
-    public String getValue()
-    {
-        return configuration.value();
     }
 
     @Override

--- a/code/app/be/objectify/deadbolt/java/actions/PatternAction.java
+++ b/code/app/be/objectify/deadbolt/java/actions/PatternAction.java
@@ -67,10 +67,10 @@ public class PatternAction extends AbstractRestrictiveAction<Pattern>
     {
         return constraintLogic.pattern(ctx,
                                        deadboltHandler,
-                                       Optional.ofNullable(configuration.content()),
-                                       getValue(),
+                                       getContent(),
+                                       configuration.value(),
                                        configuration.patternType(),
-                                       getMeta(),
+                                       Optional.ofNullable(configuration.meta()),
                                        configuration.invert(),
                                        this::authorizeAndExecute,
                                        this::unauthorizeAndFail,
@@ -89,16 +89,6 @@ public class PatternAction extends AbstractRestrictiveAction<Pattern>
     @Override
     protected boolean deferred() {
         return configuration.deferred();
-    }
-
-    public String getValue()
-    {
-        return configuration.value();
-    }
-
-    public Optional<String> getMeta()
-    {
-        return Optional.ofNullable(configuration.meta());
     }
 
     @Override

--- a/code/app/be/objectify/deadbolt/java/actions/RestrictAction.java
+++ b/code/app/be/objectify/deadbolt/java/actions/RestrictAction.java
@@ -74,7 +74,7 @@ public class RestrictAction extends AbstractRestrictiveAction<Restrict>
     {
         return constraintLogic.restrict(ctx,
                                         deadboltHandler,
-                                        Optional.ofNullable(configuration.content()),
+                                        getContent(),
                                         this::getRoleGroups,
                                         this::authorizeAndExecute,
                                         this::unauthorizeAndFail,

--- a/code/app/be/objectify/deadbolt/java/actions/RoleBasedPermissionsAction.java
+++ b/code/app/be/objectify/deadbolt/java/actions/RoleBasedPermissionsAction.java
@@ -73,7 +73,7 @@ public class RoleBasedPermissionsAction extends AbstractRestrictiveAction<RoleBa
     {
         return constraintLogic.roleBasedPermissions(ctx,
                                                     deadboltHandler,
-                                                    Optional.ofNullable(configuration.content()),
+                                                    getContent(),
                                                     configuration.value(),
                                                     this::authorizeAndExecute,
                                                     this::unauthorizeAndFail,

--- a/code/app/be/objectify/deadbolt/java/actions/UnrestrictedAction.java
+++ b/code/app/be/objectify/deadbolt/java/actions/UnrestrictedAction.java
@@ -67,4 +67,16 @@ public class UnrestrictedAction extends AbstractDeadboltAction<Unrestricted>
         return configuration.deferred();
     }
 
+    @Override
+    public Optional<String> getContent()
+    {
+        return Optional.ofNullable(configuration.content());
+    }
+
+    @Override
+    public String getHandlerKey()
+    {
+        return configuration.handlerKey();
+    }
+
 }

--- a/code/test/be/objectify/deadbolt/java/actions/CompositeActionTest.java
+++ b/code/test/be/objectify/deadbolt/java/actions/CompositeActionTest.java
@@ -79,40 +79,6 @@ public class CompositeActionTest
     }
 
     @Test
-    public void testGetMeta() throws Exception
-    {
-        final Composite composite = Mockito.mock(Composite.class);
-        Mockito.when(composite.meta())
-               .thenReturn("foo");
-        final CompositeAction action = new CompositeAction(Mockito.mock(HandlerCache.class),
-                                                           Mockito.mock(BeforeAuthCheckCache.class),
-                                                           ConfigFactory.empty(),
-                                                           Mockito.mock(CompositeCache.class),
-                                                           Mockito.mock(ConstraintLogic.class));
-        action.configuration = composite;
-
-        Assert.assertEquals("foo",
-                            action.getMeta());
-    }
-
-    @Test
-    public void testGetValue() throws Exception
-    {
-        final Composite composite = Mockito.mock(Composite.class);
-        Mockito.when(composite.value())
-               .thenReturn("foo");
-        final CompositeAction action = new CompositeAction(Mockito.mock(HandlerCache.class),
-                                                           Mockito.mock(BeforeAuthCheckCache.class),
-                                                           ConfigFactory.empty(),
-                                                           Mockito.mock(CompositeCache.class),
-                                                           Mockito.mock(ConstraintLogic.class));
-        action.configuration = composite;
-
-        Assert.assertEquals("foo",
-                            action.getValue());
-    }
-
-    @Test
     public void testGetHandlerKey() throws Exception
     {
         final Composite composite = Mockito.mock(Composite.class);

--- a/code/test/be/objectify/deadbolt/java/actions/DynamicActionTest.java
+++ b/code/test/be/objectify/deadbolt/java/actions/DynamicActionTest.java
@@ -70,41 +70,6 @@ public class DynamicActionTest
     }
 
     @Test
-    public void testGetMeta() throws Exception
-    {
-        final Dynamic dynamic = Mockito.mock(Dynamic.class);
-        Mockito.when(dynamic.meta())
-               .thenReturn("foo");
-        final DynamicAction action = new DynamicAction(Mockito.mock(HandlerCache.class),
-                                                       Mockito.mock(BeforeAuthCheckCache.class),
-                                                       ConfigFactory.empty(),
-                                                       dynamic,
-                                                       Mockito.mock(Action.class),
-                                                       Mockito.mock(ConstraintLogic.class));
-
-        final Optional<String> maybeMeta = action.getMeta();
-        Assert.assertEquals("foo",
-                            maybeMeta.orElse(null));
-    }
-
-    @Test
-    public void testGetValue() throws Exception
-    {
-        final Dynamic dynamic = Mockito.mock(Dynamic.class);
-        Mockito.when(dynamic.value())
-               .thenReturn("foo");
-        final DynamicAction action = new DynamicAction(Mockito.mock(HandlerCache.class),
-                                                       Mockito.mock(BeforeAuthCheckCache.class),
-                                                       ConfigFactory.empty(),
-                                                       dynamic,
-                                                       Mockito.mock(Action.class),
-                                                       Mockito.mock(ConstraintLogic.class));
-
-        Assert.assertEquals("foo",
-                            action.getValue());
-    }
-
-    @Test
     public void testGetHandlerKey() throws Exception
     {
         final Dynamic dynamic = Mockito.mock(Dynamic.class);

--- a/code/test/be/objectify/deadbolt/java/actions/PatternActionTest.java
+++ b/code/test/be/objectify/deadbolt/java/actions/PatternActionTest.java
@@ -77,42 +77,6 @@ public class PatternActionTest
     }
 
     @Test
-    public void testGetValue() throws Exception
-    {
-        final Pattern pattern = Mockito.mock(Pattern.class);
-        Mockito.when(pattern.value())
-               .thenReturn("foo");
-        final PatternAction action = new PatternAction(Mockito.mock(HandlerCache.class),
-                                                       Mockito.mock(BeforeAuthCheckCache.class),
-                                                       ConfigFactory.empty(),
-                                                       pattern,
-                                                       Mockito.mock(Action.class),
-                                                       Mockito.mock(ConstraintLogic.class));
-
-        Assert.assertEquals("foo",
-                            action.getValue());
-    }
-
-    @Test
-    public void testGetMeta() throws Exception
-    {
-        final Pattern pattern = Mockito.mock(Pattern.class);
-        Mockito.when(pattern.meta())
-               .thenReturn("foo");
-        final PatternAction action = new PatternAction(Mockito.mock(HandlerCache.class),
-                                                       Mockito.mock(BeforeAuthCheckCache.class),
-                                                       ConfigFactory.empty(),
-                                                       pattern,
-                                                       Mockito.mock(Action.class),
-                                                       Mockito.mock(ConstraintLogic.class));
-
-        final Optional<String> maybeMeta = action.getMeta();
-        Assert.assertTrue(maybeMeta.isPresent());
-        Assert.assertEquals("foo",
-                            maybeMeta.orElse(null));
-    }
-
-    @Test
     public void testGetHandlerKey() throws Exception
     {
         final Pattern pattern = Mockito.mock(Pattern.class);


### PR DESCRIPTION
Each *concrete* `DeadboltAction` has to provide `getContent` and `getHandlerKey`. Even `@DeferredDeadbolt` because it could fail as well when it gets called so it needs the information about the content and the handler.
On the other hand the `getValue` and `getMeta` were removed, because they just pass the `configuration.value` and `configuration.meta` through and these methods are not needed as they don't override a abstract super-method (because not every deadbolt-action has that information and the information is just needed for that special constraint)