### PR TITLE
Let's make constraint annotations @Repeatable

### DIFF
--- a/code/app/be/objectify/deadbolt/java/actions/BeforeAccess.java
+++ b/code/app/be/objectify/deadbolt/java/actions/BeforeAccess.java
@@ -20,10 +20,11 @@ import be.objectify.deadbolt.java.DeadboltHandler;
 import play.mvc.With;
 
 import java.lang.annotation.Documented;
-import java.lang.annotation.ElementType;
+import static java.lang.annotation.ElementType.*;
 import java.lang.annotation.Inherited;
+import java.lang.annotation.Repeatable;
 import java.lang.annotation.Retention;
-import java.lang.annotation.RetentionPolicy;
+import static java.lang.annotation.RetentionPolicy.*;
 import java.lang.annotation.Target;
 
 /**
@@ -33,8 +34,9 @@ import java.lang.annotation.Target;
  * @author Steve Chaloner (steve@objectify.be)
  */
 @With(BeforeAccessAction.class)
-@Retention(RetentionPolicy.RUNTIME)
-@Target({ElementType.METHOD, ElementType.TYPE})
+@Repeatable(BeforeAccess.List.class)
+@Retention(RUNTIME)
+@Target({METHOD, TYPE})
 @Inherited
 @Documented
 public @interface BeforeAccess
@@ -61,4 +63,15 @@ public @interface BeforeAccess
      * @return true iff the associated action should be deferred until class-level annotations are applied.
      */
     boolean deferred() default false;
+
+    /**
+     * Defines several {@code BeforeAccess} annotations on the same element.
+     */
+    @Retention(RUNTIME)
+    @Target({METHOD, TYPE})
+    @Documented
+    @Inherited
+    public @interface List {
+        BeforeAccess[] value();
+    }
 }

--- a/code/app/be/objectify/deadbolt/java/actions/Composite.java
+++ b/code/app/be/objectify/deadbolt/java/actions/Composite.java
@@ -19,18 +19,20 @@ import be.objectify.deadbolt.java.ConfigKeys;
 import play.mvc.With;
 
 import java.lang.annotation.Documented;
-import java.lang.annotation.ElementType;
+import static java.lang.annotation.ElementType.*;
 import java.lang.annotation.Inherited;
+import java.lang.annotation.Repeatable;
 import java.lang.annotation.Retention;
-import java.lang.annotation.RetentionPolicy;
+import static java.lang.annotation.RetentionPolicy.*;
 import java.lang.annotation.Target;
 
 /**
  * @author Steve Chaloner (steve@objectify.be)
  */
 @With(CompositeAction.class)
-@Retention(RetentionPolicy.RUNTIME)
-@Target({ElementType.METHOD, ElementType.TYPE})
+@Repeatable(Composite.List.class)
+@Retention(RUNTIME)
+@Target({METHOD, TYPE})
 @Inherited
 @Documented
 public @interface Composite
@@ -82,4 +84,15 @@ public @interface Composite
      * @return true iff the associated action should be deferred until class-level annotations are applied.
      */
     boolean deferred() default false;
+
+    /**
+     * Defines several {@code Composite} annotations on the same element.
+     */
+    @Retention(RUNTIME)
+    @Target({METHOD, TYPE})
+    @Documented
+    @Inherited
+    public @interface List {
+        Composite[] value();
+    }
 }

--- a/code/app/be/objectify/deadbolt/java/actions/DeferredDeadbolt.java
+++ b/code/app/be/objectify/deadbolt/java/actions/DeferredDeadbolt.java
@@ -18,10 +18,11 @@ package be.objectify.deadbolt.java.actions;
 import play.mvc.With;
 
 import java.lang.annotation.Documented;
-import java.lang.annotation.ElementType;
+import static java.lang.annotation.ElementType.*;
 import java.lang.annotation.Inherited;
+import java.lang.annotation.Repeatable;
 import java.lang.annotation.Retention;
-import java.lang.annotation.RetentionPolicy;
+import static java.lang.annotation.RetentionPolicy.*;
 import java.lang.annotation.Target;
 
 import be.objectify.deadbolt.java.ConfigKeys;
@@ -34,8 +35,9 @@ import be.objectify.deadbolt.java.ConfigKeys;
  * @author Steve Chaloner (steve@objectify.be)
  */
 @With(DeferredDeadboltAction.class)
-@Retention(RetentionPolicy.RUNTIME)
-@Target(ElementType.TYPE)
+@Repeatable(DeferredDeadbolt.List.class)
+@Retention(RUNTIME)
+@Target(TYPE)
 @Documented
 @Inherited
 public @interface DeferredDeadbolt
@@ -55,4 +57,15 @@ public @interface DeferredDeadbolt
      * @return the ky of the handler
      */
     String handlerKey() default ConfigKeys.DEFAULT_HANDLER_KEY;
+
+    /**
+     * Defines several {@code DeferredDeadbolt} annotations on the same element.
+     */
+    @Retention(RUNTIME)
+    @Target(TYPE)
+    @Documented
+    @Inherited
+    public @interface List {
+        DeferredDeadbolt[] value();
+    }
 }

--- a/code/app/be/objectify/deadbolt/java/actions/Dynamic.java
+++ b/code/app/be/objectify/deadbolt/java/actions/Dynamic.java
@@ -19,10 +19,11 @@ import be.objectify.deadbolt.java.ConfigKeys;
 import play.mvc.With;
 
 import java.lang.annotation.Documented;
-import java.lang.annotation.ElementType;
+import static java.lang.annotation.ElementType.*;
 import java.lang.annotation.Inherited;
+import java.lang.annotation.Repeatable;
 import java.lang.annotation.Retention;
-import java.lang.annotation.RetentionPolicy;
+import static java.lang.annotation.RetentionPolicy.*;
 import java.lang.annotation.Target;
 
 /**
@@ -32,8 +33,9 @@ import java.lang.annotation.Target;
  * @author Steve Chaloner (steve@objectify.be)
  */
 @With(DynamicAction.class)
-@Retention(RetentionPolicy.RUNTIME)
-@Target({ElementType.METHOD, ElementType.TYPE})
+@Repeatable(Dynamic.List.class)
+@Retention(RUNTIME)
+@Target({METHOD, TYPE})
 @Inherited
 @Documented
 public @interface Dynamic
@@ -75,4 +77,15 @@ public @interface Dynamic
      * @return true iff the associated action should be deferred until class-level annotations are applied.
      */
     boolean deferred() default false;
+
+    /**
+     * Defines several {@code Dynamic} annotations on the same element.
+     */
+    @Retention(RUNTIME)
+    @Target({METHOD, TYPE})
+    @Documented
+    @Inherited
+    public @interface List {
+        Dynamic[] value();
+    }
 }

--- a/code/app/be/objectify/deadbolt/java/actions/Pattern.java
+++ b/code/app/be/objectify/deadbolt/java/actions/Pattern.java
@@ -20,18 +20,20 @@ import be.objectify.deadbolt.java.models.PatternType;
 import play.mvc.With;
 
 import java.lang.annotation.Documented;
-import java.lang.annotation.ElementType;
+import static java.lang.annotation.ElementType.*;
 import java.lang.annotation.Inherited;
+import java.lang.annotation.Repeatable;
 import java.lang.annotation.Retention;
-import java.lang.annotation.RetentionPolicy;
+import static java.lang.annotation.RetentionPolicy.*;
 import java.lang.annotation.Target;
 
 /**
  * @author Steve Chaloner (steve@objectify.be)
  */
 @With(PatternAction.class)
-@Retention(RetentionPolicy.RUNTIME)
-@Target({ElementType.METHOD, ElementType.TYPE})
+@Repeatable(Pattern.List.class)
+@Retention(RUNTIME)
+@Target({METHOD, TYPE})
 @Inherited
 @Documented
 public @interface Pattern
@@ -87,4 +89,15 @@ public @interface Pattern
      * @return true if the constraint should be inverted.
      */
     boolean invert() default false;
+
+    /**
+     * Defines several {@code Pattern} annotations on the same element.
+     */
+    @Retention(RUNTIME)
+    @Target({METHOD, TYPE})
+    @Documented
+    @Inherited
+    public @interface List {
+        Pattern[] value();
+    }
 }

--- a/code/app/be/objectify/deadbolt/java/actions/Restrict.java
+++ b/code/app/be/objectify/deadbolt/java/actions/Restrict.java
@@ -19,10 +19,11 @@ import be.objectify.deadbolt.java.ConfigKeys;
 import play.mvc.With;
 
 import java.lang.annotation.Documented;
-import java.lang.annotation.ElementType;
+import static java.lang.annotation.ElementType.*;
 import java.lang.annotation.Inherited;
+import java.lang.annotation.Repeatable;
 import java.lang.annotation.Retention;
-import java.lang.annotation.RetentionPolicy;
+import static java.lang.annotation.RetentionPolicy.*;
 import java.lang.annotation.Target;
 
 /**
@@ -37,8 +38,9 @@ import java.lang.annotation.Target;
  * roles.
  */
 @With(RestrictAction.class)
-@Retention(RetentionPolicy.RUNTIME)
-@Target({ElementType.METHOD, ElementType.TYPE})
+@Repeatable(Restrict.List.class)
+@Retention(RUNTIME)
+@Target({METHOD, TYPE})
 @Documented
 @Inherited
 public @interface Restrict
@@ -72,4 +74,15 @@ public @interface Restrict
      * @return true iff the associated action should be deferred until class-level annotations are applied.
      */
     boolean deferred() default false;
+
+    /**
+     * Defines several {@code Restrict} annotations on the same element.
+     */
+    @Retention(RUNTIME)
+    @Target({METHOD, TYPE})
+    @Documented
+    @Inherited
+    public @interface List {
+        Restrict[] value();
+    }
 }

--- a/code/app/be/objectify/deadbolt/java/actions/RoleBasedPermissions.java
+++ b/code/app/be/objectify/deadbolt/java/actions/RoleBasedPermissions.java
@@ -19,10 +19,11 @@ import be.objectify.deadbolt.java.ConfigKeys;
 import play.mvc.With;
 
 import java.lang.annotation.Documented;
-import java.lang.annotation.ElementType;
+import static java.lang.annotation.ElementType.*;
 import java.lang.annotation.Inherited;
+import java.lang.annotation.Repeatable;
 import java.lang.annotation.Retention;
-import java.lang.annotation.RetentionPolicy;
+import static java.lang.annotation.RetentionPolicy.*;
 import java.lang.annotation.Target;
 
 /**
@@ -30,8 +31,9 @@ import java.lang.annotation.Target;
  * @since 2.5.1
  */
 @With(RoleBasedPermissionsAction.class)
-@Retention(RetentionPolicy.RUNTIME)
-@Target({ElementType.METHOD, ElementType.TYPE})
+@Repeatable(RoleBasedPermissions.List.class)
+@Retention(RUNTIME)
+@Target({METHOD, TYPE})
 @Documented
 @Inherited
 public @interface RoleBasedPermissions
@@ -66,4 +68,15 @@ public @interface RoleBasedPermissions
      * @return true iff the associated action should be deferred until class-level annotations are applied.
      */
     boolean deferred() default false;
+
+    /**
+     * Defines several {@code RoleBasedPermissions} annotations on the same element.
+     */
+    @Retention(RUNTIME)
+    @Target({METHOD, TYPE})
+    @Documented
+    @Inherited
+    public @interface List {
+        RoleBasedPermissions[] value();
+    }
 }

--- a/code/app/be/objectify/deadbolt/java/actions/SubjectNotPresent.java
+++ b/code/app/be/objectify/deadbolt/java/actions/SubjectNotPresent.java
@@ -20,10 +20,11 @@ import be.objectify.deadbolt.java.DeadboltHandler;
 import play.mvc.With;
 
 import java.lang.annotation.Documented;
-import java.lang.annotation.ElementType;
+import static java.lang.annotation.ElementType.*;
 import java.lang.annotation.Inherited;
+import java.lang.annotation.Repeatable;
 import java.lang.annotation.Retention;
-import java.lang.annotation.RetentionPolicy;
+import static java.lang.annotation.RetentionPolicy.*;
 import java.lang.annotation.Target;
 
 /**
@@ -33,8 +34,9 @@ import java.lang.annotation.Target;
  * @author Steve Chaloner (steve@objectify.be)
  */
 @With(SubjectNotPresentAction.class)
-@Retention(RetentionPolicy.RUNTIME)
-@Target({ElementType.METHOD, ElementType.TYPE})
+@Repeatable(SubjectNotPresent.List.class)
+@Retention(RUNTIME)
+@Target({METHOD, TYPE})
 @Documented
 @Inherited
 public @interface SubjectNotPresent
@@ -69,4 +71,15 @@ public @interface SubjectNotPresent
      * @return true iff {@link DeadboltHandler#beforeAuthCheck} should be invoked prior to applying this constraint.
      */
     boolean forceBeforeAuthCheck() default false;
+
+    /**
+     * Defines several {@code SubjectNotPresent} annotations on the same element.
+     */
+    @Retention(RUNTIME)
+    @Target({METHOD, TYPE})
+    @Documented
+    @Inherited
+    public @interface List {
+        SubjectNotPresent[] value();
+    }
 }

--- a/code/app/be/objectify/deadbolt/java/actions/SubjectPresent.java
+++ b/code/app/be/objectify/deadbolt/java/actions/SubjectPresent.java
@@ -20,10 +20,11 @@ import be.objectify.deadbolt.java.DeadboltHandler;
 import play.mvc.With;
 
 import java.lang.annotation.Documented;
-import java.lang.annotation.ElementType;
+import static java.lang.annotation.ElementType.*;
 import java.lang.annotation.Inherited;
+import java.lang.annotation.Repeatable;
 import java.lang.annotation.Retention;
-import java.lang.annotation.RetentionPolicy;
+import static java.lang.annotation.RetentionPolicy.*;
 import java.lang.annotation.Target;
 
 /**
@@ -33,8 +34,9 @@ import java.lang.annotation.Target;
  * @author Steve Chaloner (steve@objectify.be)
  */
 @With(SubjectPresentAction.class)
-@Retention(RetentionPolicy.RUNTIME)
-@Target({ElementType.METHOD, ElementType.TYPE})
+@Repeatable(SubjectPresent.List.class)
+@Retention(RUNTIME)
+@Target({METHOD, TYPE})
 @Documented
 @Inherited
 public @interface SubjectPresent
@@ -69,4 +71,15 @@ public @interface SubjectPresent
      * @return true iff {@link DeadboltHandler#beforeAuthCheck} should be invoked prior to applying this constraint.
      */
     boolean forceBeforeAuthCheck() default false;
+
+    /**
+     * Defines several {@code SubjectPresent} annotations on the same element.
+     */
+    @Retention(RUNTIME)
+    @Target({METHOD, TYPE})
+    @Documented
+    @Inherited
+    public @interface List {
+        SubjectPresent[] value();
+    }
 }

--- a/code/app/be/objectify/deadbolt/java/actions/Unrestricted.java
+++ b/code/app/be/objectify/deadbolt/java/actions/Unrestricted.java
@@ -19,9 +19,11 @@ import be.objectify.deadbolt.java.ConfigKeys;
 import play.mvc.With;
 
 import java.lang.annotation.Documented;
-import java.lang.annotation.ElementType;
+import java.lang.annotation.Repeatable;
+
+import static java.lang.annotation.ElementType.*;
 import java.lang.annotation.Retention;
-import java.lang.annotation.RetentionPolicy;
+import static java.lang.annotation.RetentionPolicy.*;
 import java.lang.annotation.Target;
 
 /**
@@ -30,8 +32,9 @@ import java.lang.annotation.Target;
  * @author Steve Chaloner (steve@objectify.be)
  */
 @With(UnrestrictedAction.class)
-@Retention(RetentionPolicy.RUNTIME)
-@Target({ElementType.METHOD, ElementType.TYPE})
+@Repeatable(Unrestricted.List.class)
+@Retention(RUNTIME)
+@Target({METHOD, TYPE})
 @Documented
 public @interface Unrestricted
 {
@@ -57,4 +60,14 @@ public @interface Unrestricted
      * @return true iff the associated action should be deferred until class-level annotations are applied.
      */
     boolean deferred() default false;
+
+    /**
+     * Defines several {@code Unrestricted} annotations on the same element.
+     */
+    @Retention(RUNTIME)
+    @Target({METHOD, TYPE})
+    @Documented
+    public @interface List {
+        Unrestricted[] value();
+    }
 }

--- a/code/build.sbt
+++ b/code/build.sbt
@@ -14,3 +14,9 @@ libraryDependencies ++= Seq(
 )
 
 releasePublishArtifactsAction := PgpKeys.publishSigned.value
+
+// workaround for scaladoc error https://github.com/scala/scala-dev/issues/249
+// also see http://www.scala-lang.org/news/2.12.0/#scaladoc-can-be-used-to-document-java-sources
+scalacOptions in (Compile, doc) ++= {
+  if (scalaBinaryVersion.value == "2.12") Seq("-no-java-comments") else Nil
+}


### PR DESCRIPTION
Since Play 2.6.11 we are able to use `@Repeatable` Java action annotations: https://github.com/playframework/playframework/pull/8117 / https://github.com/playframework/playframework/pull/8144

This allows us to use deadbolt like:
```
@Pattern(...)
@Pattern(...)
public Result myActionMethod() {
    //....
}
```

Together with the `AND` mode I implemented that's a real great feature I guess.

This is also backward compatible.