### PR TITLE
Refactor execute method

### DIFF
--- a/code/app/be/objectify/deadbolt/java/actions/AbstractDeadboltAction.java
+++ b/code/app/be/objectify/deadbolt/java/actions/AbstractDeadboltAction.java
@@ -127,7 +127,20 @@ public abstract class AbstractDeadboltAction<T> extends Action<T>
             }
             else
             {
-                result = maybeBlock(execute(ctx));
+                if (isActionUnauthorised(ctx))
+                {
+                    result = onAuthFailure(getDeadboltHandler(getHandlerKey()),
+                                           getContent(),
+                                           ctx);
+                }
+                else if (isActionAuthorised(ctx))
+                {
+                    result = delegate.call(ctx);
+                }
+                else
+                {
+                    result = maybeBlock(execute(ctx));
+                }
             }
             return result;
         }

--- a/code/app/be/objectify/deadbolt/java/actions/AbstractDeadboltAction.java
+++ b/code/app/be/objectify/deadbolt/java/actions/AbstractDeadboltAction.java
@@ -127,7 +127,7 @@ public abstract class AbstractDeadboltAction<T> extends Action<T>
             }
             else
             {
-                result = execute(ctx);
+                result = maybeBlock(execute(ctx));
             }
             return result;
         }
@@ -331,7 +331,7 @@ public abstract class AbstractDeadboltAction<T> extends Action<T>
                              context);
     }
 
-    CompletionStage<Result> maybeBlock(CompletionStage<Result> eventualResult) throws InterruptedException,
+    private CompletionStage<Result> maybeBlock(CompletionStage<Result> eventualResult) throws InterruptedException,
                                                                                       ExecutionException,
                                                                                       TimeoutException
     {

--- a/code/app/be/objectify/deadbolt/java/actions/AbstractDeadboltAction.java
+++ b/code/app/be/objectify/deadbolt/java/actions/AbstractDeadboltAction.java
@@ -49,8 +49,6 @@ public abstract class AbstractDeadboltAction<T> extends Action<T>
 
     private static final String ACTION_AUTHORISED = "deadbolt.action-authorised";
 
-    private static final String ACTION_UNAUTHORISED = "deadbolt.action-unauthorised";
-
     private static final String ACTION_DEFERRED = "deadbolt.action-deferred";
     private static final String IGNORE_DEFERRED_FLAG = "deadbolt.ignore-deferred-flag";
 
@@ -127,13 +125,7 @@ public abstract class AbstractDeadboltAction<T> extends Action<T>
             }
             else
             {
-                if (isActionUnauthorised(ctx))
-                {
-                    result = onAuthFailure(getDeadboltHandler(getHandlerKey()),
-                                           getContent(),
-                                           ctx);
-                }
-                else if (isActionAuthorised(ctx))
+                if (isActionAuthorised(ctx))
                 {
                     result = delegate.call(ctx);
                 }
@@ -208,17 +200,6 @@ public abstract class AbstractDeadboltAction<T> extends Action<T>
     }
 
     /**
-     * Marks the current action as unauthorised.  This allows method-level annotations to override controller-level annotations.
-     *
-     * @param ctx the request context
-     */
-    private void markActionAsUnauthorised(final Http.Context ctx)
-    {
-        ctx.args.put(ACTION_UNAUTHORISED,
-                     true);
-    }
-
-    /**
      * Checks if an action is authorised.  This allows controller-level annotations to cede control to method-level annotations.
      *
      * @param ctx the request context
@@ -227,18 +208,6 @@ public abstract class AbstractDeadboltAction<T> extends Action<T>
     protected boolean isActionAuthorised(final Http.Context ctx)
     {
         final Object o = ctx.args.get(ACTION_AUTHORISED);
-        return o != null && (Boolean) o;
-    }
-
-    /**
-     * Checks if an action is unauthorised.  This allows controller-level annotations to cede control to method-level annotations.
-     *
-     * @param ctx the request context
-     * @return true if a more-specific annotation has blocked access, otherwise false
-     */
-    protected boolean isActionUnauthorised(final Http.Context ctx)
-    {
-        final Object o = ctx.args.get(ACTION_UNAUTHORISED);
         return o != null && (Boolean) o;
     }
 
@@ -338,7 +307,6 @@ public abstract class AbstractDeadboltAction<T> extends Action<T>
             return delegate.call(context);
         }
 
-        markActionAsUnauthorised(context);
         return onAuthFailure(handler,
                              content,
                              context);

--- a/code/app/be/objectify/deadbolt/java/actions/AbstractRestrictiveAction.java
+++ b/code/app/be/objectify/deadbolt/java/actions/AbstractRestrictiveAction.java
@@ -51,7 +51,13 @@ public abstract class AbstractRestrictiveAction<T> extends AbstractDeadboltActio
     public CompletionStage<Result> execute(final Http.Context ctx) throws Exception
     {
         final CompletionStage<Result> result;
-        if (isActionAuthorised(ctx))
+        if (isActionUnauthorised(ctx))
+        {
+            result = onAuthFailure(getDeadboltHandler(getHandlerKey()),
+                                   getContent(),
+                                   ctx);
+        }
+        else if (isActionAuthorised(ctx))
         {
             result = delegate.call(ctx);
         }

--- a/code/app/be/objectify/deadbolt/java/actions/AbstractRestrictiveAction.java
+++ b/code/app/be/objectify/deadbolt/java/actions/AbstractRestrictiveAction.java
@@ -50,29 +50,14 @@ public abstract class AbstractRestrictiveAction<T> extends AbstractDeadboltActio
     @Override
     public CompletionStage<Result> execute(final Http.Context ctx) throws Exception
     {
-        final CompletionStage<Result> result;
-        if (isActionUnauthorised(ctx))
-        {
-            result = onAuthFailure(getDeadboltHandler(getHandlerKey()),
-                                   getContent(),
-                                   ctx);
-        }
-        else if (isActionAuthorised(ctx))
-        {
-            result = delegate.call(ctx);
-        }
-        else
-        {
-            final DeadboltHandler deadboltHandler = getDeadboltHandler(getHandlerKey());
-            result = preAuth(true,
-                             ctx,
-                             getContent(),
-                             deadboltHandler)
-                    .thenCompose(option -> option.map(value -> (CompletionStage<Result>) CompletableFuture.completedFuture(value))
-                                                      .orElseGet(() -> applyRestriction(ctx,
-                                                                                        deadboltHandler)));
-        }
-        return result;
+        final DeadboltHandler deadboltHandler = getDeadboltHandler(getHandlerKey());
+        return preAuth(true,
+                         ctx,
+                         getContent(),
+                         deadboltHandler)
+                .thenCompose(option -> option.map(value -> (CompletionStage<Result>) CompletableFuture.completedFuture(value))
+                                                  .orElseGet(() -> applyRestriction(ctx,
+                                                                                    deadboltHandler)));
     }
 
     public abstract Optional<String> getContent();

--- a/code/app/be/objectify/deadbolt/java/actions/AbstractRestrictiveAction.java
+++ b/code/app/be/objectify/deadbolt/java/actions/AbstractRestrictiveAction.java
@@ -72,7 +72,7 @@ public abstract class AbstractRestrictiveAction<T> extends AbstractDeadboltActio
                                                       .orElseGet(() -> applyRestriction(ctx,
                                                                                         deadboltHandler)));
         }
-        return maybeBlock(result);
+        return result;
     }
 
     public abstract Optional<String> getContent();

--- a/code/app/be/objectify/deadbolt/java/actions/AbstractRestrictiveAction.java
+++ b/code/app/be/objectify/deadbolt/java/actions/AbstractRestrictiveAction.java
@@ -55,9 +55,9 @@ public abstract class AbstractRestrictiveAction<T> extends AbstractDeadboltActio
                          ctx,
                          getContent(),
                          deadboltHandler)
-                .thenCompose(option -> option.map(value -> (CompletionStage<Result>) CompletableFuture.completedFuture(value))
-                                                  .orElseGet(() -> applyRestriction(ctx,
-                                                                                    deadboltHandler)));
+                .thenCompose(preAuthResult -> preAuthResult.map(value -> (CompletionStage<Result>) CompletableFuture.completedFuture(value))
+                                                           .orElseGet(() -> applyRestriction(ctx,
+                                                                                             deadboltHandler)));
     }
 
     public abstract Optional<String> getContent();

--- a/code/app/be/objectify/deadbolt/java/actions/AbstractSubjectAction.java
+++ b/code/app/be/objectify/deadbolt/java/actions/AbstractSubjectAction.java
@@ -51,30 +51,15 @@ public abstract class AbstractSubjectAction<T> extends AbstractDeadboltAction<T>
     @Override
     public CompletionStage<Result> execute(final Http.Context ctx) throws Exception
     {
-        final CompletionStage<Result> result;
-        if (isActionUnauthorised(ctx))
-        {
-            result = onAuthFailure(getDeadboltHandler(getHandlerKey()),
-                                   getContent(),
-                                   ctx);
-        }
-        else if (isActionAuthorised(ctx))
-        {
-            result = delegate.call(ctx);
-        }
-        else
-        {
-            final DeadboltHandler deadboltHandler = getDeadboltHandler(getHandlerKey());
-            result = preAuth(isForceBeforeAuthCheck(),
-                             ctx,
-                             getContent(),
-                             deadboltHandler)
-                    .thenCompose(maybePreAuth -> maybePreAuth.map(CompletableFuture::completedFuture)
-                                                             .orElseGet(testSubject(constraintLogic,
-                                                                                    ctx,
-                                                                                    deadboltHandler)));
-        }
-        return result;
+        final DeadboltHandler deadboltHandler = getDeadboltHandler(getHandlerKey());
+        return preAuth(isForceBeforeAuthCheck(),
+                         ctx,
+                         getContent(),
+                         deadboltHandler)
+                .thenCompose(maybePreAuth -> maybePreAuth.map(CompletableFuture::completedFuture)
+                                                         .orElseGet(testSubject(constraintLogic,
+                                                                                ctx,
+                                                                                deadboltHandler)));
     }
 
     abstract Supplier<CompletableFuture<Result>> testSubject(final ConstraintLogic constraintLogic,

--- a/code/app/be/objectify/deadbolt/java/actions/AbstractSubjectAction.java
+++ b/code/app/be/objectify/deadbolt/java/actions/AbstractSubjectAction.java
@@ -74,7 +74,7 @@ public abstract class AbstractSubjectAction<T> extends AbstractDeadboltAction<T>
                                                                                     ctx,
                                                                                     deadboltHandler)));
         }
-        return maybeBlock(result);
+        return result;
     }
 
     abstract Supplier<CompletableFuture<Result>> testSubject(final ConstraintLogic constraintLogic,

--- a/code/app/be/objectify/deadbolt/java/actions/AbstractSubjectAction.java
+++ b/code/app/be/objectify/deadbolt/java/actions/AbstractSubjectAction.java
@@ -56,10 +56,10 @@ public abstract class AbstractSubjectAction<T> extends AbstractDeadboltAction<T>
                          ctx,
                          getContent(),
                          deadboltHandler)
-                .thenCompose(maybePreAuth -> maybePreAuth.map(CompletableFuture::completedFuture)
-                                                         .orElseGet(testSubject(constraintLogic,
-                                                                                ctx,
-                                                                                deadboltHandler)));
+                .thenCompose(preAuthResult -> preAuthResult.map(CompletableFuture::completedFuture)
+                                                           .orElseGet(testSubject(constraintLogic,
+                                                                                  ctx,
+                                                                                  deadboltHandler)));
     }
 
     abstract Supplier<CompletableFuture<Result>> testSubject(final ConstraintLogic constraintLogic,

--- a/code/app/be/objectify/deadbolt/java/actions/BeforeAccessAction.java
+++ b/code/app/be/objectify/deadbolt/java/actions/BeforeAccessAction.java
@@ -56,7 +56,7 @@ public class BeforeAccessAction extends AbstractDeadboltAction<BeforeAccess>
                          ctx,
                          getContent(),
                          deadboltHandler)
-                .thenCompose(preAuthResult -> preAuthResult.map(r -> (CompletionStage<Result>) CompletableFuture.completedFuture(r))
+                .thenCompose(preAuthResult -> preAuthResult.map(value -> (CompletionStage<Result>) CompletableFuture.completedFuture(value))
                                                            .orElseGet(() -> delegate.call(ctx)));
     }
 

--- a/code/app/be/objectify/deadbolt/java/actions/BeforeAccessAction.java
+++ b/code/app/be/objectify/deadbolt/java/actions/BeforeAccessAction.java
@@ -52,7 +52,13 @@ public class BeforeAccessAction extends AbstractDeadboltAction<BeforeAccess>
     public CompletionStage<Result> execute(final Http.Context ctx) throws Exception
     {
         final CompletionStage<Result> result;
-        if (isActionAuthorised(ctx))
+        if (isActionUnauthorised(ctx))
+        {
+            result = onAuthFailure(getDeadboltHandler(getHandlerKey()),
+                                   getContent(),
+                                   ctx);
+        }
+        else if (isActionAuthorised(ctx))
         {
             result = delegate.call(ctx);
         }

--- a/code/app/be/objectify/deadbolt/java/actions/BeforeAccessAction.java
+++ b/code/app/be/objectify/deadbolt/java/actions/BeforeAccessAction.java
@@ -51,28 +51,13 @@ public class BeforeAccessAction extends AbstractDeadboltAction<BeforeAccess>
     @Override
     public CompletionStage<Result> execute(final Http.Context ctx) throws Exception
     {
-        final CompletionStage<Result> result;
-        if (isActionUnauthorised(ctx))
-        {
-            result = onAuthFailure(getDeadboltHandler(getHandlerKey()),
-                                   getContent(),
-                                   ctx);
-        }
-        else if (isActionAuthorised(ctx))
-        {
-            result = delegate.call(ctx);
-        }
-        else
-        {
-            final DeadboltHandler deadboltHandler = getDeadboltHandler(getHandlerKey());
-            result = preAuth(true,
-                             ctx,
-                             getContent(),
-                             deadboltHandler)
-                    .thenCompose(preAuthResult -> preAuthResult.map(r -> (CompletionStage<Result>) CompletableFuture.completedFuture(r))
-                                                               .orElseGet(() -> delegate.call(ctx)));
-        }
-        return result;
+        final DeadboltHandler deadboltHandler = getDeadboltHandler(getHandlerKey());
+        return preAuth(true,
+                         ctx,
+                         getContent(),
+                         deadboltHandler)
+                .thenCompose(preAuthResult -> preAuthResult.map(r -> (CompletionStage<Result>) CompletableFuture.completedFuture(r))
+                                                           .orElseGet(() -> delegate.call(ctx)));
     }
 
     /**

--- a/code/app/be/objectify/deadbolt/java/actions/BeforeAccessAction.java
+++ b/code/app/be/objectify/deadbolt/java/actions/BeforeAccessAction.java
@@ -72,7 +72,7 @@ public class BeforeAccessAction extends AbstractDeadboltAction<BeforeAccess>
                     .thenCompose(preAuthResult -> preAuthResult.map(r -> (CompletionStage<Result>) CompletableFuture.completedFuture(r))
                                                                .orElseGet(() -> delegate.call(ctx)));
         }
-        return maybeBlock(result);
+        return result;
     }
 
     /**

--- a/code/app/be/objectify/deadbolt/java/actions/DeferredDeadboltAction.java
+++ b/code/app/be/objectify/deadbolt/java/actions/DeferredDeadboltAction.java
@@ -18,8 +18,6 @@ package be.objectify.deadbolt.java.actions;
 import be.objectify.deadbolt.java.cache.BeforeAuthCheckCache;
 import be.objectify.deadbolt.java.cache.HandlerCache;
 import com.typesafe.config.Config;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import play.mvc.Http;
 import play.mvc.Result;
 
@@ -36,7 +34,6 @@ import java.util.concurrent.CompletionStage;
  */
 public class DeferredDeadboltAction extends AbstractDeadboltAction<DeferredDeadbolt>
 {
-    private static final Logger LOGGER = LoggerFactory.getLogger(DeferredDeadboltAction.class);
 
     @Inject
     public DeferredDeadboltAction(final HandlerCache handlerCache,

--- a/code/app/be/objectify/deadbolt/java/actions/DeferredDeadboltAction.java
+++ b/code/app/be/objectify/deadbolt/java/actions/DeferredDeadboltAction.java
@@ -51,23 +51,7 @@ public class DeferredDeadboltAction extends AbstractDeadboltAction<DeferredDeadb
     @Override
     public CompletionStage<Result> execute(final Http.Context ctx) throws Exception
     {
-        final CompletionStage<Result> result;
-        if (isActionUnauthorised(ctx))
-        {
-            result = onAuthFailure(getDeadboltHandler(getHandlerKey()),
-                                   getContent(),
-                                   ctx);
-        }
-        else if (isActionAuthorised(ctx))
-        {
-            result = delegate.call(ctx);
-        }
-        else
-        {
-            result = delegate.call(ctx);
-        }
-
-        return result;
+        return delegate.call(ctx);
     }
 
     /**

--- a/code/app/be/objectify/deadbolt/java/actions/DeferredDeadboltAction.java
+++ b/code/app/be/objectify/deadbolt/java/actions/DeferredDeadboltAction.java
@@ -67,7 +67,7 @@ public class DeferredDeadboltAction extends AbstractDeadboltAction<DeferredDeadb
             result = delegate.call(ctx);
         }
 
-        return maybeBlock(result);
+        return result;
     }
 
     /**

--- a/code/app/be/objectify/deadbolt/java/actions/DeferredDeadboltAction.java
+++ b/code/app/be/objectify/deadbolt/java/actions/DeferredDeadboltAction.java
@@ -26,7 +26,6 @@ import play.mvc.Result;
 import javax.inject.Inject;
 
 import java.util.Optional;
-import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 
 /**
@@ -52,9 +51,23 @@ public class DeferredDeadboltAction extends AbstractDeadboltAction<DeferredDeadb
     @Override
     public CompletionStage<Result> execute(final Http.Context ctx) throws Exception
     {
-        final CompletionStage<Result> eventualResult = delegate.call(ctx);
+        final CompletionStage<Result> result;
+        if (isActionUnauthorised(ctx))
+        {
+            result = onAuthFailure(getDeadboltHandler(getHandlerKey()),
+                                   getContent(),
+                                   ctx);
+        }
+        else if (isActionAuthorised(ctx))
+        {
+            result = delegate.call(ctx);
+        }
+        else
+        {
+            result = delegate.call(ctx);
+        }
 
-        return maybeBlock(eventualResult);
+        return maybeBlock(result);
     }
 
     /**

--- a/code/app/be/objectify/deadbolt/java/actions/UnrestrictedAction.java
+++ b/code/app/be/objectify/deadbolt/java/actions/UnrestrictedAction.java
@@ -70,7 +70,7 @@ public class UnrestrictedAction extends AbstractDeadboltAction<Unrestricted>
                                                                                                                                                                      .content()))
                                                                                                                     : authorizeAndExecute(ctx));
         }
-        return maybeBlock(result);
+        return result;
     }
 
     /**

--- a/code/app/be/objectify/deadbolt/java/actions/UnrestrictedAction.java
+++ b/code/app/be/objectify/deadbolt/java/actions/UnrestrictedAction.java
@@ -23,7 +23,6 @@ import play.mvc.Result;
 
 import javax.inject.Inject;
 import java.util.Optional;
-import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 
 /**
@@ -49,13 +48,7 @@ public class UnrestrictedAction extends AbstractDeadboltAction<Unrestricted>
     @Override
     public CompletionStage<Result> execute(final Http.Context ctx) throws Exception
     {
-        return CompletableFuture.completedFuture(isActionUnauthorised(ctx))
-                                                                      .thenCompose(unauthorised -> unauthorised ? unauthorizeAndFail(ctx,
-                                                                                                                                     getDeadboltHandler(configuration
-                                                                                                                                                                .handlerKey()),
-                                                                                                                                     Optional.ofNullable(configuration
-                                                                                                                                                                 .content()))
-                                                                                                                : authorizeAndExecute(ctx));
+        return authorizeAndExecute(ctx);
     }
 
     /**

--- a/code/app/be/objectify/deadbolt/java/actions/UnrestrictedAction.java
+++ b/code/app/be/objectify/deadbolt/java/actions/UnrestrictedAction.java
@@ -49,28 +49,13 @@ public class UnrestrictedAction extends AbstractDeadboltAction<Unrestricted>
     @Override
     public CompletionStage<Result> execute(final Http.Context ctx) throws Exception
     {
-        final CompletionStage<Result> result;
-        if (isActionUnauthorised(ctx))
-        {
-            result = onAuthFailure(getDeadboltHandler(getHandlerKey()),
-                                   getContent(),
-                                   ctx);
-        }
-        else if (isActionAuthorised(ctx))
-        {
-            result = delegate.call(ctx);
-        }
-        else
-        {
-            result = CompletableFuture.completedFuture(isActionUnauthorised(ctx))
-                                                                          .thenCompose(unauthorised -> unauthorised ? unauthorizeAndFail(ctx,
-                                                                                                                                         getDeadboltHandler(configuration
-                                                                                                                                                                    .handlerKey()),
-                                                                                                                                         Optional.ofNullable(configuration
-                                                                                                                                                                     .content()))
-                                                                                                                    : authorizeAndExecute(ctx));
-        }
-        return result;
+        return CompletableFuture.completedFuture(isActionUnauthorised(ctx))
+                                                                      .thenCompose(unauthorised -> unauthorised ? unauthorizeAndFail(ctx,
+                                                                                                                                     getDeadboltHandler(configuration
+                                                                                                                                                                .handlerKey()),
+                                                                                                                                     Optional.ofNullable(configuration
+                                                                                                                                                                 .content()))
+                                                                                                                : authorizeAndExecute(ctx));
     }
 
     /**

--- a/code/test/be/objectify/deadbolt/java/actions/BeforeAccessActionTest.java
+++ b/code/test/be/objectify/deadbolt/java/actions/BeforeAccessActionTest.java
@@ -44,7 +44,7 @@ public class BeforeAccessActionTest
         ctx.args.put("deadbolt.action-authorised",
                      true);
 
-        action.execute(ctx);
+        action.call(ctx);
 
         Mockito.verify(action.delegate).call(ctx);
     }

--- a/code/test/be/objectify/deadbolt/java/actions/SubjectNotPresentActionTest.java
+++ b/code/test/be/objectify/deadbolt/java/actions/SubjectNotPresentActionTest.java
@@ -82,7 +82,6 @@ public class SubjectNotPresentActionTest {
                        handler,
                        Optional.empty());
 
-        Assert.assertTrue((Boolean)ctx.args.get("deadbolt.action-unauthorised"));
         Mockito.verify(handler).onAuthFailure(ctx,
                                               Optional.empty());
     }

--- a/code/test/be/objectify/deadbolt/java/actions/SubjectPresentActionTest.java
+++ b/code/test/be/objectify/deadbolt/java/actions/SubjectPresentActionTest.java
@@ -101,7 +101,6 @@ public class SubjectPresentActionTest {
                           handler,
                           Optional.empty());
 
-        Assert.assertTrue((Boolean)ctx.args.get("deadbolt.action-unauthorised"));
         Mockito.verify(handler).onAuthFailure(ctx,
                                               Optional.empty());
     }


### PR DESCRIPTION
Cleanup.

Turns out we can centralize code into the `call` method of the `AbstractDeadboltAction` class instead of having duplicate code inside every subclass' `execute` method. E.g. we can simple wrap the `execute` method with `maybeBlock(...)` instead of calling it inside every sub-method. The same with the check for `isActionAuthorised(...)`. 
Another thing is: We don't have to `check...` or `mark` an `ActionAsUnauthorised` - it doesn't make sense at all. We don't decide based on this check if we fail the action method chain. That's because we **always** immediately fail/return an error page as soon as access was denied - there is not need for postponing via a marker - just see `unauthorizeAndFail`, that's were `onAuthFailure` is called. -> So `unauthorizeAndFail` handles all that stuff and is the entry point when you want to fail/deny access. The "mark an action as unauthorised" doesn't really do anything and even after a couple of month I revisited and thought about it again, I can not see sense in it. Probably historical left-over.