### PR TITLE
Keep backward compatibility: Re-add @Deferrable but deprecate it

### DIFF
--- a/code/app/be/objectify/deadbolt/java/actions/Deferrable.java
+++ b/code/app/be/objectify/deadbolt/java/actions/Deferrable.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2010-2016 Steve Chaloner
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package be.objectify.deadbolt.java.actions;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Marks a constraint as being deferrable, i.e. method-level constraints are not applied until controller-level annotations are applied.
+ *
+ * @deprecated Not used anymore.
+ *
+ * @author Steve Chaloner (steve@objectify.be)
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.TYPE)
+@Inherited
+@Documented
+@Deprecated
+public @interface Deferrable
+{
+}


### PR DESCRIPTION
I removed `@Deferrable` in #62 because as you can see in that pull request we don't need it anymore.

However I want to keep backward compatibility in the `2.6.4` release so I re-add it. We can remove it in the next major release.