### PR TITLE
Adding tests for all the different modes (OR, AND and the default one)

### DIFF
--- a/test-app/app/be/objectify/deadbolt/java/test/controllers/modes/ModesController.java
+++ b/test-app/app/be/objectify/deadbolt/java/test/controllers/modes/ModesController.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2010-2016 Steve Chaloner
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package be.objectify.deadbolt.java.test.controllers.modes;
+
+import be.objectify.deadbolt.java.models.PatternType;
+import be.objectify.deadbolt.java.actions.Group;
+import be.objectify.deadbolt.java.actions.Pattern;
+import be.objectify.deadbolt.java.actions.Restrict;
+import be.objectify.deadbolt.java.actions.Unrestricted;
+import play.mvc.Controller;
+import play.mvc.Result;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+
+/**
+ * @author Matthias Kurz (m.kurz@irregular.at)
+ */
+@Restrict(@Group({"foo", "bar"}))
+public class ModesController extends Controller
+{
+    @Pattern(value = "killer.undead.zombie", patternType = PatternType.EQUALITY)
+    public CompletionStage<Result> modeDependend()
+    {
+        return CompletableFuture.supplyAsync(() -> ok("Content accessible"));
+    }
+
+    @Unrestricted
+    public CompletionStage<Result> modeDependendUnrestricted()
+    {
+        return CompletableFuture.supplyAsync(() -> ok("Content accessible"));
+    }
+}

--- a/test-app/app/be/objectify/deadbolt/java/test/controllers/modes/NoConstraintsController.java
+++ b/test-app/app/be/objectify/deadbolt/java/test/controllers/modes/NoConstraintsController.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2010-2016 Steve Chaloner
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package be.objectify.deadbolt.java.test.controllers.modes;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+
+import be.objectify.deadbolt.java.actions.BeforeAccess;
+import be.objectify.deadbolt.java.actions.DeferredDeadbolt;
+import be.objectify.deadbolt.java.actions.Pattern;
+import be.objectify.deadbolt.java.models.PatternType;
+import play.mvc.Controller;
+import play.mvc.Result;
+
+/**
+ * @DeferredDeadbolt and @BeforeAccess deadbolt annotations are not treated as constraints
+ * 
+ * @author Matthias Kurz (m.kurz@irregular.at)
+ */
+@DeferredDeadbolt // Just a placeholder for a deferred constraint (if there was one) - but itself doesn't mark anything as authorized
+public class NoConstraintsController extends Controller
+{
+    /**
+     * Doesn't matter if AND, OR or default mode, this action method will always be executed, because @DeferredDeadbolt doesn't do anything
+     */
+    public CompletionStage<Result> deferredDeadbolt()
+    {
+        return CompletableFuture.supplyAsync(() -> ok("Content accessible"));
+    }
+
+    /**
+     * Will only fail when beforeAuthCheck(...) fails, otherwise action method will be executed
+     */
+    @BeforeAccess // Just triggers a beforeAuthCheck(...) - but doesn't take part in OR/AND mode au mark anything as authorized even when successful
+    public CompletionStage<Result> beforeAccess()
+    {
+        return CompletableFuture.supplyAsync(() -> ok("Content accessible"));
+    }
+
+    /**
+     * Of course when beforeAuthCheck(...) fails, the action method will be un-authorized, no matter which mode is used.
+     * However an interesting test case is the OR mode now:
+     * If beforeAuthCheck(...) is OK but the pattern constraint fails, the action method will be un-authorized because the @BeforeAccess
+     * doesn't mark anything as authorized - again, it just triggers beforeAuthCheck(...) but nothing more.
+     * For the default mode also only the pattern constraint matters (if beforeAuthCheck(...) was ok before)
+     * The same for the AND mode.
+     */
+    @BeforeAccess // Just triggers a beforeAuthCheck(...) - but doesn't take part in OR/AND mode au mark anything as authorized even when successful
+    @Pattern(value = "killer.undead.zombie", patternType = PatternType.EQUALITY)
+    public CompletionStage<Result> beforeAccessAndPattern()
+    {
+        return CompletableFuture.supplyAsync(() -> ok("Content accessible"));
+    }
+}

--- a/test-app/conf/routes
+++ b/test-app/conf/routes
@@ -80,3 +80,10 @@ GET        /composite/c/open                                                    
 GET        /filtered/subject/present/subjectMustBePresent                                be.objectify.deadbolt.java.test.controllers.NoConstraintsApp.index
 #deadbolt:subjectNotPresent
 GET        /filtered/subject/notPresent/subjectMustBePresent                             be.objectify.deadbolt.java.test.controllers.NoConstraintsApp.index
+
+# Modes
+GET        /mode/checkMode                                                               be.objectify.deadbolt.java.test.controllers.modes.ModesController.modeDependend()
+GET        /mode/checkModeUnrestricted                                                   be.objectify.deadbolt.java.test.controllers.modes.ModesController.modeDependendUnrestricted()
+GET        /mode/NoConstraintsDeferredDeadbolt                                           be.objectify.deadbolt.java.test.controllers.modes.NoConstraintsController.deferredDeadbolt()
+GET        /mode/NoConstraintsBeforeAccess                                               be.objectify.deadbolt.java.test.controllers.modes.NoConstraintsController.beforeAccess()
+GET        /mode/NoConstraintsBeforeAccessAndPattern                                     be.objectify.deadbolt.java.test.controllers.modes.NoConstraintsController.beforeAccessAndPattern()

--- a/test-app/test/be/objectify/deadbolt/java/test/controllers/AbstractApplicationTest.java
+++ b/test-app/test/be/objectify/deadbolt/java/test/controllers/AbstractApplicationTest.java
@@ -15,22 +15,39 @@
  */
 package be.objectify.deadbolt.java.test.controllers;
 
+import java.util.Map;
+
 import be.objectify.deadbolt.java.test.dao.TestUserDao;
 import be.objectify.deadbolt.java.test.dao.UserDao;
 import play.Application;
 import play.Mode;
 import play.inject.Bindings;
 import play.inject.guice.GuiceApplicationBuilder;
+import com.google.common.collect.ImmutableMap;
 
 /**
  * @author Steve Chaloner (steve@objectify.be)
  */
 public abstract class AbstractApplicationTest
 {
-    public Application app()
+    public Application app(final Map<String, Object> conf)
     {
         return new GuiceApplicationBuilder().in(Mode.TEST)
                                             .overrides(Bindings.bind(UserDao.class).to(TestUserDao.class))
+                                            .configure(conf)
                                             .build();
+    }
+
+    public Application app(final String key, final Object value)
+    {
+        if(key != null && value != null) {
+            return app(ImmutableMap.of(key, value));
+        }
+        return app();
+    }
+
+    public Application app()
+    {
+        return app(ImmutableMap.of());
     }
 }

--- a/test-app/test/be/objectify/deadbolt/java/test/controllers/AbstractApplicationTest.java
+++ b/test-app/test/be/objectify/deadbolt/java/test/controllers/AbstractApplicationTest.java
@@ -50,4 +50,11 @@ public abstract class AbstractApplicationTest
     {
         return app(ImmutableMap.of());
     }
+
+    public Application appWithoutUser(final Map<String, Object> conf)
+    {
+        return new GuiceApplicationBuilder().in(Mode.TEST)
+                                            .configure(conf)
+                                            .build();
+    }
 }

--- a/test-app/test/be/objectify/deadbolt/java/test/controllers/modes/ModesTest.java
+++ b/test-app/test/be/objectify/deadbolt/java/test/controllers/modes/ModesTest.java
@@ -1,0 +1,1063 @@
+/*
+ * Copyright 2010-2016 Steve Chaloner
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package be.objectify.deadbolt.java.test.controllers.modes;
+
+import be.objectify.deadbolt.java.test.controllers.AbstractApplicationTest;
+
+import com.google.common.collect.ImmutableMap;
+import com.jayway.restassured.RestAssured;
+import org.junit.Before;
+import org.junit.Test;
+
+import static play.test.Helpers.running;
+import static play.test.Helpers.testServer;
+
+/**
+ * @author Matthias Kurz (m.kurz@irregular.at)
+ */
+public class ModesTest extends AbstractApplicationTest
+{
+
+    private static final int PORT = 3333;
+    private static final String CONFIG_KEY_MODE = "deadbolt.java.constraint-mode";
+    private static final String CONFIG_KEY_CAF = "play.http.actionComposition.controllerAnnotationsFirst";
+
+    @Before
+    public void setUp()
+    {
+        RestAssured.port = PORT;
+    }
+
+    @Test
+    public void testAnd_subjectHasPermission_methodAnnotationsFirst()
+    {
+        running(testServer(PORT,
+                           app(ImmutableMap.of(
+                                    CONFIG_KEY_MODE, "AND",
+                                    CONFIG_KEY_CAF, "false"))),
+                () -> RestAssured.given()
+                           .cookie("user", "greet")
+                           .expect()
+                           .statusCode(200)
+                           .when()
+                           .get("/mode/checkMode"));
+    }
+
+    @Test
+    public void testAnd_subjectHasPermission_controllerAnnotationsFirst()
+    {
+        running(testServer(PORT,
+                           app(ImmutableMap.of(
+                                    CONFIG_KEY_MODE, "AND",
+                                    CONFIG_KEY_CAF, "true"))),
+                () -> RestAssured.given()
+                           .cookie("user", "greet")
+                           .expect()
+                           .statusCode(200)
+                           .when()
+                           .get("/mode/checkMode"));
+    }
+
+    @Test
+    public void testAnd_subjectDoesNotHavePermission_methodAnnotationsFirst()
+    {
+        running(testServer(PORT,
+                           app(ImmutableMap.of(
+                                    CONFIG_KEY_MODE, "AND",
+                                    CONFIG_KEY_CAF, "false"))),
+                () -> RestAssured.given()
+                           .cookie("user", "mani")
+                           .expect()
+                           .statusCode(401)
+                           .when()
+                           .get("/mode/checkMode"));
+    }
+
+    @Test
+    public void testAnd_subjectDoesNotHavePermission_controllerAnnotationsFirst()
+    {
+        running(testServer(PORT,
+                           app(ImmutableMap.of(
+                                    CONFIG_KEY_MODE, "AND",
+                                    CONFIG_KEY_CAF, "true"))),
+                () -> RestAssured.given()
+                           .cookie("user", "mani")
+                           .expect()
+                           .statusCode(401)
+                           .when()
+                           .get("/mode/checkMode"));
+    }
+
+    @Test
+    public void testAnd_noSubjectIsPresent_methodAnnotationsFirst()
+    {
+        running(testServer(PORT,
+                           appWithoutUser(ImmutableMap.of(
+                                    CONFIG_KEY_MODE, "AND",
+                                    CONFIG_KEY_CAF, "false"))),
+                () -> RestAssured.given()
+                           .cookie("user", "greet") // usually that user would pass, but no user present in backend
+                           .expect()
+                           .statusCode(401)
+                           .when()
+                           .get("/mode/checkMode"));
+    }
+
+    @Test
+    public void testAnd_noSubjectIsPresent_controllerAnnotationsFirst()
+    {
+        running(testServer(PORT,
+                          appWithoutUser(ImmutableMap.of(
+                                   CONFIG_KEY_MODE, "AND",
+                                   CONFIG_KEY_CAF, "true"))),
+                () -> RestAssured.given()
+                           .cookie("user", "greet") // usually that user would pass, but no user present in backend
+                           .expect()
+                           .statusCode(401)
+                           .when()
+                           .get("/mode/checkMode"));
+    }
+
+    @Test
+    public void testOr_subjectHasPermission_methodAnnotationsFirst()
+    {
+        running(testServer(PORT,
+                           app(ImmutableMap.of(
+                                    CONFIG_KEY_MODE, "OR",
+                                    CONFIG_KEY_CAF, "false"))),
+                () -> RestAssured.given()
+                           .cookie("user", "mani") // same user which fails in AND mode has permission in OR mode (because role is ok!)
+                           .expect()
+                           .statusCode(200)
+                           .when()
+                           .get("/mode/checkMode"));
+    }
+
+    @Test
+    public void testOr_subjectHasPermission_controllerAnnotationsFirst()
+    {
+        running(testServer(PORT,
+                           app(ImmutableMap.of(
+                                    CONFIG_KEY_MODE, "OR",
+                                    CONFIG_KEY_CAF, "true"))),
+                () -> RestAssured.given()
+                           .cookie("user", "mani") // same user which fails in AND mode has permission in OR mode (because role is ok!)
+                           .expect()
+                           .statusCode(200)
+                           .when()
+                           .get("/mode/checkMode"));
+    }
+
+    @Test
+    public void testOr_subjectDoesNotHavePermission_methodAnnotationsFirst()
+    {
+        running(testServer(PORT,
+                           app(ImmutableMap.of(
+                                    CONFIG_KEY_MODE, "OR",
+                                    CONFIG_KEY_CAF, "false"))),
+                () -> RestAssured.given()
+                           .cookie("user", "lotte")
+                           .expect()
+                           .statusCode(401)
+                           .when()
+                           .get("/mode/checkMode"));
+    }
+
+    @Test
+    public void testOr_subjectDoesNotHavePermission_controllerAnnotationsFirst()
+    {
+        running(testServer(PORT,
+                           app(ImmutableMap.of(
+                                    CONFIG_KEY_MODE, "OR",
+                                    CONFIG_KEY_CAF, "true"))),
+                () -> RestAssured.given()
+                           .cookie("user", "lotte")
+                           .expect()
+                           .statusCode(401)
+                           .when()
+                           .get("/mode/checkMode"));
+    }
+
+    @Test
+    public void testOr_noSubjectIsPresent_methodAnnotationsFirst()
+    {
+        running(testServer(PORT,
+                           appWithoutUser(ImmutableMap.of(
+                                    CONFIG_KEY_MODE, "OR",
+                                    CONFIG_KEY_CAF, "false"))),
+                () -> RestAssured.given()
+                           .cookie("user", "mani") // usually that user would pass, but no user present in backend
+                           .expect()
+                           .statusCode(401)
+                           .when()
+                           .get("/mode/checkMode"));
+    }
+
+    @Test
+    public void testOr_noSubjectIsPresent_controllerAnnotationsFirst()
+    {
+        running(testServer(PORT,
+                           appWithoutUser(ImmutableMap.of(
+                                   CONFIG_KEY_MODE, "OR",
+                                   CONFIG_KEY_CAF, "true"))),
+                () -> RestAssured.given()
+                           .cookie("user", "mani") // usually that user would pass, but no user present in backend
+                           .expect()
+                           .statusCode(401)
+                           .when()
+                           .get("/mode/checkMode"));
+    }
+
+    @Test
+    public void testDefaultMode_subjectDoesNotHavePermission_methodAnnotationsFirst()
+    {
+        running(testServer(PORT,
+                           app(ImmutableMap.of(
+                                    //CONFIG_KEY_MODE, "PROCESS_FIRST_CONSTRAINT_ONLY", // that's the default
+                                    CONFIG_KEY_CAF, "false"))), // false is the default in Play
+                () -> RestAssured.given()
+                           .cookie("user", "mani")
+                           .expect()
+                           .statusCode(401) // We fail Because the method annotation is processed first (and nothing else)
+                           .when()
+                           .get("/mode/checkMode"));
+    }
+
+    @Test
+    public void testDefaultMode_subjectDoesHavePermission_controllerAnnotationsFirst()
+    {
+        running(testServer(PORT,
+                           app(ImmutableMap.of(
+                                    //CONFIG_KEY_MODE, "PROCESS_FIRST_CONSTRAINT_ONLY", // that's the default
+                                    CONFIG_KEY_CAF, "true"))),
+                () -> RestAssured.given()
+                           .cookie("user", "mani")
+                           .expect()
+                           .statusCode(200) // WE NOW PASS!!! Because now the controller annotation is processed first (and nothing else)
+                           .when()
+                           .get("/mode/checkMode"));
+    }
+
+    @Test
+    public void testDefaultMode_noSubjectIsPresent_methodAnnotationsFirst()
+    {
+        running(testServer(PORT,
+                           appWithoutUser(ImmutableMap.of(
+                                    //CONFIG_KEY_MODE, "PROCESS_FIRST_CONSTRAINT_ONLY", // that's the default
+                                    CONFIG_KEY_CAF, "false"))), // false is the default in Play
+                () -> RestAssured.given()
+                           .cookie("user", "greet") // use a user that would usually pass
+                           .expect()
+                           .statusCode(401)
+                           .when()
+                           .get("/mode/checkMode"));
+    }
+
+    @Test
+    public void testDefaultMode_noSubjectIsPresent_controllerAnnotationsFirst()
+    {
+        running(testServer(PORT,
+                           appWithoutUser(ImmutableMap.of(
+                                    //CONFIG_KEY_MODE, "PROCESS_FIRST_CONSTRAINT_ONLY", // that's the default
+                                    CONFIG_KEY_CAF, "true"))),
+                () -> RestAssured.given()
+                           .cookie("user", "mani")
+                           .expect()
+                           .statusCode(401)
+                           .when()
+                           .get("/mode/checkMode"));
+    }
+
+    @Test
+    public void testAnd_Unrestricted_subjectHasPermission_methodAnnotationsFirst()
+    {
+        running(testServer(PORT,
+                           app(ImmutableMap.of(
+                                    CONFIG_KEY_MODE, "AND",
+                                    CONFIG_KEY_CAF, "false"))),
+                () -> RestAssured.given()
+                           .cookie("user", "greet")
+                           .expect()
+                           .statusCode(200)
+                           .when()
+                           .get("/mode/checkModeUnrestricted"));
+    }
+
+    @Test
+    public void testAnd_Unrestricted_subjectHasPermission_controllerAnnotationsFirst()
+    {
+        running(testServer(PORT,
+                           app(ImmutableMap.of(
+                                    CONFIG_KEY_MODE, "AND",
+                                    CONFIG_KEY_CAF, "true"))),
+                () -> RestAssured.given()
+                           .cookie("user", "greet")
+                           .expect()
+                           .statusCode(200)
+                           .when()
+                           .get("/mode/checkModeUnrestricted"));
+    }
+
+    @Test
+    public void testAnd_Unrestricted_subjectDoesNotHavePermission_methodAnnotationsFirst()
+    {
+        running(testServer(PORT,
+                           app(ImmutableMap.of(
+                                    CONFIG_KEY_MODE, "AND",
+                                    CONFIG_KEY_CAF, "false"))),
+                () -> RestAssured.given()
+                           .cookie("user", "lotte")
+                           .expect()
+                           .statusCode(401)
+                           .when()
+                           .get("/mode/checkModeUnrestricted"));
+    }
+
+    @Test
+    public void testAnd_Unrestricted_subjectDoesNotHavePermission_controllerAnnotationsFirst()
+    {
+        running(testServer(PORT,
+                           app(ImmutableMap.of(
+                                    CONFIG_KEY_MODE, "AND",
+                                    CONFIG_KEY_CAF, "true"))),
+                () -> RestAssured.given()
+                           .cookie("user", "lotte")
+                           .expect()
+                           .statusCode(401)
+                           .when()
+                           .get("/mode/checkModeUnrestricted"));
+    }
+
+    @Test
+    public void testAnd_Unrestricted_noSubjectIsPresent_methodAnnotationsFirst()
+    {
+        running(testServer(PORT,
+                           appWithoutUser(ImmutableMap.of(
+                                    CONFIG_KEY_MODE, "AND",
+                                    CONFIG_KEY_CAF, "false"))),
+                () -> RestAssured.given()
+                           .cookie("user", "greet") // usually that user would pass, but no user present in backend
+                           .expect()
+                           .statusCode(401)
+                           .when()
+                           .get("/mode/checkModeUnrestricted"));
+    }
+
+    @Test
+    public void testAnd_Unrestricted_noSubjectIsPresent_controllerAnnotationsFirst()
+    {
+        running(testServer(PORT,
+                          appWithoutUser(ImmutableMap.of(
+                                   CONFIG_KEY_MODE, "AND",
+                                   CONFIG_KEY_CAF, "true"))),
+                () -> RestAssured.given()
+                           .cookie("user", "greet") // usually that user would pass, but no user present in backend
+                           .expect()
+                           .statusCode(401)
+                           .when()
+                           .get("/mode/checkModeUnrestricted"));
+    }
+
+    @Test
+    public void testOr_Unrestricted_subjectHasPermission_methodAnnotationsFirst()
+    {
+        running(testServer(PORT,
+                           app(ImmutableMap.of(
+                                    CONFIG_KEY_MODE, "OR",
+                                    CONFIG_KEY_CAF, "false"))),
+                () -> RestAssured.given()
+                           .cookie("user", "mani")
+                           .expect()
+                           .statusCode(200)
+                           .when()
+                           .get("/mode/checkModeUnrestricted"));
+    }
+
+    @Test
+    public void testOr_Unrestricted_subjectHasPermission_controllerAnnotationsFirst()
+    {
+        running(testServer(PORT,
+                           app(ImmutableMap.of(
+                                    CONFIG_KEY_MODE, "OR",
+                                    CONFIG_KEY_CAF, "true"))),
+                () -> RestAssured.given()
+                           .cookie("user", "mani")
+                           .expect()
+                           .statusCode(200)
+                           .when()
+                           .get("/mode/checkModeUnrestricted"));
+    }
+
+    @Test
+    public void testOr_Unrestricted_subjectDoesNotHavePermission_methodAnnotationsFirst()
+    {
+        running(testServer(PORT,
+                           app(ImmutableMap.of(
+                                    CONFIG_KEY_MODE, "OR",
+                                    CONFIG_KEY_CAF, "false"))),
+                () -> RestAssured.given()
+                           .cookie("user", "lotte")
+                           .expect()
+                           .statusCode(200)
+                           .when()
+                           .get("/mode/checkModeUnrestricted"));
+    }
+
+    @Test
+    public void testOr_Unrestricted_subjectDoesNotHavePermission_controllerAnnotationsFirst()
+    {
+        running(testServer(PORT,
+                           app(ImmutableMap.of(
+                                    CONFIG_KEY_MODE, "OR",
+                                    CONFIG_KEY_CAF, "true"))),
+                () -> RestAssured.given()
+                           .cookie("user", "lotte")
+                           .expect()
+                           .statusCode(200)
+                           .when()
+                           .get("/mode/checkModeUnrestricted"));
+    }
+
+    @Test
+    public void testOr_Unrestricted_noSubjectIsPresent_methodAnnotationsFirst()
+    {
+        running(testServer(PORT,
+                           appWithoutUser(ImmutableMap.of(
+                                    CONFIG_KEY_MODE, "OR",
+                                    CONFIG_KEY_CAF, "false"))),
+                () -> RestAssured.given()
+                           .cookie("user", "mani")
+                           .expect()
+                           .statusCode(200)
+                           .when()
+                           .get("/mode/checkModeUnrestricted"));
+    }
+
+    @Test
+    public void testOr_Unrestricted_noSubjectIsPresent_controllerAnnotationsFirst()
+    {
+        running(testServer(PORT,
+                           appWithoutUser(ImmutableMap.of(
+                                   CONFIG_KEY_MODE, "OR",
+                                   CONFIG_KEY_CAF, "true"))),
+                () -> RestAssured.given()
+                           .cookie("user", "mani")
+                           .expect()
+                           .statusCode(200)
+                           .when()
+                           .get("/mode/checkModeUnrestricted"));
+    }
+
+    @Test
+    public void testDefaultMode_Unrestricted_subjectDoesNotHavePermission_methodAnnotationsFirst()
+    {
+        running(testServer(PORT,
+                           app(ImmutableMap.of(
+                                    //CONFIG_KEY_MODE, "PROCESS_FIRST_CONSTRAINT_ONLY", // that's the default
+                                    CONFIG_KEY_CAF, "false"))), // false is the default in Play
+                () -> RestAssured.given()
+                           .cookie("user", "lotte")
+                           .expect()
+                           .statusCode(200) // Success because the method annotation (@Unrestricted) is processed first (and nothing else)
+                           .when()
+                           .get("/mode/checkModeUnrestricted"));
+    }
+
+    @Test
+    public void testDefaultMode_Unrestricted_subjectDoesHavePermission_controllerAnnotationsFirst()
+    {
+        running(testServer(PORT,
+                           app(ImmutableMap.of(
+                                    //CONFIG_KEY_MODE, "PROCESS_FIRST_CONSTRAINT_ONLY", // that's the default
+                                    CONFIG_KEY_CAF, "true"))),
+                () -> RestAssured.given()
+                           .cookie("user", "lotte")
+                           .expect()
+                           .statusCode(401) // Fails because now the controller annotation is processed first (and nothing else)
+                           .when()
+                           .get("/mode/checkModeUnrestricted"));
+    }
+
+    @Test
+    public void testDefaultMode_Unrestricted_noSubjectIsPresent_methodAnnotationsFirst()
+    {
+        running(testServer(PORT,
+                           appWithoutUser(ImmutableMap.of(
+                                    //CONFIG_KEY_MODE, "PROCESS_FIRST_CONSTRAINT_ONLY", // that's the default
+                                    CONFIG_KEY_CAF, "false"))), // false is the default in Play
+                () -> RestAssured.given()
+                           .cookie("user", "lotte") // use a user that would usually pass
+                           .expect()
+                           .statusCode(200) // Success because the method annotation (@Unrestricted) is processed first (and nothing else)
+                           .when()
+                           .get("/mode/checkModeUnrestricted"));
+    }
+
+    @Test
+    public void testDefaultMode_Unrestricted_noSubjectIsPresent_controllerAnnotationsFirst()
+    {
+        running(testServer(PORT,
+                           appWithoutUser(ImmutableMap.of(
+                                    //CONFIG_KEY_MODE, "PROCESS_FIRST_CONSTRAINT_ONLY", // that's the default
+                                    CONFIG_KEY_CAF, "true"))),
+                () -> RestAssured.given()
+                           .cookie("user", "lotte")
+                           .expect()
+                           .statusCode(401) // Fails because now the controller annotation is processed first (and nothing else)
+                           .when()
+                           .get("/mode/checkModeUnrestricted"));
+    }
+
+    @Test
+    public void testAnd_deferredDeadbolt_subjectIsPresent_methodAnnotationsFirst()
+    {
+        running(testServer(PORT,
+                           app(ImmutableMap.of(
+                                    CONFIG_KEY_MODE, "AND",
+                                    CONFIG_KEY_CAF, "false"))),
+                () -> RestAssured.given()
+                           .cookie("user", "lotte")
+                           .expect()
+                           .statusCode(200)
+                           .when()
+                           .get("/mode/NoConstraintsDeferredDeadbolt"));
+    }
+
+    @Test
+    public void testAnd_deferredDeadbolt_subjectIsPresent_controllerAnnotationsFirst()
+    {
+        running(testServer(PORT,
+                           app(ImmutableMap.of(
+                                    CONFIG_KEY_MODE, "AND",
+                                    CONFIG_KEY_CAF, "true"))),
+                () -> RestAssured.given()
+                           .cookie("user", "lotte")
+                           .expect()
+                           .statusCode(200)
+                           .when()
+                           .get("/mode/NoConstraintsDeferredDeadbolt"));
+    }
+
+    @Test
+    public void testAnd_deferredDeadbolt_noSubjectIsPresent_methodAnnotationsFirst()
+    {
+        running(testServer(PORT,
+                           appWithoutUser(ImmutableMap.of(
+                                    CONFIG_KEY_MODE, "AND",
+                                    CONFIG_KEY_CAF, "false"))),
+                () -> RestAssured.given()
+                           .cookie("user", "lotte")
+                           .expect()
+                           .statusCode(200)
+                           .when()
+                           .get("/mode/NoConstraintsDeferredDeadbolt"));
+    }
+
+    @Test
+    public void testAnd_deferredDeadbolt_noSubjectIsPresent_controllerAnnotationsFirst()
+    {
+        running(testServer(PORT,
+                           appWithoutUser(ImmutableMap.of(
+                                    CONFIG_KEY_MODE, "AND",
+                                    CONFIG_KEY_CAF, "true"))),
+                () -> RestAssured.given()
+                           .cookie("user", "lotte")
+                           .expect()
+                           .statusCode(200)
+                           .when()
+                           .get("/mode/NoConstraintsDeferredDeadbolt"));
+    }
+
+    @Test
+    public void testOr_deferredDeadbolt_subjectIsPresent_methodAnnotationsFirst()
+    {
+        running(testServer(PORT,
+                           app(ImmutableMap.of(
+                                    CONFIG_KEY_MODE, "OR",
+                                    CONFIG_KEY_CAF, "false"))),
+                () -> RestAssured.given()
+                           .cookie("user", "lotte")
+                           .expect()
+                           .statusCode(200)
+                           .when()
+                           .get("/mode/NoConstraintsDeferredDeadbolt"));
+    }
+
+    @Test
+    public void testOr_deferredDeadbolt_subjectIsPresent_controllerAnnotationsFirst()
+    {
+        running(testServer(PORT,
+                           app(ImmutableMap.of(
+                                    CONFIG_KEY_MODE, "OR",
+                                    CONFIG_KEY_CAF, "true"))),
+                () -> RestAssured.given()
+                           .cookie("user", "lotte")
+                           .expect()
+                           .statusCode(200)
+                           .when()
+                           .get("/mode/NoConstraintsDeferredDeadbolt"));
+    }
+
+    @Test
+    public void testOr_deferredDeadbolt_noSubjectIsPresent_methodAnnotationsFirst()
+    {
+        running(testServer(PORT,
+                           appWithoutUser(ImmutableMap.of(
+                                    CONFIG_KEY_MODE, "OR",
+                                    CONFIG_KEY_CAF, "false"))),
+                () -> RestAssured.given()
+                           .cookie("user", "lotte")
+                           .expect()
+                           .statusCode(200)
+                           .when()
+                           .get("/mode/NoConstraintsDeferredDeadbolt"));
+    }
+
+    @Test
+    public void testOr_deferredDeadbolt_noSubjectIsPresent_controllerAnnotationsFirst()
+    {
+        running(testServer(PORT,
+                           appWithoutUser(ImmutableMap.of(
+                                    CONFIG_KEY_MODE, "OR",
+                                    CONFIG_KEY_CAF, "true"))),
+                () -> RestAssured.given()
+                           .cookie("user", "lotte")
+                           .expect()
+                           .statusCode(200)
+                           .when()
+                           .get("/mode/NoConstraintsDeferredDeadbolt"));
+    }
+
+    @Test
+    public void testDefaultMode_deferredDeadbolt_subjectIsPresent_methodAnnotationsFirst()
+    {
+        running(testServer(PORT,
+                           app(ImmutableMap.of(
+                                    //CONFIG_KEY_MODE, "PROCESS_FIRST_CONSTRAINT_ONLY", // that's the default
+                                    CONFIG_KEY_CAF, "false"))),
+                () -> RestAssured.given()
+                           .cookie("user", "lotte")
+                           .expect()
+                           .statusCode(200)
+                           .when()
+                           .get("/mode/NoConstraintsDeferredDeadbolt"));
+    }
+
+    @Test
+    public void testDefaultMode_deferredDeadbolt_subjectIsPresent_controllerAnnotationsFirst()
+    {
+        running(testServer(PORT,
+                           app(ImmutableMap.of(
+                                    //CONFIG_KEY_MODE, "PROCESS_FIRST_CONSTRAINT_ONLY", // that's the default
+                                    CONFIG_KEY_CAF, "true"))),
+                () -> RestAssured.given()
+                           .cookie("user", "lotte")
+                           .expect()
+                           .statusCode(200)
+                           .when()
+                           .get("/mode/NoConstraintsDeferredDeadbolt"));
+    }
+
+    @Test
+    public void testDefaultMode_deferredDeadbolt_noSubjectIsPresent_methodAnnotationsFirst()
+    {
+        running(testServer(PORT,
+                           appWithoutUser(ImmutableMap.of(
+                                    //CONFIG_KEY_MODE, "PROCESS_FIRST_CONSTRAINT_ONLY", // that's the default
+                                    CONFIG_KEY_CAF, "false"))),
+                () -> RestAssured.given()
+                           .cookie("user", "lotte")
+                           .expect()
+                           .statusCode(200)
+                           .when()
+                           .get("/mode/NoConstraintsDeferredDeadbolt"));
+    }
+
+    @Test
+    public void testDefaultMode_deferredDeadbolt_noSubjectIsPresent_controllerAnnotationsFirst()
+    {
+        running(testServer(PORT,
+                           appWithoutUser(ImmutableMap.of(
+                                    //CONFIG_KEY_MODE, "PROCESS_FIRST_CONSTRAINT_ONLY", // that's the default
+                                    CONFIG_KEY_CAF, "true"))),
+                () -> RestAssured.given()
+                           .cookie("user", "lotte")
+                           .expect()
+                           .statusCode(200)
+                           .when()
+                           .get("/mode/NoConstraintsDeferredDeadbolt"));
+    }
+
+    @Test
+    public void testAnd_beforeAccess_subjectIsPresent_methodAnnotationsFirst()
+    {
+        running(testServer(PORT,
+                           app(ImmutableMap.of(
+                                    CONFIG_KEY_MODE, "AND",
+                                    CONFIG_KEY_CAF, "false"))),
+                () -> RestAssured.given()
+                           .cookie("user", "lotte")
+                           .expect()
+                           .statusCode(200)
+                           .when()
+                           .get("/mode/NoConstraintsBeforeAccess"));
+    }
+
+    @Test
+    public void testAnd_beforeAccess_subjectIsPresent_controllerAnnotationsFirst()
+    {
+        running(testServer(PORT,
+                           app(ImmutableMap.of(
+                                    CONFIG_KEY_MODE, "AND",
+                                    CONFIG_KEY_CAF, "true"))),
+                () -> RestAssured.given()
+                           .cookie("user", "lotte")
+                           .expect()
+                           .statusCode(200)
+                           .when()
+                           .get("/mode/NoConstraintsBeforeAccess"));
+    }
+
+    @Test
+    public void testAnd_beforeAccess_noSubjectIsPresent_methodAnnotationsFirst()
+    {
+        running(testServer(PORT,
+                           appWithoutUser(ImmutableMap.of(
+                                    CONFIG_KEY_MODE, "AND",
+                                    CONFIG_KEY_CAF, "false"))),
+                () -> RestAssured.given()
+                           .cookie("user", "lotte")
+                           .expect()
+                           .statusCode(200)
+                           .when()
+                           .get("/mode/NoConstraintsBeforeAccess"));
+    }
+
+    @Test
+    public void testAnd_beforeAccess_noSubjectIsPresent_controllerAnnotationsFirst()
+    {
+        running(testServer(PORT,
+                           appWithoutUser(ImmutableMap.of(
+                                    CONFIG_KEY_MODE, "AND",
+                                    CONFIG_KEY_CAF, "true"))),
+                () -> RestAssured.given()
+                           .cookie("user", "lotte")
+                           .expect()
+                           .statusCode(200)
+                           .when()
+                           .get("/mode/NoConstraintsBeforeAccess"));
+    }
+
+    @Test
+    public void testOr_beforeAccess_subjectIsPresent_methodAnnotationsFirst()
+    {
+        running(testServer(PORT,
+                           app(ImmutableMap.of(
+                                    CONFIG_KEY_MODE, "OR",
+                                    CONFIG_KEY_CAF, "false"))),
+                () -> RestAssured.given()
+                           .cookie("user", "lotte")
+                           .expect()
+                           .statusCode(200)
+                           .when()
+                           .get("/mode/NoConstraintsBeforeAccess"));
+    }
+
+    @Test
+    public void testOr_beforeAccess_subjectIsPresent_controllerAnnotationsFirst()
+    {
+        running(testServer(PORT,
+                           app(ImmutableMap.of(
+                                    CONFIG_KEY_MODE, "OR",
+                                    CONFIG_KEY_CAF, "true"))),
+                () -> RestAssured.given()
+                           .cookie("user", "lotte")
+                           .expect()
+                           .statusCode(200)
+                           .when()
+                           .get("/mode/NoConstraintsBeforeAccess"));
+    }
+
+    @Test
+    public void testOr_beforeAccess_noSubjectIsPresent_methodAnnotationsFirst()
+    {
+        running(testServer(PORT,
+                           appWithoutUser(ImmutableMap.of(
+                                    CONFIG_KEY_MODE, "OR",
+                                    CONFIG_KEY_CAF, "false"))),
+                () -> RestAssured.given()
+                           .cookie("user", "lotte")
+                           .expect()
+                           .statusCode(200)
+                           .when()
+                           .get("/mode/NoConstraintsBeforeAccess"));
+    }
+
+    @Test
+    public void testOr_beforeAccess_noSubjectIsPresent_controllerAnnotationsFirst()
+    {
+        running(testServer(PORT,
+                           appWithoutUser(ImmutableMap.of(
+                                    CONFIG_KEY_MODE, "OR",
+                                    CONFIG_KEY_CAF, "true"))),
+                () -> RestAssured.given()
+                           .cookie("user", "lotte")
+                           .expect()
+                           .statusCode(200)
+                           .when()
+                           .get("/mode/NoConstraintsBeforeAccess"));
+    }
+
+    @Test
+    public void testDefaultMode_beforeAccess_subjectIsPresent_methodAnnotationsFirst()
+    {
+        running(testServer(PORT,
+                           app(ImmutableMap.of(
+                                    //CONFIG_KEY_MODE, "PROCESS_FIRST_CONSTRAINT_ONLY", // that's the default
+                                    CONFIG_KEY_CAF, "false"))),
+                () -> RestAssured.given()
+                           .cookie("user", "lotte")
+                           .expect()
+                           .statusCode(200)
+                           .when()
+                           .get("/mode/NoConstraintsBeforeAccess"));
+    }
+
+    @Test
+    public void testDefaultMode_beforeAccess_subjectIsPresent_controllerAnnotationsFirst()
+    {
+        running(testServer(PORT,
+                           app(ImmutableMap.of(
+                                    //CONFIG_KEY_MODE, "PROCESS_FIRST_CONSTRAINT_ONLY", // that's the default
+                                    CONFIG_KEY_CAF, "true"))),
+                () -> RestAssured.given()
+                           .cookie("user", "lotte")
+                           .expect()
+                           .statusCode(200)
+                           .when()
+                           .get("/mode/NoConstraintsBeforeAccess"));
+    }
+
+    @Test
+    public void testDefaultMode_beforeAccess_noSubjectIsPresent_methodAnnotationsFirst()
+    {
+        running(testServer(PORT,
+                           appWithoutUser(ImmutableMap.of(
+                                    //CONFIG_KEY_MODE, "PROCESS_FIRST_CONSTRAINT_ONLY", // that's the default
+                                    CONFIG_KEY_CAF, "false"))),
+                () -> RestAssured.given()
+                           .cookie("user", "lotte")
+                           .expect()
+                           .statusCode(200)
+                           .when()
+                           .get("/mode/NoConstraintsBeforeAccess"));
+    }
+
+    @Test
+    public void testDefaultMode_beforeAccess_noSubjectIsPresent_controllerAnnotationsFirst()
+    {
+        running(testServer(PORT,
+                           appWithoutUser(ImmutableMap.of(
+                                    //CONFIG_KEY_MODE, "PROCESS_FIRST_CONSTRAINT_ONLY", // that's the default
+                                    CONFIG_KEY_CAF, "true"))),
+                () -> RestAssured.given()
+                           .cookie("user", "lotte")
+                           .expect()
+                           .statusCode(200)
+                           .when()
+                           .get("/mode/NoConstraintsBeforeAccess"));
+    }
+
+    @Test
+    public void testAnd_beforeAccessAndPattern_subjectIsPresent_methodAnnotationsFirst()
+    {
+        running(testServer(PORT,
+                           app(ImmutableMap.of(
+                                    CONFIG_KEY_MODE, "AND",
+                                    CONFIG_KEY_CAF, "false"))),
+                () -> RestAssured.given()
+                           .cookie("user", "lotte")
+                           .expect()
+                           .statusCode(401)
+                           .when()
+                           .get("/mode/NoConstraintsBeforeAccessAndPattern"));
+    }
+
+    @Test
+    public void testAnd_beforeAccessAndPattern_subjectIsPresent_controllerAnnotationsFirst()
+    {
+        running(testServer(PORT,
+                           app(ImmutableMap.of(
+                                    CONFIG_KEY_MODE, "AND",
+                                    CONFIG_KEY_CAF, "true"))),
+                () -> RestAssured.given()
+                           .cookie("user", "lotte")
+                           .expect()
+                           .statusCode(401)
+                           .when()
+                           .get("/mode/NoConstraintsBeforeAccessAndPattern"));
+    }
+
+    @Test
+    public void testAnd_beforeAccessAndPattern_noSubjectIsPresent_methodAnnotationsFirst()
+    {
+        running(testServer(PORT,
+                           appWithoutUser(ImmutableMap.of(
+                                    CONFIG_KEY_MODE, "AND",
+                                    CONFIG_KEY_CAF, "false"))),
+                () -> RestAssured.given()
+                           .cookie("user", "lotte")
+                           .expect()
+                           .statusCode(401)
+                           .when()
+                           .get("/mode/NoConstraintsBeforeAccessAndPattern"));
+    }
+
+    @Test
+    public void testAnd_beforeAccessAndPattern_noSubjectIsPresent_controllerAnnotationsFirst()
+    {
+        running(testServer(PORT,
+                           appWithoutUser(ImmutableMap.of(
+                                    CONFIG_KEY_MODE, "AND",
+                                    CONFIG_KEY_CAF, "true"))),
+                () -> RestAssured.given()
+                           .cookie("user", "lotte")
+                           .expect()
+                           .statusCode(401)
+                           .when()
+                           .get("/mode/NoConstraintsBeforeAccessAndPattern"));
+    }
+
+    @Test
+    public void testOr_beforeAccessAndPattern_subjectIsPresent_methodAnnotationsFirst()
+    {
+        running(testServer(PORT,
+                           app(ImmutableMap.of(
+                                    CONFIG_KEY_MODE, "OR",
+                                    CONFIG_KEY_CAF, "false"))),
+                () -> RestAssured.given()
+                           .cookie("user", "lotte")
+                           .expect()
+                           .statusCode(401)
+                           .when()
+                           .get("/mode/NoConstraintsBeforeAccessAndPattern"));
+    }
+
+    @Test
+    public void testOr_beforeAccessAndPattern_subjectIsPresent_controllerAnnotationsFirst()
+    {
+        running(testServer(PORT,
+                           app(ImmutableMap.of(
+                                    CONFIG_KEY_MODE, "OR",
+                                    CONFIG_KEY_CAF, "true"))),
+                () -> RestAssured.given()
+                           .cookie("user", "lotte")
+                           .expect()
+                           .statusCode(401)
+                           .when()
+                           .get("/mode/NoConstraintsBeforeAccessAndPattern"));
+    }
+
+    @Test
+    public void testOr_beforeAccessAndPattern_noSubjectIsPresent_methodAnnotationsFirst()
+    {
+        running(testServer(PORT,
+                           appWithoutUser(ImmutableMap.of(
+                                    CONFIG_KEY_MODE, "OR",
+                                    CONFIG_KEY_CAF, "false"))),
+                () -> RestAssured.given()
+                           .cookie("user", "lotte")
+                           .expect()
+                           .statusCode(401)
+                           .when()
+                           .get("/mode/NoConstraintsBeforeAccessAndPattern"));
+    }
+
+    @Test
+    public void testOr_beforeAccessAndPattern_noSubjectIsPresent_controllerAnnotationsFirst()
+    {
+        running(testServer(PORT,
+                           appWithoutUser(ImmutableMap.of(
+                                    CONFIG_KEY_MODE, "OR",
+                                    CONFIG_KEY_CAF, "true"))),
+                () -> RestAssured.given()
+                           .cookie("user", "lotte")
+                           .expect()
+                           .statusCode(401)
+                           .when()
+                           .get("/mode/NoConstraintsBeforeAccessAndPattern"));
+    }
+
+    @Test
+    public void testDefaultMode_beforeAccessAndPattern_subjectIsPresent_methodAnnotationsFirst()
+    {
+        running(testServer(PORT,
+                           app(ImmutableMap.of(
+                                    //CONFIG_KEY_MODE, "PROCESS_FIRST_CONSTRAINT_ONLY", // that's the default
+                                    CONFIG_KEY_CAF, "false"))),
+                () -> RestAssured.given()
+                           .cookie("user", "lotte")
+                           .expect()
+                           .statusCode(401)
+                           .when()
+                           .get("/mode/NoConstraintsBeforeAccessAndPattern"));
+    }
+
+    @Test
+    public void testDefaultMode_beforeAccessAndPattern_subjectIsPresent_controllerAnnotationsFirst()
+    {
+        running(testServer(PORT,
+                           app(ImmutableMap.of(
+                                    //CONFIG_KEY_MODE, "PROCESS_FIRST_CONSTRAINT_ONLY", // that's the default
+                                    CONFIG_KEY_CAF, "true"))),
+                () -> RestAssured.given()
+                           .cookie("user", "lotte")
+                           .expect()
+                           .statusCode(401)
+                           .when()
+                           .get("/mode/NoConstraintsBeforeAccessAndPattern"));
+    }
+
+    @Test
+    public void testDefaultMode_beforeAccessAndPattern_noSubjectIsPresent_methodAnnotationsFirst()
+    {
+        running(testServer(PORT,
+                           appWithoutUser(ImmutableMap.of(
+                                    //CONFIG_KEY_MODE, "PROCESS_FIRST_CONSTRAINT_ONLY", // that's the default
+                                    CONFIG_KEY_CAF, "false"))),
+                () -> RestAssured.given()
+                           .cookie("user", "lotte")
+                           .expect()
+                           .statusCode(401)
+                           .when()
+                           .get("/mode/NoConstraintsBeforeAccessAndPattern"));
+    }
+
+    @Test
+    public void testDefaultMode_beforeAccessAndPattern_noSubjectIsPresent_controllerAnnotationsFirst()
+    {
+        running(testServer(PORT,
+                           appWithoutUser(ImmutableMap.of(
+                                    //CONFIG_KEY_MODE, "PROCESS_FIRST_CONSTRAINT_ONLY", // that's the default
+                                    CONFIG_KEY_CAF, "true"))),
+                () -> RestAssured.given()
+                           .cookie("user", "lotte")
+                           .expect()
+                           .statusCode(401)
+                           .when()
+                           .get("/mode/NoConstraintsBeforeAccessAndPattern"));
+    }
+}


### PR DESCRIPTION
Added 68 tests which make sure that the `AND`, `OR` and the backward compatible `PROCESS_FIRST_CONSTRAINT_ONLY` mode really do what they are supposed to do.

I also ran the tests for the default `PROCESS_FIRST_CONSTRAINT_ONLY` on the last stable 2.6.3 release and they all passed which is another proof we stay backward compatible.