### PR TITLE
Rename ConstraintMode to ConstraintAnnotationMode

### DIFF
--- a/code/app/be/objectify/deadbolt/java/ConfigKeys.java
+++ b/code/app/be/objectify/deadbolt/java/ConfigKeys.java
@@ -47,7 +47,7 @@ public class ConfigKeys
 
     public static final String CONSTRAINT_MODE = "deadbolt.java.constraint-mode";
     public static final F.Tuple<String, String> CONSTRAINT_MODE_DEFAULT = new F.Tuple<>(CONSTRAINT_MODE,
-                                                                                   ConstraintMode.PROCESS_FIRST_CONSTRAINT_ONLY.toString());
+                                                                                   ConstraintAnnotationMode.PROCESS_FIRST_CONSTRAINT_ONLY.toString());
 
     public static final String PATTERN_INVERT = "deadbolt.pattern.invert";
 

--- a/code/app/be/objectify/deadbolt/java/ConstraintAnnotationMode.java
+++ b/code/app/be/objectify/deadbolt/java/ConstraintAnnotationMode.java
@@ -1,6 +1,6 @@
 package be.objectify.deadbolt.java;
 
-public enum ConstraintMode {
+public enum ConstraintAnnotationMode {
 
     // Only the first constraint in the action composition chain will ever be checked (the remaining ones will always be skipped and NEVER be executed).
     // The default (because of backward compatibility).


### PR DESCRIPTION
Makes it clear that this `enum` is "only" used for the mode between annotations. I need the name `ConstraintMode` later for a other pr where it makes much more sense.