### PR TITLE
[2.7] Remove deprecated beforeAuthCheck(...) method

### DIFF
--- a/code/app/be/objectify/deadbolt/java/AbstractDeadboltHandler.java
+++ b/code/app/be/objectify/deadbolt/java/AbstractDeadboltHandler.java
@@ -56,14 +56,6 @@ public abstract class AbstractDeadboltHandler extends Results implements Deadbol
     @Override
     public CompletionStage<Optional<Result>> beforeAuthCheck(Http.Context context, Optional<String> content)
     {
-        return beforeAuthCheck(context);
-    }
-
-    /**
-     * @deprecated Just use the overloaded beforeAuthCheck method that also takes an Optional<String> content
-     */
-    @Deprecated
-    public CompletionStage<Optional<Result>> beforeAuthCheck(Http.Context context) {
         return CompletableFuture.completedFuture(Optional.empty());
     }
 


### PR DESCRIPTION
### Do NOT merge yet, this has to wait for the 2.7 release because it breaks backward compatibility.