### PR TITLE
Keep backwards compatibility: Re-implement BeforeAccess.alwaysExecute

### DIFF
--- a/code/app/be/objectify/deadbolt/java/actions/AbstractDeadboltAction.java
+++ b/code/app/be/objectify/deadbolt/java/actions/AbstractDeadboltAction.java
@@ -132,7 +132,7 @@ public abstract class AbstractDeadboltAction<T> extends Action<T>
             }
             else
             {
-                if (isActionAuthorised(ctx))
+                if (isActionAuthorised(ctx) && !alwaysExecute())
                 {
                     result = delegate.call(ctx);
                 }
@@ -369,5 +369,9 @@ public abstract class AbstractDeadboltAction<T> extends Action<T>
     public abstract Optional<String> getContent();
 
     public abstract String getHandlerKey();
+
+    public boolean alwaysExecute() {
+        return false;
+    }
 
 }

--- a/code/app/be/objectify/deadbolt/java/actions/BeforeAccess.java
+++ b/code/app/be/objectify/deadbolt/java/actions/BeforeAccess.java
@@ -58,6 +58,14 @@ public @interface BeforeAccess
     String handlerKey() default ConfigKeys.DEFAULT_HANDLER_KEY;
 
     /**
+     * By default, if another Deadbolt action has already been executed in the same request and has allowed access,
+     * beforeAuthCheck will not be executed again.  Set this to true if you want it to execute unconditionally.
+     *
+     * @return true if beforeAuthCheck should always be executed, otherwise false
+     */
+    boolean alwaysExecute() default true;
+
+    /**
      * If true, the annotation will only be run if there is a {@link DeferredDeadbolt} annotation at the class level.
      *
      * @return true iff the associated action should be deferred until class-level annotations are applied.

--- a/code/app/be/objectify/deadbolt/java/actions/BeforeAccessAction.java
+++ b/code/app/be/objectify/deadbolt/java/actions/BeforeAccessAction.java
@@ -80,4 +80,9 @@ public class BeforeAccessAction extends AbstractDeadboltAction<BeforeAccess>
         return configuration.handlerKey();
     }
 
+    @Override
+    public boolean alwaysExecute() {
+        return configuration.alwaysExecute();
+    }
+
 }

--- a/code/test/be/objectify/deadbolt/java/actions/BeforeAccessActionTest.java
+++ b/code/test/be/objectify/deadbolt/java/actions/BeforeAccessActionTest.java
@@ -15,7 +15,9 @@
  */
 package be.objectify.deadbolt.java.actions;
 
+import be.objectify.deadbolt.java.DeadboltHandler;
 import be.objectify.deadbolt.java.cache.BeforeAuthCheckCache;
+import be.objectify.deadbolt.java.cache.DefaultBeforeAuthCheckCache;
 import be.objectify.deadbolt.java.cache.HandlerCache;
 import com.typesafe.config.ConfigFactory;
 import org.junit.Test;
@@ -24,6 +26,8 @@ import play.mvc.Action;
 import play.mvc.Http;
 
 import java.util.HashMap;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
 
 /**
  * @author Steve Chaloner (steve@objectify.be)
@@ -31,21 +35,64 @@ import java.util.HashMap;
 public class BeforeAccessActionTest
 {
     @Test
-    public void testExecute_alreadyAuthorised_alwaysExecuteFalse() throws Exception
+    public void testExecute_alreadyAuthorised_alwaysExecuteTrue() throws Exception
     {
-        final BeforeAccessAction action = new BeforeAccessAction(Mockito.mock(HandlerCache.class),
-                                                                 Mockito.mock(BeforeAuthCheckCache.class),
-                                                                 ConfigFactory.empty());
-        action.configuration = Mockito.mock(BeforeAccess.class);
-        action.delegate = Mockito.mock(Action.class);
-
         final Http.Context ctx = Mockito.mock(Http.Context.class);
         ctx.args = new HashMap<>();
         ctx.args.put("deadbolt.action-authorised",
                      true);
 
+        final DeadboltHandler handler = Mockito.mock(DeadboltHandler.class);
+        Mockito.when(handler.beforeAuthCheck(ctx, Optional.empty()))
+               .thenReturn(CompletableFuture.completedFuture(Optional.empty()));
+
+        final HandlerCache handlerCache = Mockito.mock(HandlerCache.class);
+        Mockito.when(handlerCache.get())
+               .thenReturn(handler);
+
+        final BeforeAuthCheckCache beforeAuthCheckCache = new DefaultBeforeAuthCheckCache(ConfigFactory.empty());
+
+        final BeforeAccessAction action = new BeforeAccessAction(handlerCache,
+                                                                 beforeAuthCheckCache,
+                                                                 ConfigFactory.empty());
+        action.configuration = Mockito.mock(BeforeAccess.class);
+        Mockito.when(action.configuration.alwaysExecute())
+               .thenReturn(true);
+        action.delegate = Mockito.mock(Action.class);
+
         action.call(ctx);
 
+        Mockito.verify(handler).beforeAuthCheck(ctx, Optional.empty());
+        Mockito.verify(action.delegate).call(ctx);
+    }
+
+    @Test
+    public void testExecute_alreadyAuthorised_alwaysExecuteFalse() throws Exception
+    {
+        final Http.Context ctx = Mockito.mock(Http.Context.class);
+        ctx.args = new HashMap<>();
+        ctx.args.put("deadbolt.action-authorised",
+                     true);
+
+        final DeadboltHandler handler = Mockito.mock(DeadboltHandler.class);
+        Mockito.when(handler.beforeAuthCheck(ctx, Optional.empty()))
+               .thenReturn(CompletableFuture.completedFuture(Optional.empty()));
+
+        final HandlerCache handlerCache = Mockito.mock(HandlerCache.class);
+        Mockito.when(handlerCache.get())
+               .thenReturn(handler);
+
+        final BeforeAccessAction action = new BeforeAccessAction(handlerCache,
+                                                                 Mockito.mock(BeforeAuthCheckCache.class),
+                                                                 ConfigFactory.empty());
+        action.configuration = Mockito.mock(BeforeAccess.class);
+        Mockito.when(action.configuration.alwaysExecute())
+               .thenReturn(false);
+        action.delegate = Mockito.mock(Action.class);
+
+        action.call(ctx);
+
+        Mockito.verify(handler, Mockito.never()).beforeAuthCheck(ctx, Optional.empty());
         Mockito.verify(action.delegate).call(ctx);
     }
 }


### PR DESCRIPTION
I removed that "feature" in #66 because that made all the refactoring I did easier. However finally I decided to re-implement the feature to stay 100% backward compatible with the 2.6.x branch. The "feature" doesn't hurt and whoever wants to use it can do so, I don't really care.