### PR TITLE
[2.7] Change scala bug workaround to work with Scala 2.13

### DIFF
--- a/code/build.sbt
+++ b/code/build.sbt
@@ -17,8 +17,6 @@ releasePublishArtifactsAction := PgpKeys.publishSigned.value
 
 // workaround for scaladoc error https://github.com/scala/scala-dev/issues/249
 // also see http://www.scala-lang.org/news/2.12.0/#scaladoc-can-be-used-to-document-java-sources
-scalacOptions in (Compile, doc) ++= {
-  if (scalaBinaryVersion.value == "2.12") Seq("-no-java-comments") else Nil
-}
+scalacOptions in (Compile, doc) += "-no-java-comments"
 
 resolvers += Resolver.sonatypeRepo("snapshots")


### PR DESCRIPTION
## Do **not** merge yet, this has to wait for the 2.7 release.

Deadbolt 2.7 will use Play 2.7. In Play 2.7 Scala 2.11 will be dropped, so there is no need anymore for that `if` - also because there will be Scala 2.13 support already so the fix has to apply to that major version as well.