### PR TITLE
AND/OR mode for @Pattern constraint

### DIFF
--- a/code/app/be/objectify/deadbolt/java/ConstraintMode.java
+++ b/code/app/be/objectify/deadbolt/java/ConstraintMode.java
@@ -1,0 +1,6 @@
+package be.objectify.deadbolt.java;
+
+public enum ConstraintMode {
+    AND,
+    OR
+}

--- a/code/app/be/objectify/deadbolt/java/actions/Pattern.java
+++ b/code/app/be/objectify/deadbolt/java/actions/Pattern.java
@@ -16,6 +16,7 @@
 package be.objectify.deadbolt.java.actions;
 
 import be.objectify.deadbolt.java.ConfigKeys;
+import be.objectify.deadbolt.java.ConstraintMode;
 import be.objectify.deadbolt.java.models.PatternType;
 import play.mvc.With;
 
@@ -43,7 +44,12 @@ public @interface Pattern
      *
      * @return the pattern
      */
-    String value();
+    String[] value();
+
+    /**
+     * If multiple values should be AND (default) or OR
+     */
+    ConstraintMode mode() default ConstraintMode.AND;
 
     /**
      * The type of pattern matching

--- a/code/app/be/objectify/deadbolt/java/actions/PatternAction.java
+++ b/code/app/be/objectify/deadbolt/java/actions/PatternAction.java
@@ -69,6 +69,7 @@ public class PatternAction extends AbstractRestrictiveAction<Pattern>
                                        deadboltHandler,
                                        getContent(),
                                        configuration.value(),
+                                       configuration.mode(),
                                        configuration.patternType(),
                                        Optional.ofNullable(configuration.meta()),
                                        configuration.invert(),

--- a/code/test/be/objectify/deadbolt/java/actions/PatternActionTest.java
+++ b/code/test/be/objectify/deadbolt/java/actions/PatternActionTest.java
@@ -16,6 +16,7 @@
 package be.objectify.deadbolt.java.actions;
 
 import be.objectify.deadbolt.java.ConstraintLogic;
+import be.objectify.deadbolt.java.ConstraintMode;
 import be.objectify.deadbolt.java.ConstraintPoint;
 import be.objectify.deadbolt.java.DeadboltHandler;
 import be.objectify.deadbolt.java.cache.BeforeAuthCheckCache;
@@ -42,7 +43,9 @@ public class PatternActionTest
     {
         final Pattern pattern = Mockito.mock(Pattern.class);
         Mockito.when(pattern.value())
-               .thenReturn("foo");
+               .thenReturn(new String[] {"foo"});
+        Mockito.when(pattern.mode())
+                .thenReturn(ConstraintMode.AND);
         Mockito.when(pattern.meta())
                .thenReturn("bar");
         Mockito.when(pattern.content())
@@ -67,7 +70,8 @@ public class PatternActionTest
         Mockito.verify(constraintLogic).pattern(Mockito.eq(ctx),
                                                 Mockito.eq(handler),
                                                 Mockito.eq(Optional.of("x/y")),
-                                                Mockito.eq("foo"),
+                                                Mockito.eq(new String[] {"foo"}),
+                                                Mockito.eq(ConstraintMode.AND),
                                                 Mockito.eq(PatternType.EQUALITY),
                                                 Mockito.eq(Optional.of("bar")),
                                                 Mockito.eq(false),

--- a/test-app/app/be/objectify/deadbolt/java/test/controllers/pattern/PatternModes.java
+++ b/test-app/app/be/objectify/deadbolt/java/test/controllers/pattern/PatternModes.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2010-2016 Steve Chaloner
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package be.objectify.deadbolt.java.test.controllers.pattern;
+
+import static be.objectify.deadbolt.java.ConstraintMode.*;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+
+import be.objectify.deadbolt.java.actions.Pattern;
+import be.objectify.deadbolt.java.models.PatternType;
+import play.mvc.Controller;
+import play.mvc.Result;
+
+/**
+ * @author Matthias Kurz (m.kurz@irregular.at)
+ */
+public class PatternModes extends Controller
+{
+    @Pattern(value = { "curator.museum.insects", "killer.undead.zombie" }, patternType = PatternType.EQUALITY) // AND is the default mode
+    public CompletionStage<Result> modeDefault()
+    {
+        return CompletableFuture.supplyAsync(() -> ok("Content accessible"));
+    }
+
+    @Pattern(value = { "curator.museum.insects", "killer.undead.zombie" }, mode = AND, patternType = PatternType.EQUALITY)
+    public CompletionStage<Result> modeAnd()
+    {
+        return CompletableFuture.supplyAsync(() -> ok("Content accessible"));
+    }
+
+    @Pattern(value = { "curator.museum.insects", "killer.undead.zombie" }, mode = OR, patternType = PatternType.EQUALITY)
+    public CompletionStage<Result> modeOr()
+    {
+        return CompletableFuture.supplyAsync(() -> ok("Content accessible"));
+    }
+}

--- a/test-app/conf/routes
+++ b/test-app/conf/routes
@@ -69,6 +69,11 @@ GET        /pattern/invert/custom/m/checkCustom                                 
 GET        /pattern/invert/custom/c/checkCustom                                          be.objectify.deadbolt.java.test.controllers.pattern.InvertedCustomForController.protectedByControllerLevelCustom()
 GET        /pattern/invert/custom/c/checkCustom/open                                     be.objectify.deadbolt.java.test.controllers.pattern.InvertedCustomForController.unrestricted()
 
+# Pattern constraints modes
+GET        /pattern/mode/default                                                         be.objectify.deadbolt.java.test.controllers.pattern.PatternModes.modeDefault()
+GET        /pattern/mode/and                                                             be.objectify.deadbolt.java.test.controllers.pattern.PatternModes.modeAnd()
+GET        /pattern/mode/or                                                              be.objectify.deadbolt.java.test.controllers.pattern.PatternModes.modeOr()
+
 # Composite constraints
 GET        /composite/m/foo                                                              be.objectify.deadbolt.java.test.controllers.composite.CompositeForMethod.foo()
 GET        /composite/m/fooInUnrestrictedController                                      be.objectify.deadbolt.java.test.controllers.composite.ExplicitlyUnrestrictedControllerWithCompositeForMethod.foo()

--- a/test-app/test/be/objectify/deadbolt/java/test/controllers/pattern/PatternModesTest.java
+++ b/test-app/test/be/objectify/deadbolt/java/test/controllers/pattern/PatternModesTest.java
@@ -1,0 +1,130 @@
+/*
+ * Copyright 2010-2016 Steve Chaloner
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package be.objectify.deadbolt.java.test.controllers.pattern;
+
+import be.objectify.deadbolt.java.test.controllers.AbstractApplicationTest;
+import com.jayway.restassured.RestAssured;
+import org.junit.Before;
+import org.junit.Test;
+
+import static play.test.Helpers.running;
+import static play.test.Helpers.testServer;
+
+/**
+ * @author Matthias Kurz (m.kurz@irregular.at)
+ */
+public class PatternModesTest extends AbstractApplicationTest
+{
+
+    private static final int PORT = 3333;
+
+    @Before
+    public void setUp()
+    {
+        RestAssured.port = PORT;
+    }
+
+    @Test
+    public void testDefault_subjectHasPermission()
+    {
+        running(testServer(PORT,
+                           app()),
+                () -> RestAssured.given()
+                           .cookie("user", "tom") // has both permissions
+                           .expect()
+                           .statusCode(200)
+                           .when()
+                           .get("/pattern/mode/default"));
+    }
+
+    @Test
+    public void testDefault_subjectDoesNotHavePermission()
+    {
+        running(testServer(PORT,
+                           app()),
+                () -> RestAssured.given()
+                           .cookie("user", "greet") // misses one of the two permissions
+                           .expect()
+                           .statusCode(401)
+                           .when()
+                           .get("/pattern/mode/default"));
+    }
+
+    @Test
+    public void testAnd_subjectHasPermission()
+    {
+        running(testServer(PORT,
+                           app()),
+                () -> RestAssured.given()
+                           .cookie("user", "tom") // has both permissions
+                           .expect()
+                           .statusCode(200)
+                           .when()
+                           .get("/pattern/mode/and"));
+    }
+
+    @Test
+    public void testAnd_subjectDoesNotHavePermission()
+    {
+        running(testServer(PORT,
+                           app()),
+                () -> RestAssured.given()
+                           .cookie("user", "greet") // misses one of the two permissions
+                           .expect()
+                           .statusCode(401)
+                           .when()
+                           .get("/pattern/mode/and"));
+    }
+    
+    @Test
+    public void testOr_subjectHasAllPermissions()
+    {
+        running(testServer(PORT,
+                           app()),
+                () -> RestAssured.given()
+                           .cookie("user", "tom") // has both permissions even though one would be enough
+                           .expect()
+                           .statusCode(200)
+                           .when()
+                           .get("/pattern/mode/or"));
+    }
+
+    @Test
+    public void testOr_subjectHasOnlyOnePermission()
+    {
+        running(testServer(PORT,
+                           app()),
+                () -> RestAssured.given()
+                           .cookie("user", "greet") // has (only) one of the two permissions - passes now too!
+                           .expect()
+                           .statusCode(200)
+                           .when()
+                           .get("/pattern/mode/or"));
+    }
+
+    @Test
+    public void testOr_subjectDoesNotHavePermission()
+    {
+        running(testServer(PORT,
+                           app()),
+                () -> RestAssured.given()
+                           .cookie("user", "lotte") // does not even have one of the two permissions needed...
+                           .expect()
+                           .statusCode(401)
+                           .when()
+                           .get("/pattern/mode/or"));
+    }
+}

--- a/test-app/test/be/objectify/deadbolt/java/test/dao/TestUserDao.java
+++ b/test-app/test/be/objectify/deadbolt/java/test/dao/TestUserDao.java
@@ -53,6 +53,10 @@ public class TestUserDao implements UserDao {
                   new User("steve",
                            Collections.singletonList(barRole),
                            Collections.singletonList(cmiPermission)));
+        users.put("tom",
+                new User("tom",
+                         Collections.singletonList(barRole),
+                         Arrays.asList(cmiPermission, kuzPermission)));
         users.put("mani",
                   new User("mani",
                            Arrays.asList(fooRole, barRole, hurdyRole),


### PR DESCRIPTION
Fully backwards compatible.

Allows us to to write awesome stuff like:
```java
// subject needs to have both permissions
@Pattern(value = { "curator.museum.insects", "killer.undead.zombie" }, mode = AND)

// subject needs to have one of these permissions
@Pattern(value = { "curator.museum.insects", "killer.undead.zombie" }, mode = OR)
```

Together with the `deadbolt.java.constraint-mode` setting this is really useful. E.g. you could set `deadbolt.java.constraint-mode = AND`, annotate the controller with `@Restrict(...)` to only allow certain roles and on the method method you can then require that this role has x *or* y permission to access that action method. Nice.