### PR TITLE
Upgrade to Play 2.7.0-RC3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,15 +2,15 @@ language: scala
 jdk:
 - oraclejdk8
 scala:
-- 2.12.6
+- 2.12.7
 script:
 - cd code
 - sbt --info ++$TRAVIS_SCALA_VERSION +publishLocal
-- sbt --info ++$TRAVIS_SCALA_VERSION -DplayTestVersion=2.7.0-M1 +test
+- sbt --info ++$TRAVIS_SCALA_VERSION -DplayTestVersion=2.7.0-RC3 +test
 - cd ../test-app
-- sbt --info ++$TRAVIS_SCALA_VERSION -DplayTestVersion=2.7.0-M1 +test
+- sbt --info ++$TRAVIS_SCALA_VERSION -DplayTestVersion=2.7.0-RC3 +test
 - cd ../test-app-filters
-- sbt --info ++$TRAVIS_SCALA_VERSION -DplayTestVersion=2.7.0-M1 +test
+- sbt --info ++$TRAVIS_SCALA_VERSION -DplayTestVersion=2.7.0-RC3 +test
 - cd ../code
 after_success:
 - ! '[[ $TRAVIS_BRANCH == "master" ]] && { sbt --info +publish; };'

--- a/code/app/be/objectify/deadbolt/java/AbstractDeadboltHandler.java
+++ b/code/app/be/objectify/deadbolt/java/AbstractDeadboltHandler.java
@@ -36,34 +36,22 @@ public abstract class AbstractDeadboltHandler extends Results implements Deadbol
     private static final AtomicLong NEXT_ID = new AtomicLong(0);
     private final long id = NEXT_ID.getAndIncrement();
 
-    /**
-     * {@inheritDoc}
-     */
     public long getId() {
         return this.id;
     }
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public CompletionStage<Optional<Result>> beforeAuthCheck(Http.RequestHeader requestHeader, Optional<String> content)
     {
         return CompletableFuture.completedFuture(Optional.empty());
     }
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public CompletionStage<Optional<? extends Subject>> getSubject(final Http.RequestHeader requestHeader)
     {
         return CompletableFuture.completedFuture(Optional.empty());
     }
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public CompletionStage<Result> onAuthFailure(final Http.RequestHeader requestHeader,
                                                  final Optional<String> content)
@@ -72,9 +60,6 @@ public abstract class AbstractDeadboltHandler extends Results implements Deadbol
                                 .thenApply(Results::unauthorized);
     }
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public CompletionStage<Optional<DynamicResourceHandler>> getDynamicResourceHandler(final Http.RequestHeader requestHeader)
     {

--- a/code/app/be/objectify/deadbolt/java/AbstractDeadboltHandler.java
+++ b/code/app/be/objectify/deadbolt/java/AbstractDeadboltHandler.java
@@ -47,7 +47,7 @@ public abstract class AbstractDeadboltHandler extends Results implements Deadbol
      * {@inheritDoc}
      */
     @Override
-    public CompletionStage<Optional<Result>> beforeAuthCheck(Http.Context context, Optional<String> content)
+    public CompletionStage<Optional<Result>> beforeAuthCheck(Http.RequestHeader requestHeader, Optional<String> content)
     {
         return CompletableFuture.completedFuture(Optional.empty());
     }
@@ -56,7 +56,7 @@ public abstract class AbstractDeadboltHandler extends Results implements Deadbol
      * {@inheritDoc}
      */
     @Override
-    public CompletionStage<Optional<? extends Subject>> getSubject(final Http.Context context)
+    public CompletionStage<Optional<? extends Subject>> getSubject(final Http.RequestHeader requestHeader)
     {
         return CompletableFuture.completedFuture(Optional.empty());
     }
@@ -65,10 +65,10 @@ public abstract class AbstractDeadboltHandler extends Results implements Deadbol
      * {@inheritDoc}
      */
     @Override
-    public CompletionStage<Result> onAuthFailure(final Http.Context context,
+    public CompletionStage<Result> onAuthFailure(final Http.RequestHeader requestHeader,
                                                  final Optional<String> content)
     {
-        return CompletableFuture.completedFuture(unauthorized.render())
+        return CompletableFuture.completedFuture(unauthorized.render(requestHeader.asScala()))
                                 .thenApply(Results::unauthorized);
     }
 
@@ -76,7 +76,7 @@ public abstract class AbstractDeadboltHandler extends Results implements Deadbol
      * {@inheritDoc}
      */
     @Override
-    public CompletionStage<Optional<DynamicResourceHandler>> getDynamicResourceHandler(final Http.Context context)
+    public CompletionStage<Optional<DynamicResourceHandler>> getDynamicResourceHandler(final Http.RequestHeader requestHeader)
     {
         return CompletableFuture.completedFuture(Optional.empty());
     }

--- a/code/app/be/objectify/deadbolt/java/AbstractDynamicResourceHandler.java
+++ b/code/app/be/objectify/deadbolt/java/AbstractDynamicResourceHandler.java
@@ -31,10 +31,11 @@ public abstract class AbstractDynamicResourceHandler implements DynamicResourceH
     /**
      * {@inheritDoc}
      */
+    @Override
     public CompletionStage<Boolean> isAllowed(final String name,
                                               final Optional<String> meta,
                                               final DeadboltHandler deadboltHandler,
-                                              final Http.Context ctx)
+                                              final Http.RequestHeader requestHeader)
     {
         return CompletableFuture.completedFuture(false);
     }
@@ -42,10 +43,11 @@ public abstract class AbstractDynamicResourceHandler implements DynamicResourceH
     /**
      * {@inheritDoc}
      */
+    @Override
     public CompletionStage<Boolean> checkPermission(final String permissionValue,
                                                     final Optional<String> meta,
                                                     final DeadboltHandler deadboltHandler,
-                                                    final Http.Context ctx)
+                                                    final Http.RequestHeader requestHeader)
     {
         return CompletableFuture.completedFuture(false);
     }

--- a/code/app/be/objectify/deadbolt/java/AbstractDynamicResourceHandler.java
+++ b/code/app/be/objectify/deadbolt/java/AbstractDynamicResourceHandler.java
@@ -28,9 +28,7 @@ import java.util.concurrent.CompletionStage;
  */
 public abstract class AbstractDynamicResourceHandler implements DynamicResourceHandler
 {
-    /**
-     * {@inheritDoc}
-     */
+
     @Override
     public CompletionStage<Boolean> isAllowed(final String name,
                                               final Optional<String> meta,
@@ -40,9 +38,6 @@ public abstract class AbstractDynamicResourceHandler implements DynamicResourceH
         return CompletableFuture.completedFuture(false);
     }
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public CompletionStage<Boolean> checkPermission(final String permissionValue,
                                                     final Optional<String> meta,

--- a/code/app/be/objectify/deadbolt/java/ConfigKeys.java
+++ b/code/app/be/objectify/deadbolt/java/ConfigKeys.java
@@ -16,6 +16,7 @@
 package be.objectify.deadbolt.java;
 
 import play.libs.F;
+import play.libs.typedmap.TypedKey;
 
 /**
  * @author Steve Chaloner (steve@objectify.be)
@@ -46,7 +47,7 @@ public class ConfigKeys
     public static final F.Tuple<String, String> CONSTRAINT_MODE_DEFAULT = new F.Tuple<>(CONSTRAINT_MODE,
                                                                                    ConstraintAnnotationMode.PROCESS_FIRST_CONSTRAINT_ONLY.toString());
 
-    public static final String PATTERN_INVERT = "deadbolt.pattern.invert";
+    public static final TypedKey<Boolean> PATTERN_INVERT = TypedKey.create("deadbolt.pattern.invert");
 
     private ConfigKeys()
     {

--- a/code/app/be/objectify/deadbolt/java/ConfigKeys.java
+++ b/code/app/be/objectify/deadbolt/java/ConfigKeys.java
@@ -15,42 +15,14 @@
  */
 package be.objectify.deadbolt.java;
 
-import play.libs.F;
 import play.libs.typedmap.TypedKey;
 
 /**
  * @author Steve Chaloner (steve@objectify.be)
  */
-public class ConfigKeys
+public final class ConfigKeys
 {
     public static final String DEFAULT_HANDLER_KEY = "defaultHandler";
 
-    public static final String CACHE_DEADBOLT_USER = "deadbolt.java.cache-user";
-    public static final F.Tuple<String, Boolean> CACHE_DEADBOLT_USER_DEFAULT = new F.Tuple<>(CACHE_DEADBOLT_USER,
-                                                                                             false);
-
-    public static final String CACHE_BEFORE_AUTH_CHECK = "deadbolt.java.cache-before-auth-check";
-    public static final F.Tuple<String, Boolean> CACHE_BEFORE_AUTH_CHECK_DEFAULT = new F.Tuple<>(CACHE_BEFORE_AUTH_CHECK,
-                                                                                             false);
-
-    public static final String DEFAULT_VIEW_TIMEOUT = "deadbolt.java.view-timeout";
-    public static final F.Tuple<String, Long> DEFAULT_VIEW_TIMEOUT_DEFAULT = new F.Tuple<>(DEFAULT_VIEW_TIMEOUT,
-                                                                                           1000L);
-    public static final String BLOCKING = "deadbolt.java.blocking";
-    public static final F.Tuple<String, Boolean> BLOCKING_DEFAULT = new F.Tuple<>(BLOCKING,
-                                                                                  false);
-    public static final String DEFAULT_BLOCKING_TIMEOUT = "deadbolt.java.blocking-timeout";
-    public static final F.Tuple<String, Long> DEFAULT_BLOCKING_TIMEOUT_DEFAULT = new F.Tuple<>(DEFAULT_BLOCKING_TIMEOUT,
-                                                                                               1000L);
-
-    public static final String CONSTRAINT_MODE = "deadbolt.java.constraint-mode";
-    public static final F.Tuple<String, String> CONSTRAINT_MODE_DEFAULT = new F.Tuple<>(CONSTRAINT_MODE,
-                                                                                   ConstraintAnnotationMode.PROCESS_FIRST_CONSTRAINT_ONLY.toString());
-
     public static final TypedKey<Boolean> PATTERN_INVERT = TypedKey.create("deadbolt.pattern.invert");
-
-    private ConfigKeys()
-    {
-        // no-op
-    }
 }

--- a/code/app/be/objectify/deadbolt/java/Constants.java
+++ b/code/app/be/objectify/deadbolt/java/Constants.java
@@ -20,7 +20,7 @@ import play.libs.typedmap.TypedKey;
 /**
  * @author Steve Chaloner (steve@objectify.be)
  */
-public final class ConfigKeys
+public final class Constants
 {
     public static final String DEFAULT_HANDLER_KEY = "defaultHandler";
 

--- a/code/app/be/objectify/deadbolt/java/ConstraintLogic.java
+++ b/code/app/be/objectify/deadbolt/java/ConstraintLogic.java
@@ -291,7 +291,7 @@ public class ConstraintLogic
                                           final TriFunction<Http.RequestHeader, DeadboltHandler, Optional<String>, CompletionStage<T>> fail,
                                           final ConstraintPoint constraintPoint)
     {
-        final Http.RequestHeader requestHeaderWithAttr = requestHeader.addAttr(ConfigKeys.PATTERN_INVERT,
+        final Http.RequestHeader requestHeaderWithAttr = requestHeader.addAttr(Constants.PATTERN_INVERT,
                      invert);
         return deadboltHandler.getDynamicResourceHandler(requestHeaderWithAttr)
                               .thenApply(option -> option.orElseGet(() -> ExceptionThrowingDynamicResourceHandler.INSTANCE))

--- a/code/app/be/objectify/deadbolt/java/ConstraintLogic.java
+++ b/code/app/be/objectify/deadbolt/java/ConstraintLogic.java
@@ -20,6 +20,7 @@ import be.objectify.deadbolt.java.cache.SubjectCache;
 import be.objectify.deadbolt.java.models.PatternType;
 import be.objectify.deadbolt.java.models.Subject;
 import be.objectify.deadbolt.java.utils.TriFunction;
+import play.libs.F;
 import play.mvc.Http;
 
 import javax.inject.Inject;
@@ -378,11 +379,11 @@ public class ConstraintLogic
                 });
     }
 
-    protected CompletionStage<Optional<? extends Subject>> getSubject(final Http.Context ctx,
-                                                                      final DeadboltHandler deadboltHandler)
+    protected CompletionStage<F.Tuple<Optional<? extends Subject>, Http.RequestHeader>> getSubject(final Http.RequestHeader requestHeader,
+                                                                                                   final DeadboltHandler deadboltHandler)
     {
         return subjectCache.apply(deadboltHandler,
-                                  ctx);
+                                  requestHeader);
     }
 
     /**

--- a/code/app/be/objectify/deadbolt/java/ConstraintLogic.java
+++ b/code/app/be/objectify/deadbolt/java/ConstraintLogic.java
@@ -291,15 +291,15 @@ public class ConstraintLogic
                                           final TriFunction<Http.RequestHeader, DeadboltHandler, Optional<String>, CompletionStage<T>> fail,
                                           final ConstraintPoint constraintPoint)
     {
-        requestHeader.args.put(ConfigKeys.PATTERN_INVERT,
+        final Http.RequestHeader requestHeaderWithAttr = requestHeader.addAttr(ConfigKeys.PATTERN_INVERT,
                      invert);
-        return deadboltHandler.getDynamicResourceHandler(requestHeader)
+        return deadboltHandler.getDynamicResourceHandler(requestHeaderWithAttr)
                               .thenApply(option -> option.orElseGet(() -> ExceptionThrowingDynamicResourceHandler.INSTANCE))
                               .thenCompose(resourceHandler -> resourceHandler.checkPermission(values[valueIndex],
                                                                                               meta,
                                                                                               deadboltHandler,
-                                                                                              requestHeader))
-                              .thenCompose(allowed -> (invert ? !allowed : allowed) ? (successCallAgain(mode, values, valueIndex) ? custom(requestHeader,
+                                                                                              requestHeaderWithAttr))
+                              .thenCompose(allowed -> (invert ? !allowed : allowed) ? (successCallAgain(mode, values, valueIndex) ? custom(requestHeaderWithAttr,
                                                                                                                                            deadboltHandler,
                                                                                                                                            content,
                                                                                                                                            values,
@@ -310,12 +310,12 @@ public class ConstraintLogic
                                                                                                                                            pass,
                                                                                                                                            fail,
                                                                                                                                            constraintPoint)
-                                                                                                                                  : pass(requestHeader,
+                                                                                                                                  : pass(requestHeaderWithAttr,
                                                                                                                                          deadboltHandler,
                                                                                                                                          pass,
                                                                                                                                          constraintPoint,
                                                                                                                                          "pattern - custom"))
-                                                                                    : (failCallAgain(mode, values, valueIndex) ? custom(requestHeader,
+                                                                                    : (failCallAgain(mode, values, valueIndex) ? custom(requestHeaderWithAttr,
                                                                                                                                         deadboltHandler,
                                                                                                                                         content,
                                                                                                                                         values,
@@ -326,7 +326,7 @@ public class ConstraintLogic
                                                                                                                                         pass,
                                                                                                                                         fail,
                                                                                                                                         constraintPoint)
-                                                                                                                               : fail.apply(requestHeader,
+                                                                                                                               : fail.apply(requestHeaderWithAttr,
                                                                                                                                             deadboltHandler,
                                                                                                                                             content)));
     }

--- a/code/app/be/objectify/deadbolt/java/ConstraintLogic.java
+++ b/code/app/be/objectify/deadbolt/java/ConstraintLogic.java
@@ -56,75 +56,75 @@ public class ConstraintLogic
         this.patternCache = patternCache;
     }
 
-    public <T> CompletionStage<T> subjectPresent(final Http.Context ctx,
+    public <T> CompletionStage<T> subjectPresent(final Http.RequestHeader requestHeader,
                                                  final DeadboltHandler deadboltHandler,
                                                  final Optional<String> content,
-                                                 final TriFunction<Http.Context, DeadboltHandler, Optional<String>, CompletionStage<T>> present,
-                                                 final TriFunction<Http.Context, DeadboltHandler, Optional<String>, CompletionStage<T>> notPresent,
+                                                 final TriFunction<Http.RequestHeader, DeadboltHandler, Optional<String>, CompletionStage<T>> present,
+                                                 final TriFunction<Http.RequestHeader, DeadboltHandler, Optional<String>, CompletionStage<T>> notPresent,
                                                  final ConstraintPoint constraintPoint)
     {
-        return subjectTest(ctx,
+        return subjectTest(requestHeader,
                            deadboltHandler,
                            content,
-                           (context, handler, cnt) ->
+                           (rh, handler, cnt) ->
                            {
-                               handler.onAuthSuccess(context,
+                               handler.onAuthSuccess(rh,
                                                      "subjectPresent",
                                                      constraintPoint);
-                               return present.apply(context,
+                               return present.apply(rh,
                                                     handler,
                                                     cnt);
                            },
                            notPresent);
     }
 
-    public <T> CompletionStage<T> subjectNotPresent(final Http.Context ctx,
+    public <T> CompletionStage<T> subjectNotPresent(final Http.RequestHeader requestHeader,
                                                     final DeadboltHandler deadboltHandler,
                                                     final Optional<String> content,
-                                                    final TriFunction<Http.Context, DeadboltHandler, Optional<String>, CompletionStage<T>> present,
-                                                    final TriFunction<Http.Context, DeadboltHandler, Optional<String>, CompletionStage<T>> notPresent,
+                                                    final TriFunction<Http.RequestHeader, DeadboltHandler, Optional<String>, CompletionStage<T>> present,
+                                                    final TriFunction<Http.RequestHeader, DeadboltHandler, Optional<String>, CompletionStage<T>> notPresent,
                                                     final ConstraintPoint constraintPoint)
     {
-        return subjectTest(ctx,
+        return subjectTest(requestHeader,
                            deadboltHandler,
                            content,
                            present,
-                           (context, handler, cnt) ->
+                           (rh, handler, cnt) ->
                            {
-                               handler.onAuthSuccess(context,
+                               handler.onAuthSuccess(rh,
                                                      "subjectNotPresent",
                                                      constraintPoint);
-                               return notPresent.apply(context,
+                               return notPresent.apply(rh,
                                                     handler,
                                                     cnt);
                            });
     }
 
-    private <T> CompletionStage<T> subjectTest(final Http.Context ctx,
+    private <T> CompletionStage<T> subjectTest(final Http.RequestHeader requestHeader,
                                                final DeadboltHandler deadboltHandler,
                                                final Optional<String> content,
-                                               final TriFunction<Http.Context, DeadboltHandler, Optional<String>, CompletionStage<T>> present,
-                                               final TriFunction<Http.Context, DeadboltHandler, Optional<String>, CompletionStage<T>> notPresent)
+                                               final TriFunction<Http.RequestHeader, DeadboltHandler, Optional<String>, CompletionStage<T>> present,
+                                               final TriFunction<Http.RequestHeader, DeadboltHandler, Optional<String>, CompletionStage<T>> notPresent)
     {
-        return getSubject(ctx,
+        return getSubject(requestHeader,
                           deadboltHandler)
-                .thenCompose(maybeSubject -> maybeSubject.map(subject -> present.apply(ctx,
+                .thenCompose(maybeSubject -> maybeSubject.map(subject -> present.apply(requestHeader,
                                                                                        deadboltHandler,
                                                                                        content))
-                                                         .orElseGet(() -> notPresent.apply(ctx,
+                                                         .orElseGet(() -> notPresent.apply(requestHeader,
                                                                                            deadboltHandler,
                                                                                            content)));
     }
 
-    public <T> CompletionStage<T> restrict(final Http.Context ctx,
+    public <T> CompletionStage<T> restrict(final Http.RequestHeader requestHeader,
                                            final DeadboltHandler deadboltHandler,
                                            final Optional<String> content,
                                            final Supplier<List<String[]>> roleGroupSupplier,
-                                           final Function<Http.Context, CompletionStage<T>> pass,
-                                           final TriFunction<Http.Context, DeadboltHandler, Optional<String>, CompletionStage<T>> fail,
+                                           final Function<Http.RequestHeader, CompletionStage<T>> pass,
+                                           final TriFunction<Http.RequestHeader, DeadboltHandler, Optional<String>, CompletionStage<T>> fail,
                                            final ConstraintPoint constraintPoint)
     {
-        return getSubject(ctx,
+        return getSubject(requestHeader,
                           deadboltHandler)
                 .thenCompose(subjectOption ->
                                   {
@@ -138,26 +138,26 @@ public class ConstraintLogic
                                                                           roleGroups.get(i));
                                           }
                                       }
-                                      return roleOk ? pass(ctx,
+                                      return roleOk ? pass(requestHeader,
                                                            deadboltHandler,
                                                            pass,
                                                            constraintPoint,
                                                            "restrict")
-                                                    : fail.apply(ctx,
+                                                    : fail.apply(requestHeader,
                                                                  deadboltHandler,
                                                                  content);
                                   });
     }
 
-    public <T> CompletionStage<T> roleBasedPermissions(final Http.Context ctx,
+    public <T> CompletionStage<T> roleBasedPermissions(final Http.RequestHeader requestHeader,
                                                        final DeadboltHandler deadboltHandler,
                                                        final Optional<String> content,
                                                        final String roleName,
-                                                       final Function<Http.Context, CompletionStage<T>> pass,
-                                                       final TriFunction<Http.Context, DeadboltHandler, Optional<String>, CompletionStage<T>> fail,
+                                                       final Function<Http.RequestHeader, CompletionStage<T>> pass,
+                                                       final TriFunction<Http.RequestHeader, DeadboltHandler, Optional<String>, CompletionStage<T>> fail,
                                                        final ConstraintPoint constraintPoint)
     {
-        return getSubject(ctx,
+        return getSubject(requestHeader,
                           deadboltHandler)
                 .thenCompose(maybeSubject -> maybeSubject.isPresent() ? deadboltHandler.getPermissionsForRole(roleName)
                                                                                        .thenApply(permissions -> permissions.stream()
@@ -169,32 +169,32 @@ public class ConstraintLogic
                                                                                                                             .isPresent())
 
                                                                       : CompletableFuture.completedFuture(false))
-                .thenCompose(allowed -> allowed ? pass(ctx,
+                .thenCompose(allowed -> allowed ? pass(requestHeader,
                                                             deadboltHandler,
                                                             pass,
                                                             constraintPoint,
                                                             "roleBasedPermissions")
-                                                     : fail.apply(ctx,
+                                                     : fail.apply(requestHeader,
                                                                   deadboltHandler,
                                                                   content));
 
     }
 
-    public <T> CompletionStage<T> pattern(final Http.Context ctx,
+    public <T> CompletionStage<T> pattern(final Http.RequestHeader requestHeader,
                                           final DeadboltHandler deadboltHandler,
                                           final Optional<String> content,
                                           final String value,
                                           final PatternType patternType,
                                           final Optional<String> meta,
                                           final boolean invert,
-                                          final Function<Http.Context, CompletionStage<T>> pass,
-                                          final TriFunction<Http.Context, DeadboltHandler, Optional<String>, CompletionStage<T>> fail,
+                                          final Function<Http.RequestHeader, CompletionStage<T>> pass,
+                                          final TriFunction<Http.RequestHeader, DeadboltHandler, Optional<String>, CompletionStage<T>> fail,
                                           final ConstraintPoint constraintPoint)
     {
-        return pattern(ctx, deadboltHandler, content, new String[] {value}, null, patternType, meta, invert, pass, fail, constraintPoint);
+        return pattern(requestHeader, deadboltHandler, content, new String[] {value}, null, patternType, meta, invert, pass, fail, constraintPoint);
     }
 
-    public <T> CompletionStage<T> pattern(final Http.Context ctx,
+    public <T> CompletionStage<T> pattern(final Http.RequestHeader requestHeader,
                                           final DeadboltHandler deadboltHandler,
                                           final Optional<String> content,
                                           final String[] values,
@@ -202,8 +202,8 @@ public class ConstraintLogic
                                           final PatternType patternType,
                                           final Optional<String> meta,
                                           final boolean invert,
-                                          final Function<Http.Context, CompletionStage<T>> pass,
-                                          final TriFunction<Http.Context, DeadboltHandler, Optional<String>, CompletionStage<T>> fail,
+                                          final Function<Http.RequestHeader, CompletionStage<T>> pass,
+                                          final TriFunction<Http.RequestHeader, DeadboltHandler, Optional<String>, CompletionStage<T>> fail,
                                           final ConstraintPoint constraintPoint)
     {
         final CompletionStage<T> result;
@@ -211,7 +211,7 @@ public class ConstraintLogic
         switch (patternType)
         {
             case EQUALITY:
-                result = equality(ctx,
+                result = equality(requestHeader,
                                   deadboltHandler,
                                   content,
                                   values,
@@ -223,7 +223,7 @@ public class ConstraintLogic
                                   constraintPoint);
                 break;
             case REGEX:
-                result = regex(ctx,
+                result = regex(requestHeader,
                                deadboltHandler,
                                content,
                                values,
@@ -235,7 +235,7 @@ public class ConstraintLogic
                                constraintPoint);
                 break;
             case CUSTOM:
-                result = custom(ctx,
+                result = custom(requestHeader,
                                 deadboltHandler,
                                 content,
                                 values,
@@ -254,32 +254,32 @@ public class ConstraintLogic
         return result;
     }
 
-    public <T> CompletionStage<T> dynamic(final Http.Context ctx,
+    public <T> CompletionStage<T> dynamic(final Http.RequestHeader requestHeader,
                                           final DeadboltHandler deadboltHandler,
                                           final Optional<String> content,
                                           final String name,
                                           final Optional<String> meta,
-                                          final Function<Http.Context, CompletionStage<T>> pass,
-                                          final TriFunction<Http.Context, DeadboltHandler, Optional<String>, CompletionStage<T>> fail,
+                                          final Function<Http.RequestHeader, CompletionStage<T>> pass,
+                                          final TriFunction<Http.RequestHeader, DeadboltHandler, Optional<String>, CompletionStage<T>> fail,
                                           final ConstraintPoint constraintPoint)
     {
-        return deadboltHandler.getDynamicResourceHandler(ctx)
+        return deadboltHandler.getDynamicResourceHandler(requestHeader)
                               .thenApply(option -> option.orElseGet(() -> ExceptionThrowingDynamicResourceHandler.INSTANCE))
                               .thenCompose(drh -> drh.isAllowed(name,
                                                                 meta,
                                                                 deadboltHandler,
-                                                                ctx))
-                              .thenCompose(allowed -> allowed ? pass(ctx,
+                                                                requestHeader))
+                              .thenCompose(allowed -> allowed ? pass(requestHeader,
                                                                           deadboltHandler,
                                                                           pass,
                                                                           constraintPoint,
                                                                           "dynamic")
-                                                                   : fail.apply(ctx,
+                                                                   : fail.apply(requestHeader,
                                                                                 deadboltHandler,
                                                                                 content));
     }
 
-    private <T> CompletionStage<T> custom(final Http.Context ctx,
+    private <T> CompletionStage<T> custom(final Http.RequestHeader requestHeader,
                                           final DeadboltHandler deadboltHandler,
                                           final Optional<String> content,
                                           final String[] values,
@@ -287,19 +287,19 @@ public class ConstraintLogic
                                           final ConstraintMode mode,
                                           final Optional<String> meta,
                                           final boolean invert,
-                                          final Function<Http.Context, CompletionStage<T>> pass,
-                                          final TriFunction<Http.Context, DeadboltHandler, Optional<String>, CompletionStage<T>> fail,
+                                          final Function<Http.RequestHeader, CompletionStage<T>> pass,
+                                          final TriFunction<Http.RequestHeader, DeadboltHandler, Optional<String>, CompletionStage<T>> fail,
                                           final ConstraintPoint constraintPoint)
     {
-        ctx.args.put(ConfigKeys.PATTERN_INVERT,
+        requestHeader.args.put(ConfigKeys.PATTERN_INVERT,
                      invert);
-        return deadboltHandler.getDynamicResourceHandler(ctx)
+        return deadboltHandler.getDynamicResourceHandler(requestHeader)
                               .thenApply(option -> option.orElseGet(() -> ExceptionThrowingDynamicResourceHandler.INSTANCE))
                               .thenCompose(resourceHandler -> resourceHandler.checkPermission(values[valueIndex],
                                                                                               meta,
                                                                                               deadboltHandler,
-                                                                                              ctx))
-                              .thenCompose(allowed -> (invert ? !allowed : allowed) ? (successCallAgain(mode, values, valueIndex) ? custom(ctx,
+                                                                                              requestHeader))
+                              .thenCompose(allowed -> (invert ? !allowed : allowed) ? (successCallAgain(mode, values, valueIndex) ? custom(requestHeader,
                                                                                                                                            deadboltHandler,
                                                                                                                                            content,
                                                                                                                                            values,
@@ -310,12 +310,12 @@ public class ConstraintLogic
                                                                                                                                            pass,
                                                                                                                                            fail,
                                                                                                                                            constraintPoint)
-                                                                                                                                  : pass(ctx,
+                                                                                                                                  : pass(requestHeader,
                                                                                                                                          deadboltHandler,
                                                                                                                                          pass,
                                                                                                                                          constraintPoint,
                                                                                                                                          "pattern - custom"))
-                                                                                    : (failCallAgain(mode, values, valueIndex) ? custom(ctx,
+                                                                                    : (failCallAgain(mode, values, valueIndex) ? custom(requestHeader,
                                                                                                                                         deadboltHandler,
                                                                                                                                         content,
                                                                                                                                         values,
@@ -326,29 +326,29 @@ public class ConstraintLogic
                                                                                                                                         pass,
                                                                                                                                         fail,
                                                                                                                                         constraintPoint)
-                                                                                                                               : fail.apply(ctx,
+                                                                                                                               : fail.apply(requestHeader,
                                                                                                                                             deadboltHandler,
                                                                                                                                             content)));
     }
 
-    private <T> CompletionStage<T> equality(final Http.Context ctx,
+    private <T> CompletionStage<T> equality(final Http.RequestHeader requestHeader,
                                             final DeadboltHandler deadboltHandler,
                                             final Optional<String> content,
                                             final String[] values,
                                             final int valueIndex,
                                             final ConstraintMode mode,
                                             final boolean invert,
-                                            final Function<Http.Context, CompletionStage<T>> pass,
-                                            final TriFunction<Http.Context, DeadboltHandler, Optional<String>, CompletionStage<T>> fail,
+                                            final Function<Http.RequestHeader, CompletionStage<T>> pass,
+                                            final TriFunction<Http.RequestHeader, DeadboltHandler, Optional<String>, CompletionStage<T>> fail,
                                             final ConstraintPoint constraintPoint)
     {
-        return getSubject(ctx,
+        return getSubject(requestHeader,
                           deadboltHandler)
                 .thenCompose(subject -> {
                                       final boolean equal = subject.isPresent() ? analyzer.checkPatternEquality(subject,
                                                                                                                 Optional.ofNullable(values[valueIndex]))
                                                                                 : invert; // this is a little clumsy - it means no subject + invert is still denied
-                                      return (invert ? !equal : equal) ? (successCallAgain(mode, values, valueIndex) ? equality(ctx,
+                                      return (invert ? !equal : equal) ? (successCallAgain(mode, values, valueIndex) ? equality(requestHeader,
                                                                                                                                 deadboltHandler,
                                                                                                                                 content,
                                                                                                                                 values,
@@ -358,12 +358,12 @@ public class ConstraintLogic
                                                                                                                                 pass,
                                                                                                                                 fail,
                                                                                                                                 constraintPoint)
-                                                                                                                     : pass(ctx,
+                                                                                                                     : pass(requestHeader,
                                                                                                                             deadboltHandler,
                                                                                                                             pass,
                                                                                                                             constraintPoint,
                                                                                                                             "pattern - equality"))
-                                                                       : (failCallAgain(mode, values, valueIndex) ? equality(ctx,
+                                                                       : (failCallAgain(mode, values, valueIndex) ? equality(requestHeader,
                                                                                                                              deadboltHandler,
                                                                                                                              content,
                                                                                                                              values,
@@ -373,7 +373,7 @@ public class ConstraintLogic
                                                                                                                              pass,
                                                                                                                              fail,
                                                                                                                              constraintPoint)
-                                                                                                                  : fail.apply(ctx,
+                                                                                                                  : fail.apply(requestHeader,
                                                                                                                                deadboltHandler,
                                                                                                                                content));
                 });
@@ -389,31 +389,31 @@ public class ConstraintLogic
     /**
      * Checks access to the resource based on the regex
      *
-     * @param ctx             the HTTP context
+     * @param requestHeader             the HTTP request header
      * @param deadboltHandler the Deadbolt handler
      * @param invert          if true, invert the application of the constraint
      * @return the necessary result
      */
-    private <T> CompletionStage<T> regex(final Http.Context ctx,
+    private <T> CompletionStage<T> regex(final Http.RequestHeader requestHeader,
                                          final DeadboltHandler deadboltHandler,
                                          final Optional<String> content,
                                          final String[] values,
                                          final int valueIndex,
                                          final ConstraintMode mode,
                                          final boolean invert,
-                                         final Function<Http.Context, CompletionStage<T>> pass,
-                                         final TriFunction<Http.Context, DeadboltHandler, Optional<String>, CompletionStage<T>> fail,
+                                         final Function<Http.RequestHeader, CompletionStage<T>> pass,
+                                         final TriFunction<Http.RequestHeader, DeadboltHandler, Optional<String>, CompletionStage<T>> fail,
                                          final ConstraintPoint constraintPoint)
     {
         return CompletableFuture.completedFuture(patternCache.apply(values[valueIndex]))
-                                .thenCombine(getSubject(ctx,
+                                .thenCombine(getSubject(requestHeader,
                                                              deadboltHandler),
                                              (patternValue, subject) ->
                                                      subject.isPresent() ? analyzer.checkRegexPattern(subject,
                                                                                                       Optional.ofNullable(patternValue))
                                                                          : invert) // this is a little clumsy - it means no subject + invert is still denied
 
-                                .thenCompose(hasPassed -> (invert ? !hasPassed : hasPassed) ? (successCallAgain(mode, values, valueIndex) ? regex(ctx,
+                                .thenCompose(hasPassed -> (invert ? !hasPassed : hasPassed) ? (successCallAgain(mode, values, valueIndex) ? regex(requestHeader,
                                                                                                                                                   deadboltHandler,
                                                                                                                                                   content,
                                                                                                                                                   values,
@@ -423,12 +423,12 @@ public class ConstraintLogic
                                                                                                                                                   pass,
                                                                                                                                                   fail,
                                                                                                                                                   constraintPoint)
-                                                                                                                                          : pass(ctx,
+                                                                                                                                          : pass(requestHeader,
                                                                                                                                                  deadboltHandler,
                                                                                                                                                  pass,
                                                                                                                                                  constraintPoint,
                                                                                                                                                  "pattern - regex"))
-                                                                                            : (failCallAgain(mode, values, valueIndex) ? regex(ctx,
+                                                                                            : (failCallAgain(mode, values, valueIndex) ? regex(requestHeader,
                                                                                                                                                deadboltHandler,
                                                                                                                                                content,
                                                                                                                                                values,
@@ -438,7 +438,7 @@ public class ConstraintLogic
                                                                                                                                                pass,
                                                                                                                                                fail,
                                                                                                                                                constraintPoint)
-                                                                                                                                       : fail.apply(ctx,
+                                                                                                                                       : fail.apply(requestHeader,
                                                                                                                                                     deadboltHandler,
                                                                                                                                                     content)));
     }
@@ -463,15 +463,15 @@ public class ConstraintLogic
         return false;
     }
 
-    private <T> CompletionStage<T> pass(final Http.Context context,
+    private <T> CompletionStage<T> pass(final Http.RequestHeader requestHeader,
                                         final DeadboltHandler handler,
-                                        final Function<Http.Context, CompletionStage<T>> pass,
+                                        final Function<Http.RequestHeader, CompletionStage<T>> pass,
                                         final ConstraintPoint constraintPoint,
                                         final String constraintType)
     {
-        handler.onAuthSuccess(context,
+        handler.onAuthSuccess(requestHeader,
                               constraintType,
                               constraintPoint);
-        return pass.apply(context);
+        return pass.apply(requestHeader);
     }
 }

--- a/code/app/be/objectify/deadbolt/java/DeadboltHandler.java
+++ b/code/app/be/objectify/deadbolt/java/DeadboltHandler.java
@@ -48,39 +48,39 @@ public interface DeadboltHandler
      * Invoked immediately before controller restrictions are checked. This forms the integration with any
      * authentication actions that may need to occur.
      *
-     * @param context the HTTP context
+     * @param requestHeader the HTTP request header
      * @return the action result if an action other than the delegate must be taken, otherwise null. For a case where
      * the user is authenticated (or whatever your test condition is), this will be null otherwise the restriction
      * won't be applied.
      */
-    CompletionStage<Optional<Result>> beforeAuthCheck(Http.Context context, Optional<String> content);
+    CompletionStage<Optional<Result>> beforeAuthCheck(Http.RequestHeader requestHeader, Optional<String> content);
 
     /**
      * Gets the current {@link Subject}, e.g. the current user.
      *
-     * @param context the HTTP context
+     * @param requestHeader the HTTP request header
      * @return the current subject
      */
-    CompletionStage<Optional<? extends Subject>> getSubject(Http.Context context);
+    CompletionStage<Optional<? extends Subject>> getSubject(Http.RequestHeader requestHeader);
 
     /**
      * Invoked when an access failure is detected on <i>controllerClassName</i>.
      *
-     * @param context the HTTP context
+     * @param requestHeader the HTTP request header
      * @param content the content type hint.  This can be used to return a response in the appropriate content
      *                type, e.g. JSON
      * @return the action result
      */
-    CompletionStage<Result> onAuthFailure(Http.Context context,
+    CompletionStage<Result> onAuthFailure(Http.RequestHeader requestHeader,
                                           Optional<String> content);
 
     /**
      * Gets the handler used for dealing with resources restricted to specific users/groups.
      *
-     * @param context the HTTP context
+     * @param requestHeader the HTTP request header
      * @return the handler for restricted resources. May be null.
      */
-    CompletionStage<Optional<DynamicResourceHandler>> getDynamicResourceHandler(Http.Context context);
+    CompletionStage<Optional<DynamicResourceHandler>> getDynamicResourceHandler(Http.RequestHeader requestHeader);
 
     /**
      * Gets the canonical name of the handler.  Defaults to the class name.
@@ -95,11 +95,11 @@ public interface DeadboltHandler
     /**
      * Invoked when access to a resource is authorized.
      *
-     * @param context the context, can be used to get various bits of information such as the route and method
+     * @param requestHeader the request header, can be used to get various bits of information such as the route and method
      * @param constraintType the type of constraint, e.g. Dynamic, etc
      * @param constraintPoint the point at which the constraint was applied
      */
-    default void onAuthSuccess(final Http.Context context,
+    default void onAuthSuccess(final Http.RequestHeader requestHeader,
                                final String constraintType,
                                final ConstraintPoint constraintPoint) {
         // no-op

--- a/code/app/be/objectify/deadbolt/java/DeadboltModule.java
+++ b/code/app/be/objectify/deadbolt/java/DeadboltModule.java
@@ -25,13 +25,14 @@ import be.objectify.deadbolt.java.cache.SubjectCache;
 import be.objectify.deadbolt.java.cache.BeforeAuthCheckCache;
 import be.objectify.deadbolt.java.composite.ConstraintBuilders;
 import be.objectify.deadbolt.java.filters.FilterConstraints;
-import play.api.Configuration;
-import play.api.Environment;
-import play.api.inject.Binding;
-import play.api.inject.Module;
-import scala.collection.Seq;
+import com.typesafe.config.Config;
+import play.Environment;
+import play.inject.Binding;
+import play.inject.Module;
 
 import javax.inject.Singleton;
+import java.util.Arrays;
+import java.util.List;
 
 /**
  * @author Steve Chaloner (steve@objectify.be)
@@ -39,10 +40,10 @@ import javax.inject.Singleton;
 public class DeadboltModule extends Module
 {
     @Override
-    public Seq<Binding<?>> bindings(final Environment environment,
-                                    final Configuration configuration)
+    public List<Binding<?>> bindings(final Environment environment,
+                                     final Config config)
     {
-        return seq(subjectCache(),
+        return Arrays.asList(subjectCache(),
                    beforeAuthCheckCache(),
                    patternCache(),
                    analyzer(),
@@ -61,7 +62,7 @@ public class DeadboltModule extends Module
      */
     public Binding<TemplateFailureListenerProvider> templateFailureListenerProvider()
     {
-        return bind(TemplateFailureListenerProvider.class).toSelf().in(Singleton.class);
+        return bindClass(TemplateFailureListenerProvider.class).toSelf().in(Singleton.class);
     }
 
     /**
@@ -71,7 +72,7 @@ public class DeadboltModule extends Module
      */
     public Binding<ViewSupport> viewSupport()
     {
-        return bind(ViewSupport.class).toSelf().in(Singleton.class);
+        return bindClass(ViewSupport.class).toSelf().in(Singleton.class);
     }
 
     /**
@@ -81,7 +82,7 @@ public class DeadboltModule extends Module
      */
     public Binding<DeadboltAnalyzer> analyzer()
     {
-        return bind(DeadboltAnalyzer.class).toSelf().in(Singleton.class);
+        return bindClass(DeadboltAnalyzer.class).toSelf().in(Singleton.class);
     }
 
     /**
@@ -91,7 +92,7 @@ public class DeadboltModule extends Module
      */
     public Binding<ConstraintBuilders> constraintBuilders()
     {
-        return bind(ConstraintBuilders.class).toSelf().in(Singleton.class);
+        return bindClass(ConstraintBuilders.class).toSelf().in(Singleton.class);
     }
 
     /**
@@ -101,7 +102,7 @@ public class DeadboltModule extends Module
      */
     public Binding<PatternCache> patternCache()
     {
-        return bind(PatternCache.class).to(DefaultPatternCache.class).in(Singleton.class);
+        return bindClass(PatternCache.class).to(DefaultPatternCache.class).in(Singleton.class);
     }
 
     /**
@@ -111,7 +112,7 @@ public class DeadboltModule extends Module
      */
     public Binding<CompositeCache> compositeCache()
     {
-        return bind(CompositeCache.class).to(DefaultCompositeCache.class).in(Singleton.class);
+        return bindClass(CompositeCache.class).to(DefaultCompositeCache.class).in(Singleton.class);
     }
 
     /**
@@ -121,7 +122,7 @@ public class DeadboltModule extends Module
      */
     public Binding<SubjectCache> subjectCache()
     {
-        return bind(SubjectCache.class).to(DefaultSubjectCache.class).in(Singleton.class);
+        return bindClass(SubjectCache.class).to(DefaultSubjectCache.class).in(Singleton.class);
     }
 
     /**
@@ -131,7 +132,7 @@ public class DeadboltModule extends Module
      */
     public Binding<BeforeAuthCheckCache> beforeAuthCheckCache()
     {
-        return bind(BeforeAuthCheckCache.class).to(DefaultBeforeAuthCheckCache.class).in(Singleton.class);
+        return bindClass(BeforeAuthCheckCache.class).to(DefaultBeforeAuthCheckCache.class).in(Singleton.class);
     }
 
     /**
@@ -141,7 +142,7 @@ public class DeadboltModule extends Module
      */
     public Binding<ConstraintLogic> constraintLogic()
     {
-        return bind(ConstraintLogic.class).toSelf().in(Singleton.class);
+        return bindClass(ConstraintLogic.class).toSelf().in(Singleton.class);
     }
 
     /**
@@ -151,6 +152,6 @@ public class DeadboltModule extends Module
      */
     public Binding<FilterConstraints> filterConstraints()
     {
-        return bind(FilterConstraints.class).toSelf().in(Singleton.class);
+        return bindClass(FilterConstraints.class).toSelf().in(Singleton.class);
     }
 }

--- a/code/app/be/objectify/deadbolt/java/DynamicResourceHandler.java
+++ b/code/app/be/objectify/deadbolt/java/DynamicResourceHandler.java
@@ -63,13 +63,13 @@ public interface DynamicResourceHandler
      * @param name            the resource name
      * @param meta            additional information on the resource
      * @param deadboltHandler the current {@link DeadboltHandler}
-     * @param ctx             the context of the current request
+     * @param requestHeader             the current request header
      * @return true if access to the resource is allowed, otherwise false
      */
     CompletionStage<Boolean> isAllowed(String name,
                                        Optional<String> meta,
                                        DeadboltHandler deadboltHandler,
-                                       Http.Context ctx);
+                                       Http.RequestHeader requestHeader);
 
     /**
      * Invoked when a custom pattern needs checking..
@@ -77,11 +77,11 @@ public interface DynamicResourceHandler
      * @param permissionValue the permission value
      * @param meta            additional information on the resource
      * @param deadboltHandler the current {@link DeadboltHandler}
-     * @param ctx             the context of the current request
+     * @param requestHeader             the current request header
      * @return true if access based on the permission is  allowed, otherwise false
      */
     CompletionStage<Boolean> checkPermission(String permissionValue,
                                              Optional<String> meta,
                                              DeadboltHandler deadboltHandler,
-                                             Http.Context ctx);
+                                             Http.RequestHeader requestHeader);
 }

--- a/code/app/be/objectify/deadbolt/java/ExceptionThrowingDynamicResourceHandler.java
+++ b/code/app/be/objectify/deadbolt/java/ExceptionThrowingDynamicResourceHandler.java
@@ -38,7 +38,7 @@ public class ExceptionThrowingDynamicResourceHandler implements DynamicResourceH
     public CompletionStage<Boolean> isAllowed(final String name,
                                               final Optional<String> meta,
                                               final DeadboltHandler deadboltHandler,
-                                              final Http.Context ctx)
+                                              final Http.RequestHeader requestHeader)
     {
         throw new RuntimeException(String.format("A dynamic resource with name [%s] is specified but no dynamic resource handler is provided",
                                                  name));
@@ -48,7 +48,7 @@ public class ExceptionThrowingDynamicResourceHandler implements DynamicResourceH
     public CompletionStage<Boolean> checkPermission(final String permissionValue,
                                                     final Optional<String> meta,
                                                     final DeadboltHandler deadboltHandler,
-                                                    final Http.Context ctx)
+                                                    final Http.RequestHeader requestHeader)
     {
         throw new RuntimeException(String.format("A custom permission type is specified for value [%s] but no dynamic resource handler is provided",
                                                  permissionValue));

--- a/code/app/be/objectify/deadbolt/java/ViewSupport.java
+++ b/code/app/be/objectify/deadbolt/java/ViewSupport.java
@@ -42,7 +42,7 @@ public class ViewSupport
 {
     private static final Logger LOGGER = LoggerFactory.getLogger(ViewSupport.class);
 
-    public final Supplier<Long> defaultTimeout;
+    public final long timeout;
 
     private final HandlerCache handlerCache;
 
@@ -61,12 +61,9 @@ public class ViewSupport
         this.handlerCache = handlerCache;
         this.failureListener = failureListener.get();
         this.constraintLogic = constraintLogic;
-        final Long timeout = config.getLong("deadbolt.java.view-timeout");
-        LOGGER.info("Default timeout period for blocking views is [{}]ms",
-                    timeout);
-        this.defaultTimeout = () -> timeout;
-
-        timeoutHandler = (timeoutInMillis, e) ->
+        this.timeout = config.getLong("deadbolt.java.view-timeout");
+        LOGGER.info("Default timeout period for blocking views is [{}]ms", this.timeout);
+        this.timeoutHandler = (timeoutInMillis, e) ->
         {
             LOGGER.error("Timeout when attempting to complete future within [{}]ms.  Denying access to resource.",
                          timeoutInMillis,

--- a/code/app/be/objectify/deadbolt/java/ViewSupport.java
+++ b/code/app/be/objectify/deadbolt/java/ViewSupport.java
@@ -94,17 +94,17 @@ public class ViewSupport
                                 final DeadboltHandler handler,
                                 final Optional<String> content,
                                 final long timeoutInMillis,
-                                final Http.Context context) throws Throwable
+                                final Http.RequestHeader requestHeader) throws Throwable
     {
         boolean allowed;
         try
         {
-            allowed = constraintLogic.restrict(context,
+            allowed = constraintLogic.restrict(requestHeader,
                                                handler(handler),
                                                content,
                                                () -> roles,
-                                               ctx -> CompletableFuture.completedFuture(Boolean.TRUE),
-                                               (ctx, dh, cnt) -> CompletableFuture.completedFuture(Boolean.FALSE),
+                                               rh -> CompletableFuture.completedFuture(Boolean.TRUE),
+                                               (rh, dh, cnt) -> CompletableFuture.completedFuture(Boolean.FALSE),
                                                ConstraintPoint.TEMPLATE)
                                      .toCompletableFuture()
                                      .get(timeoutInMillis,
@@ -131,18 +131,18 @@ public class ViewSupport
                                final DeadboltHandler handler,
                                final Optional<String> content,
                                final long timeoutInMillis,
-                               final Http.Context context) throws Throwable
+                               final Http.RequestHeader requestHeader) throws Throwable
     {
         boolean allowed;
         try
         {
-            allowed = constraintLogic.dynamic(context,
+            allowed = constraintLogic.dynamic(requestHeader,
                                               handler(handler),
                                               content,
                                               name,
                                               meta,
-                                              ctx -> CompletableFuture.completedFuture(Boolean.TRUE),
-                                              (ctx, dh, cnt) -> CompletableFuture.completedFuture(Boolean.FALSE),
+                                              rh -> CompletableFuture.completedFuture(Boolean.TRUE),
+                                              (rh, dh, cnt) -> CompletableFuture.completedFuture(Boolean.FALSE),
                                               ConstraintPoint.TEMPLATE)
                                      .toCompletableFuture()
                                      .get(timeoutInMillis,
@@ -164,17 +164,17 @@ public class ViewSupport
     public boolean viewSubjectPresent(final DeadboltHandler handler,
                                       final Optional<String> content,
                                       final long timeoutInMillis,
-                                      final Http.Context context) throws Throwable
+                                      final Http.RequestHeader requestHeader) throws Throwable
     {
         boolean allowed;
         try
         {
-            allowed = constraintLogic.subjectPresent(context,
+            allowed = constraintLogic.subjectPresent(requestHeader,
                                                      handler == null ? handlerCache.get()
                                                                      : handler,
                                                      content,
-                                                     (ctx, dh, cnt) -> CompletableFuture.completedFuture(Boolean.TRUE),
-                                                     (ctx, dh, cnt) -> CompletableFuture.completedFuture(Boolean.FALSE),
+                                                     (rh, dh, cnt) -> CompletableFuture.completedFuture(Boolean.TRUE),
+                                                     (rh, dh, cnt) -> CompletableFuture.completedFuture(Boolean.FALSE),
                                                      ConstraintPoint.TEMPLATE)
                                      .toCompletableFuture()
                                      .get(timeoutInMillis,
@@ -196,16 +196,16 @@ public class ViewSupport
     public boolean viewSubjectNotPresent(final DeadboltHandler handler,
                                          final Optional<String> content,
                                          final long timeoutInMillis,
-                                         final Http.Context context) throws Throwable
+                                         final Http.RequestHeader requestHeader) throws Throwable
     {
         boolean allowed;
         try
         {
-            allowed = constraintLogic.subjectNotPresent(context,
+            allowed = constraintLogic.subjectNotPresent(requestHeader,
                                                         handler(handler),
                                                         content,
-                                                        (ctx, dh, cnt) -> CompletableFuture.completedFuture(Boolean.FALSE),
-                                                        (ctx, dh, cnt) -> CompletableFuture.completedFuture(Boolean.TRUE),
+                                                        (rh, dh, cnt) -> CompletableFuture.completedFuture(Boolean.FALSE),
+                                                        (rh, dh, cnt) -> CompletableFuture.completedFuture(Boolean.TRUE),
                                                         ConstraintPoint.TEMPLATE)
                                      .toCompletableFuture()
                                      .get(timeoutInMillis,
@@ -226,20 +226,20 @@ public class ViewSupport
                                final DeadboltHandler handler,
                                final Optional<String> content,
                                final long timeoutInMillis,
-                               final Http.Context context) throws Exception
+                               final Http.RequestHeader requestHeader) throws Exception
     {
         boolean allowed;
         try
         {
-            allowed = constraintLogic.pattern(context,
+            allowed = constraintLogic.pattern(requestHeader,
                                               handler(handler),
                                               content,
                                               value,
                                               patternType,
                                               meta,
                                               invert,
-                                              ctx -> CompletableFuture.completedFuture(Boolean.TRUE),
-                                              (ctx, dh, cnt) -> CompletableFuture.completedFuture(Boolean.FALSE),
+                                              rh -> CompletableFuture.completedFuture(Boolean.TRUE),
+                                              (rh, dh, cnt) -> CompletableFuture.completedFuture(Boolean.FALSE),
                                               ConstraintPoint.TEMPLATE)
                                      .toCompletableFuture()
                                      .get(timeoutInMillis,
@@ -264,17 +264,17 @@ public class ViewSupport
                                             final DeadboltHandler handler,
                                             final Optional<String> content,
                                             final long timeoutInMillis,
-                                            final Http.Context context) throws Throwable
+                                            final Http.RequestHeader requestHeader) throws Throwable
     {
         boolean allowed;
         try
         {
-            allowed = constraintLogic.roleBasedPermissions(context,
+            allowed = constraintLogic.roleBasedPermissions(requestHeader,
                                                            handler(handler),
                                                            content,
                                                            roleName,
-                                                           ctx -> CompletableFuture.completedFuture(Boolean.TRUE),
-                                                           (ctx, dh, cnt) -> CompletableFuture.completedFuture(Boolean.FALSE),
+                                                           rh -> CompletableFuture.completedFuture(Boolean.TRUE),
+                                                           (rh, dh, cnt) -> CompletableFuture.completedFuture(Boolean.FALSE),
                                                            ConstraintPoint.TEMPLATE)
                                      .toCompletableFuture()
                                      .get(timeoutInMillis,

--- a/code/app/be/objectify/deadbolt/java/ViewSupport.java
+++ b/code/app/be/objectify/deadbolt/java/ViewSupport.java
@@ -18,14 +18,12 @@ package be.objectify.deadbolt.java;
 import be.objectify.deadbolt.java.cache.HandlerCache;
 import be.objectify.deadbolt.java.models.PatternType;
 import com.typesafe.config.Config;
-import com.typesafe.config.ConfigFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import play.mvc.Http;
 
 import javax.inject.Inject;
 import javax.inject.Singleton;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
@@ -63,12 +61,7 @@ public class ViewSupport
         this.handlerCache = handlerCache;
         this.failureListener = failureListener.get();
         this.constraintLogic = constraintLogic;
-
-        final HashMap<String, Object> defaults = new HashMap<>();
-        defaults.put(ConfigKeys.DEFAULT_VIEW_TIMEOUT_DEFAULT._1,
-                     ConfigKeys.DEFAULT_VIEW_TIMEOUT_DEFAULT._2);
-        final Config configWithFallback = config.withFallback(ConfigFactory.parseMap(defaults));
-        final Long timeout = configWithFallback.getLong(ConfigKeys.DEFAULT_VIEW_TIMEOUT_DEFAULT._1);
+        final Long timeout = config.getLong("deadbolt.java.view-timeout");
         LOGGER.info("Default timeout period for blocking views is [{}]ms",
                     timeout);
         this.defaultTimeout = () -> timeout;

--- a/code/app/be/objectify/deadbolt/java/actions/AbstractDeadboltAction.java
+++ b/code/app/be/objectify/deadbolt/java/actions/AbstractDeadboltAction.java
@@ -15,7 +15,7 @@
  */
 package be.objectify.deadbolt.java.actions;
 
-import be.objectify.deadbolt.java.ConfigKeys;
+import be.objectify.deadbolt.java.Constants;
 import be.objectify.deadbolt.java.ConstraintAnnotationMode;
 import be.objectify.deadbolt.java.DeadboltHandler;
 import be.objectify.deadbolt.java.cache.BeforeAuthCheckCache;
@@ -87,7 +87,7 @@ public abstract class AbstractDeadboltAction<T> extends Action<T>
     {
         LOGGER.debug("Getting Deadbolt handler with key [{}]",
                      handlerKey);
-        return handlerKey == null || ConfigKeys.DEFAULT_HANDLER_KEY.equals(handlerKey) ? handlerCache.get()
+        return handlerKey == null || Constants.DEFAULT_HANDLER_KEY.equals(handlerKey) ? handlerCache.get()
                                                                                        : handlerCache.apply(handlerKey);
     }
 

--- a/code/app/be/objectify/deadbolt/java/actions/AbstractDeadboltAction.java
+++ b/code/app/be/objectify/deadbolt/java/actions/AbstractDeadboltAction.java
@@ -307,7 +307,7 @@ public abstract class AbstractDeadboltAction<T> extends Action<T>
 
     /**
      * Add a flag to the context to indicate the action has been blocked by the
-     * constraint and call {@link DeadboltHandler#onAuthFailure(Http.Context, Optional<String>)}.
+     * constraint and call {@link DeadboltHandler#onAuthFailure(Http.RequestHeader, Optional<String>)}.
      *
      * @param context the context
      * @param handler the relevant handler

--- a/code/app/be/objectify/deadbolt/java/actions/AbstractDeadboltAction.java
+++ b/code/app/be/objectify/deadbolt/java/actions/AbstractDeadboltAction.java
@@ -21,7 +21,6 @@ import be.objectify.deadbolt.java.DeadboltHandler;
 import be.objectify.deadbolt.java.cache.BeforeAuthCheckCache;
 import be.objectify.deadbolt.java.cache.HandlerCache;
 import com.typesafe.config.Config;
-import com.typesafe.config.ConfigFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import play.libs.F;
@@ -31,7 +30,6 @@ import play.mvc.Http;
 import play.mvc.Result;
 import play.mvc.Results;
 
-import java.util.HashMap;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
@@ -59,8 +57,6 @@ public abstract class AbstractDeadboltAction<T> extends Action<T>
 
     final BeforeAuthCheckCache beforeAuthCheckCache;
 
-    final Config config;
-
     public final boolean blocking;
     public final long blockingTimeout;
     public final ConstraintAnnotationMode constraintAnnotationMode;
@@ -73,19 +69,9 @@ public abstract class AbstractDeadboltAction<T> extends Action<T>
     {
         this.handlerCache = handlerCache;
         this.beforeAuthCheckCache = beforeAuthCheckCache;
-        this.config = config;
-
-        final HashMap<String, Object> defaults = new HashMap<>();
-        defaults.put(ConfigKeys.BLOCKING_DEFAULT._1,
-                     ConfigKeys.BLOCKING_DEFAULT._2);
-        defaults.put(ConfigKeys.DEFAULT_BLOCKING_TIMEOUT_DEFAULT._1,
-                     ConfigKeys.DEFAULT_BLOCKING_TIMEOUT_DEFAULT._2);
-        defaults.put(ConfigKeys.CONSTRAINT_MODE_DEFAULT._1,
-                     ConfigKeys.CONSTRAINT_MODE_DEFAULT._2);
-        final Config configWithFallback = config.withFallback(ConfigFactory.parseMap(defaults));
-        this.blocking = configWithFallback.getBoolean(ConfigKeys.BLOCKING_DEFAULT._1);
-        this.blockingTimeout = configWithFallback.getLong(ConfigKeys.DEFAULT_BLOCKING_TIMEOUT_DEFAULT._1);
-        this.constraintAnnotationMode = ConstraintAnnotationMode.valueOf(configWithFallback.getString(ConfigKeys.CONSTRAINT_MODE_DEFAULT._1));
+        this.blocking = config.getBoolean("deadbolt.java.blocking");
+        this.blockingTimeout = config.getLong("deadbolt.java.blocking-timeout");
+        this.constraintAnnotationMode = ConstraintAnnotationMode.valueOf(config.getString("deadbolt.java.constraint-mode"));
     }
 
     /**

--- a/code/app/be/objectify/deadbolt/java/actions/AbstractDeadboltAction.java
+++ b/code/app/be/objectify/deadbolt/java/actions/AbstractDeadboltAction.java
@@ -163,11 +163,11 @@ public abstract class AbstractDeadboltAction<T> extends Action<T>
     /**
      * Execute the action.
      *
-     * @param ctx the request context
+     * @param requestHeader the request header
      * @return the result
      * @throws Exception if something bad happens
      */
-    public abstract CompletionStage<Result> execute(final Http.Context ctx) throws Exception;
+    public abstract CompletionStage<Result> execute(final Http.RequestHeader requestHeader) throws Exception;
 
     /**
      * If a constraint is deferrable, i.e. method-level constraints are not applied until controller-level annotations are applied.

--- a/code/app/be/objectify/deadbolt/java/actions/AbstractDeadboltAction.java
+++ b/code/app/be/objectify/deadbolt/java/actions/AbstractDeadboltAction.java
@@ -105,9 +105,6 @@ public abstract class AbstractDeadboltAction<T> extends Action<T>
                                                                                        : handlerCache.apply(handlerKey);
     }
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public CompletionStage<Result> call(final Http.Request request)
     {

--- a/code/app/be/objectify/deadbolt/java/actions/AbstractDeadboltAction.java
+++ b/code/app/be/objectify/deadbolt/java/actions/AbstractDeadboltAction.java
@@ -24,6 +24,7 @@ import com.typesafe.config.Config;
 import com.typesafe.config.ConfigFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import play.libs.F;
 import play.mvc.Action;
 import play.mvc.Http;
 import play.mvc.Result;
@@ -279,13 +280,13 @@ public abstract class AbstractDeadboltAction<T> extends Action<T>
         return action;
     }
 
-    public CompletionStage<Optional<Result>> preAuth(final boolean forcePreAuthCheck,
-                                                     final Http.Context ctx,
-                                                     final Optional<String> content,
-                                                     final DeadboltHandler deadboltHandler)
+    public CompletionStage<F.Tuple<Optional<Result>, Http.RequestHeader>> preAuth(final boolean forcePreAuthCheck,
+                                                                                  final Http.RequestHeader requestHeader,
+                                                                                  final Optional<String> content,
+                                                                                  final DeadboltHandler deadboltHandler)
     {
-        return forcePreAuthCheck ? beforeAuthCheckCache.apply(deadboltHandler, ctx, content)
-                                 : CompletableFuture.completedFuture(Optional.empty());
+        return forcePreAuthCheck ? beforeAuthCheckCache.apply(deadboltHandler, requestHeader, content)
+                                 : CompletableFuture.completedFuture(F.Tuple(Optional.empty(), requestHeader));
     }
 
     /**

--- a/code/app/be/objectify/deadbolt/java/actions/AbstractRestrictiveAction.java
+++ b/code/app/be/objectify/deadbolt/java/actions/AbstractRestrictiveAction.java
@@ -48,15 +48,15 @@ public abstract class AbstractRestrictiveAction<T> extends AbstractDeadboltActio
     }
 
     @Override
-    public CompletionStage<Result> execute(final Http.Context ctx) throws Exception
+    public CompletionStage<Result> execute(final Http.RequestHeader request) throws Exception
     {
         final DeadboltHandler deadboltHandler = getDeadboltHandler(getHandlerKey());
         return preAuth(true,
-                         ctx,
+                         request,
                          getContent(),
                          deadboltHandler)
-                .thenCompose(preAuthResult -> preAuthResult.map(value -> (CompletionStage<Result>) CompletableFuture.completedFuture(value))
-                                                           .orElseGet(() -> applyRestriction(ctx,
+                .thenCompose(preAuthResult -> preAuthResult._1.map(value -> (CompletionStage<Result>) CompletableFuture.completedFuture(value))
+                                                           .orElseGet(() -> applyRestriction(preAuthResult._2,
                                                                                              deadboltHandler)));
     }
 
@@ -69,6 +69,6 @@ public abstract class AbstractRestrictiveAction<T> extends AbstractDeadboltActio
      */
     public abstract String getHandlerKey();
 
-    public abstract CompletionStage<Result> applyRestriction(Http.Context ctx,
+    public abstract CompletionStage<Result> applyRestriction(Http.RequestHeader request,
                                                              DeadboltHandler deadboltHandler);
 }

--- a/code/app/be/objectify/deadbolt/java/actions/AbstractSubjectAction.java
+++ b/code/app/be/objectify/deadbolt/java/actions/AbstractSubjectAction.java
@@ -49,28 +49,28 @@ public abstract class AbstractSubjectAction<T> extends AbstractDeadboltAction<T>
      * {@inheritDoc}
      */
     @Override
-    public CompletionStage<Result> execute(final Http.Context ctx) throws Exception
+    public CompletionStage<Result> execute(final Http.RequestHeader request) throws Exception
     {
         final DeadboltHandler deadboltHandler = getDeadboltHandler(getHandlerKey());
         return preAuth(isForceBeforeAuthCheck(),
-                         ctx,
+                         request,
                          getContent(),
                          deadboltHandler)
-                .thenCompose(preAuthResult -> preAuthResult.map(CompletableFuture::completedFuture)
+                .thenCompose(preAuthResult -> preAuthResult._1.map(CompletableFuture::completedFuture)
                                                            .orElseGet(testSubject(constraintLogic,
-                                                                                  ctx,
+                                                                                  preAuthResult._2,
                                                                                   deadboltHandler)));
     }
 
     abstract Supplier<CompletableFuture<Result>> testSubject(final ConstraintLogic constraintLogic,
-                                                              final Http.Context context,
+                                                              final Http.RequestHeader request,
                                                               final DeadboltHandler deadboltHandler);
 
-    abstract CompletionStage<Result> present(Http.Context context,
+    abstract CompletionStage<Result> present(Http.RequestHeader request,
                                              DeadboltHandler handler,
                                              Optional<String> content);
 
-    abstract CompletionStage<Result> notPresent(Http.Context context,
+    abstract CompletionStage<Result> notPresent(Http.RequestHeader request,
                                                 DeadboltHandler handler,
                                                 Optional<String> content);
 

--- a/code/app/be/objectify/deadbolt/java/actions/AbstractSubjectAction.java
+++ b/code/app/be/objectify/deadbolt/java/actions/AbstractSubjectAction.java
@@ -45,9 +45,6 @@ public abstract class AbstractSubjectAction<T> extends AbstractDeadboltAction<T>
         this.constraintLogic = constraintLogic;
     }
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public CompletionStage<Result> execute(final Http.RequestHeader request) throws Exception
     {

--- a/code/app/be/objectify/deadbolt/java/actions/BeforeAccess.java
+++ b/code/app/be/objectify/deadbolt/java/actions/BeforeAccess.java
@@ -15,7 +15,7 @@
  */
 package be.objectify.deadbolt.java.actions;
 
-import be.objectify.deadbolt.java.ConfigKeys;
+import be.objectify.deadbolt.java.Constants;
 import be.objectify.deadbolt.java.DeadboltHandler;
 import play.mvc.With;
 
@@ -55,7 +55,7 @@ public @interface BeforeAccess
      *
      * @return the key of the handler
      */
-    String handlerKey() default ConfigKeys.DEFAULT_HANDLER_KEY;
+    String handlerKey() default Constants.DEFAULT_HANDLER_KEY;
 
     /**
      * By default, if another Deadbolt action has already been executed in the same request and has allowed access,

--- a/code/app/be/objectify/deadbolt/java/actions/BeforeAccessAction.java
+++ b/code/app/be/objectify/deadbolt/java/actions/BeforeAccessAction.java
@@ -49,15 +49,15 @@ public class BeforeAccessAction extends AbstractDeadboltAction<BeforeAccess>
      * {@inheritDoc}
      */
     @Override
-    public CompletionStage<Result> execute(final Http.Context ctx) throws Exception
+    public CompletionStage<Result> execute(final Http.RequestHeader request) throws Exception
     {
         final DeadboltHandler deadboltHandler = getDeadboltHandler(getHandlerKey());
         return preAuth(true,
-                         ctx,
+                         request,
                          getContent(),
                          deadboltHandler)
-                .thenCompose(preAuthResult -> preAuthResult.map(value -> (CompletionStage<Result>) CompletableFuture.completedFuture(value))
-                                                           .orElseGet(() -> delegate.call(ctx)));
+                .thenCompose(preAuthResult -> preAuthResult._1.map(value -> (CompletionStage<Result>) CompletableFuture.completedFuture(value))
+                                                           .orElseGet(() -> delegate.call((Http.Request)preAuthResult._2)));
     }
 
     /**

--- a/code/app/be/objectify/deadbolt/java/actions/BeforeAccessAction.java
+++ b/code/app/be/objectify/deadbolt/java/actions/BeforeAccessAction.java
@@ -45,9 +45,6 @@ public class BeforeAccessAction extends AbstractDeadboltAction<BeforeAccess>
               config);
     }
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public CompletionStage<Result> execute(final Http.RequestHeader request) throws Exception
     {
@@ -60,9 +57,6 @@ public class BeforeAccessAction extends AbstractDeadboltAction<BeforeAccess>
                                                            .orElseGet(() -> delegate.call((Http.Request)preAuthResult._2)));
     }
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     protected boolean deferred() {
         return configuration.deferred();

--- a/code/app/be/objectify/deadbolt/java/actions/Composite.java
+++ b/code/app/be/objectify/deadbolt/java/actions/Composite.java
@@ -15,7 +15,7 @@
  */
 package be.objectify.deadbolt.java.actions;
 
-import be.objectify.deadbolt.java.ConfigKeys;
+import be.objectify.deadbolt.java.Constants;
 import play.mvc.With;
 
 import java.lang.annotation.Documented;
@@ -66,7 +66,7 @@ public @interface Composite
      *
      * @return the key of the handler
      */
-    String handlerKey() default ConfigKeys.DEFAULT_HANDLER_KEY;
+    String handlerKey() default Constants.DEFAULT_HANDLER_KEY;
 
     /**
      * If true, constraints will use the metadata defined in this annotation over any constraint-local

--- a/code/app/be/objectify/deadbolt/java/actions/CompositeAction.java
+++ b/code/app/be/objectify/deadbolt/java/actions/CompositeAction.java
@@ -63,9 +63,9 @@ public class CompositeAction extends AbstractRestrictiveAction<Composite>
                                                              Optional.ofNullable(configuration.meta()),
                                                              (globalMd, localMd) -> preferGlobalMeta ? globalMd.isPresent() ? globalMd : localMd
                                                                                                      : localMd.isPresent() ? localMd : globalMd)
-                                                       .thenCompose(allowed -> allowed ? authorizeAndExecute(request,
+                                                       .thenCompose(allowed -> allowed._1 ? authorizeAndExecute(allowed._2,
                                                                                                              handler)
-                                                                                       : unauthorizeAndFail(request,
+                                                                                       : unauthorizeAndFail(allowed._2,
                                                                                                             handler,
                                                                                                             getContent()));
                                   })

--- a/code/app/be/objectify/deadbolt/java/actions/CompositeAction.java
+++ b/code/app/be/objectify/deadbolt/java/actions/CompositeAction.java
@@ -74,9 +74,6 @@ public class CompositeAction extends AbstractRestrictiveAction<Composite>
                                                                  getContent()));
     }
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     protected boolean deferred() {
         return configuration.deferred();

--- a/code/app/be/objectify/deadbolt/java/actions/CompositeAction.java
+++ b/code/app/be/objectify/deadbolt/java/actions/CompositeAction.java
@@ -51,25 +51,25 @@ public class CompositeAction extends AbstractRestrictiveAction<Composite>
     }
 
     @Override
-    public CompletionStage<Result> applyRestriction(final Http.Context ctx,
+    public CompletionStage<Result> applyRestriction(final Http.RequestHeader request,
                                                     final DeadboltHandler handler)
     {
         return compositeCache.apply(configuration.value())
                              .map(constraint ->
                                   {
                                       final boolean preferGlobalMeta = configuration.preferGlobalMeta();
-                                      return constraint.test(ctx,
+                                      return constraint.test(request,
                                                              handler,
                                                              Optional.ofNullable(configuration.meta()),
                                                              (globalMd, localMd) -> preferGlobalMeta ? globalMd.isPresent() ? globalMd : localMd
                                                                                                      : localMd.isPresent() ? localMd : globalMd)
-                                                       .thenCompose(allowed -> allowed ? authorizeAndExecute(ctx,
+                                                       .thenCompose(allowed -> allowed ? authorizeAndExecute(request,
                                                                                                              handler)
-                                                                                       : unauthorizeAndFail(ctx,
+                                                                                       : unauthorizeAndFail(request,
                                                                                                             handler,
                                                                                                             getContent()));
                                   })
-                             .orElseGet(() -> unauthorizeAndFail(ctx,
+                             .orElseGet(() -> unauthorizeAndFail(request,
                                                                  handler,
                                                                  getContent()));
     }
@@ -82,13 +82,13 @@ public class CompositeAction extends AbstractRestrictiveAction<Composite>
         return configuration.deferred();
     }
 
-    private CompletionStage<Result> authorizeAndExecute(final Http.Context context,
+    private CompletionStage<Result> authorizeAndExecute(final Http.RequestHeader request,
                                                         final DeadboltHandler handler) 
     {
-        handler.onAuthSuccess(context,
+        handler.onAuthSuccess(request,
                               "composite",
                               ConstraintPoint.CONTROLLER);
-        return authorizeAndExecute(context);
+        return authorizeAndExecute(request);
     }
 
     @Override

--- a/code/app/be/objectify/deadbolt/java/actions/DeferredDeadbolt.java
+++ b/code/app/be/objectify/deadbolt/java/actions/DeferredDeadbolt.java
@@ -25,7 +25,7 @@ import java.lang.annotation.Retention;
 import static java.lang.annotation.RetentionPolicy.*;
 import java.lang.annotation.Target;
 
-import be.objectify.deadbolt.java.ConfigKeys;
+import be.objectify.deadbolt.java.Constants;
 
 /**
  * If a method-level Deadbolt annotation is marked as deferred, it can be run by adding this annotation to the class level.
@@ -56,7 +56,7 @@ public @interface DeferredDeadbolt
      *
      * @return the ky of the handler
      */
-    String handlerKey() default ConfigKeys.DEFAULT_HANDLER_KEY;
+    String handlerKey() default Constants.DEFAULT_HANDLER_KEY;
 
     /**
      * Defines several {@code DeferredDeadbolt} annotations on the same element.

--- a/code/app/be/objectify/deadbolt/java/actions/DeferredDeadboltAction.java
+++ b/code/app/be/objectify/deadbolt/java/actions/DeferredDeadboltAction.java
@@ -46,9 +46,9 @@ public class DeferredDeadboltAction extends AbstractDeadboltAction<DeferredDeadb
     }
 
     @Override
-    public CompletionStage<Result> execute(final Http.Context ctx) throws Exception
+    public CompletionStage<Result> execute(final Http.RequestHeader request) throws Exception
     {
-        return delegate.call(ctx);
+        return delegate.call((Http.Request)request);
     }
 
     /**

--- a/code/app/be/objectify/deadbolt/java/actions/DeferredDeadboltAction.java
+++ b/code/app/be/objectify/deadbolt/java/actions/DeferredDeadboltAction.java
@@ -51,9 +51,6 @@ public class DeferredDeadboltAction extends AbstractDeadboltAction<DeferredDeadb
         return delegate.call((Http.Request)request);
     }
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     protected boolean deferred() {
         return false; // you can't defer a DeferredDeadboltAction, makes absolutely no sense

--- a/code/app/be/objectify/deadbolt/java/actions/Dynamic.java
+++ b/code/app/be/objectify/deadbolt/java/actions/Dynamic.java
@@ -15,7 +15,7 @@
  */
 package be.objectify.deadbolt.java.actions;
 
-import be.objectify.deadbolt.java.ConfigKeys;
+import be.objectify.deadbolt.java.Constants;
 import play.mvc.With;
 
 import java.lang.annotation.Documented;
@@ -69,7 +69,7 @@ public @interface Dynamic
      *
      * @return the ky of the handler
      */
-    String handlerKey() default ConfigKeys.DEFAULT_HANDLER_KEY;
+    String handlerKey() default Constants.DEFAULT_HANDLER_KEY;
 
     /**
      * If true, the annotation will only be run if there is a {@link DeferredDeadbolt} annotation at the class level.

--- a/code/app/be/objectify/deadbolt/java/actions/DynamicAction.java
+++ b/code/app/be/objectify/deadbolt/java/actions/DynamicAction.java
@@ -78,9 +78,6 @@ public class DynamicAction extends AbstractRestrictiveAction<Dynamic>
                                        ConstraintPoint.CONTROLLER);
     }
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     protected boolean deferred() {
         return configuration.deferred();

--- a/code/app/be/objectify/deadbolt/java/actions/DynamicAction.java
+++ b/code/app/be/objectify/deadbolt/java/actions/DynamicAction.java
@@ -65,10 +65,10 @@ public class DynamicAction extends AbstractRestrictiveAction<Dynamic>
     }
 
     @Override
-    public CompletionStage<Result> applyRestriction(final Http.Context ctx,
+    public CompletionStage<Result> applyRestriction(final Http.RequestHeader request,
                                                     final DeadboltHandler deadboltHandler)
     {
-        return constraintLogic.dynamic(ctx,
+        return constraintLogic.dynamic(request,
                                        deadboltHandler,
                                        getContent(),
                                        configuration.value(),

--- a/code/app/be/objectify/deadbolt/java/actions/Pattern.java
+++ b/code/app/be/objectify/deadbolt/java/actions/Pattern.java
@@ -15,7 +15,7 @@
  */
 package be.objectify.deadbolt.java.actions;
 
-import be.objectify.deadbolt.java.ConfigKeys;
+import be.objectify.deadbolt.java.Constants;
 import be.objectify.deadbolt.java.ConstraintMode;
 import be.objectify.deadbolt.java.models.PatternType;
 import play.mvc.With;
@@ -80,7 +80,7 @@ public @interface Pattern
      *
      * @return the ky of the handler
      */
-    String handlerKey() default ConfigKeys.DEFAULT_HANDLER_KEY;
+    String handlerKey() default Constants.DEFAULT_HANDLER_KEY;
 
     /**
      * If true, the annotation will only be run if there is a {@link DeferredDeadbolt} annotation at the class level.

--- a/code/app/be/objectify/deadbolt/java/actions/PatternAction.java
+++ b/code/app/be/objectify/deadbolt/java/actions/PatternAction.java
@@ -62,10 +62,10 @@ public class PatternAction extends AbstractRestrictiveAction<Pattern>
     }
 
     @Override
-    public CompletionStage<Result> applyRestriction(final Http.Context ctx,
+    public CompletionStage<Result> applyRestriction(final Http.RequestHeader request,
                                                     final DeadboltHandler deadboltHandler)
     {
-        return constraintLogic.pattern(ctx,
+        return constraintLogic.pattern(request,
                                        deadboltHandler,
                                        getContent(),
                                        configuration.value(),

--- a/code/app/be/objectify/deadbolt/java/actions/PatternAction.java
+++ b/code/app/be/objectify/deadbolt/java/actions/PatternAction.java
@@ -84,9 +84,6 @@ public class PatternAction extends AbstractRestrictiveAction<Pattern>
         return Optional.ofNullable(configuration.content());
     }
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     protected boolean deferred() {
         return configuration.deferred();

--- a/code/app/be/objectify/deadbolt/java/actions/Restrict.java
+++ b/code/app/be/objectify/deadbolt/java/actions/Restrict.java
@@ -15,7 +15,7 @@
  */
 package be.objectify.deadbolt.java.actions;
 
-import be.objectify.deadbolt.java.ConfigKeys;
+import be.objectify.deadbolt.java.Constants;
 import play.mvc.With;
 
 import java.lang.annotation.Documented;
@@ -66,7 +66,7 @@ public @interface Restrict
      *
      * @return the ky of the handler
      */
-    String handlerKey() default ConfigKeys.DEFAULT_HANDLER_KEY;
+    String handlerKey() default Constants.DEFAULT_HANDLER_KEY;
 
     /**
      * If true, the annotation will only be run if there is a {@link DeferredDeadbolt} annotation at the class level.

--- a/code/app/be/objectify/deadbolt/java/actions/RestrictAction.java
+++ b/code/app/be/objectify/deadbolt/java/actions/RestrictAction.java
@@ -79,9 +79,6 @@ public class RestrictAction extends AbstractRestrictiveAction<Restrict>
                                         ConstraintPoint.CONTROLLER);
     }
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     protected boolean deferred() {
         return configuration.deferred();

--- a/code/app/be/objectify/deadbolt/java/actions/RestrictAction.java
+++ b/code/app/be/objectify/deadbolt/java/actions/RestrictAction.java
@@ -67,10 +67,10 @@ public class RestrictAction extends AbstractRestrictiveAction<Restrict>
     }
 
     @Override
-    public CompletionStage<Result> applyRestriction(final Http.Context ctx,
+    public CompletionStage<Result> applyRestriction(final Http.RequestHeader request,
                                                     final DeadboltHandler deadboltHandler)
     {
-        return constraintLogic.restrict(ctx,
+        return constraintLogic.restrict(request,
                                         deadboltHandler,
                                         getContent(),
                                         this::getRoleGroups,

--- a/code/app/be/objectify/deadbolt/java/actions/RoleBasedPermissions.java
+++ b/code/app/be/objectify/deadbolt/java/actions/RoleBasedPermissions.java
@@ -15,7 +15,7 @@
  */
 package be.objectify.deadbolt.java.actions;
 
-import be.objectify.deadbolt.java.ConfigKeys;
+import be.objectify.deadbolt.java.Constants;
 import play.mvc.With;
 
 import java.lang.annotation.Documented;
@@ -60,7 +60,7 @@ public @interface RoleBasedPermissions
      *
      * @return the ky of the handler
      */
-    String handlerKey() default ConfigKeys.DEFAULT_HANDLER_KEY;
+    String handlerKey() default Constants.DEFAULT_HANDLER_KEY;
 
     /**
      * If true, the annotation will only be run if there is a {@link DeferredDeadbolt} annotation at the class level.

--- a/code/app/be/objectify/deadbolt/java/actions/RoleBasedPermissionsAction.java
+++ b/code/app/be/objectify/deadbolt/java/actions/RoleBasedPermissionsAction.java
@@ -78,9 +78,6 @@ public class RoleBasedPermissionsAction extends AbstractRestrictiveAction<RoleBa
                                                     ConstraintPoint.CONTROLLER);
     }
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     protected boolean deferred() {
         return configuration.deferred();

--- a/code/app/be/objectify/deadbolt/java/actions/RoleBasedPermissionsAction.java
+++ b/code/app/be/objectify/deadbolt/java/actions/RoleBasedPermissionsAction.java
@@ -66,10 +66,10 @@ public class RoleBasedPermissionsAction extends AbstractRestrictiveAction<RoleBa
     }
 
     @Override
-    public CompletionStage<Result> applyRestriction(final Http.Context ctx,
+    public CompletionStage<Result> applyRestriction(final Http.RequestHeader request,
                                                     final DeadboltHandler deadboltHandler)
     {
-        return constraintLogic.roleBasedPermissions(ctx,
+        return constraintLogic.roleBasedPermissions(request,
                                                     deadboltHandler,
                                                     getContent(),
                                                     configuration.value(),

--- a/code/app/be/objectify/deadbolt/java/actions/SubjectNotPresent.java
+++ b/code/app/be/objectify/deadbolt/java/actions/SubjectNotPresent.java
@@ -15,7 +15,7 @@
  */
 package be.objectify.deadbolt.java.actions;
 
-import be.objectify.deadbolt.java.ConfigKeys;
+import be.objectify.deadbolt.java.Constants;
 import be.objectify.deadbolt.java.DeadboltHandler;
 import play.mvc.With;
 
@@ -55,7 +55,7 @@ public @interface SubjectNotPresent
      *
      * @return the key of the handler
      */
-    String handlerKey() default ConfigKeys.DEFAULT_HANDLER_KEY;
+    String handlerKey() default Constants.DEFAULT_HANDLER_KEY;
 
     /**
      * If true, the annotation will only be run if there is a {@link DeferredDeadbolt} annotation at the class level.

--- a/code/app/be/objectify/deadbolt/java/actions/SubjectNotPresentAction.java
+++ b/code/app/be/objectify/deadbolt/java/actions/SubjectNotPresentAction.java
@@ -50,9 +50,6 @@ public class SubjectNotPresentAction extends AbstractSubjectAction<SubjectNotPre
               constraintLogic);
     }
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     CompletionStage<Result> present(final Http.RequestHeader request,
                                     final DeadboltHandler handler,
@@ -63,9 +60,6 @@ public class SubjectNotPresentAction extends AbstractSubjectAction<SubjectNotPre
                                   content);
     }
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     CompletionStage<Result> notPresent(final Http.RequestHeader request,
                                        final DeadboltHandler handler,
@@ -87,9 +81,6 @@ public class SubjectNotPresentAction extends AbstractSubjectAction<SubjectNotPre
                                                         ConstraintPoint.CONTROLLER).toCompletableFuture();
     }
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     protected boolean deferred() {
         return configuration.deferred();

--- a/code/app/be/objectify/deadbolt/java/actions/SubjectNotPresentAction.java
+++ b/code/app/be/objectify/deadbolt/java/actions/SubjectNotPresentAction.java
@@ -54,11 +54,11 @@ public class SubjectNotPresentAction extends AbstractSubjectAction<SubjectNotPre
      * {@inheritDoc}
      */
     @Override
-    CompletionStage<Result> present(final Http.Context context,
+    CompletionStage<Result> present(final Http.RequestHeader request,
                                     final DeadboltHandler handler,
                                     final Optional<String> content)
     {
-        return unauthorizeAndFail(context,
+        return unauthorizeAndFail(request,
                                   handler,
                                   content);
     }
@@ -67,19 +67,19 @@ public class SubjectNotPresentAction extends AbstractSubjectAction<SubjectNotPre
      * {@inheritDoc}
      */
     @Override
-    CompletionStage<Result> notPresent(final Http.Context context,
+    CompletionStage<Result> notPresent(final Http.RequestHeader request,
                                        final DeadboltHandler handler,
                                        final Optional<String> content)
     {
-        return authorizeAndExecute(context);
+        return authorizeAndExecute(request);
     }
 
     @Override
     protected Supplier<CompletableFuture<Result>> testSubject(final ConstraintLogic constraintLogic,
-                                                              final Http.Context context,
+                                                              final Http.RequestHeader request,
                                                               final DeadboltHandler deadboltHandler)
     {
-        return () -> constraintLogic.subjectNotPresent(context,
+        return () -> constraintLogic.subjectNotPresent(request,
                                                         deadboltHandler,
                                                         getContent(),
                                                         this::present,

--- a/code/app/be/objectify/deadbolt/java/actions/SubjectPresent.java
+++ b/code/app/be/objectify/deadbolt/java/actions/SubjectPresent.java
@@ -15,7 +15,7 @@
  */
 package be.objectify.deadbolt.java.actions;
 
-import be.objectify.deadbolt.java.ConfigKeys;
+import be.objectify.deadbolt.java.Constants;
 import be.objectify.deadbolt.java.DeadboltHandler;
 import play.mvc.With;
 
@@ -55,7 +55,7 @@ public @interface SubjectPresent
      *
      * @return the ky of the handler
      */
-    String handlerKey() default ConfigKeys.DEFAULT_HANDLER_KEY;
+    String handlerKey() default Constants.DEFAULT_HANDLER_KEY;
 
     /**
      * If true, the annotation will only be run if there is a {@link DeferredDeadbolt} annotation at the class level.

--- a/code/app/be/objectify/deadbolt/java/actions/SubjectPresentAction.java
+++ b/code/app/be/objectify/deadbolt/java/actions/SubjectPresentAction.java
@@ -53,32 +53,32 @@ public class SubjectPresentAction extends AbstractSubjectAction<SubjectPresent>
      * {@inheritDoc}
      */
     @Override
-    CompletionStage<Result> present(final Http.Context context,
+    CompletionStage<Result> present(final Http.RequestHeader request,
                                     final DeadboltHandler handler,
                                     final Optional<String> content)
     {
-        return authorizeAndExecute(context);
+        return authorizeAndExecute(request);
     }
 
     /**
      * {@inheritDoc}
      */
     @Override
-    CompletionStage<Result> notPresent(final Http.Context context,
+    CompletionStage<Result> notPresent(final Http.RequestHeader request,
                                        final DeadboltHandler handler,
                                        final Optional<String> content)
     {
-        return unauthorizeAndFail(context,
+        return unauthorizeAndFail(request,
                                   handler,
                                   content);
     }
 
     @Override
     protected Supplier<CompletableFuture<Result>> testSubject(final ConstraintLogic constraintLogic,
-                                                              final Http.Context context,
+                                                              final Http.RequestHeader request,
                                                               final DeadboltHandler deadboltHandler)
     {
-        return () -> constraintLogic.subjectPresent(context,
+        return () -> constraintLogic.subjectPresent(request,
                                                      deadboltHandler,
                                                      getContent(),
                                                      this::present,

--- a/code/app/be/objectify/deadbolt/java/actions/SubjectPresentAction.java
+++ b/code/app/be/objectify/deadbolt/java/actions/SubjectPresentAction.java
@@ -49,9 +49,6 @@ public class SubjectPresentAction extends AbstractSubjectAction<SubjectPresent>
               constraintLogic);
     }
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     CompletionStage<Result> present(final Http.RequestHeader request,
                                     final DeadboltHandler handler,
@@ -60,9 +57,6 @@ public class SubjectPresentAction extends AbstractSubjectAction<SubjectPresent>
         return authorizeAndExecute(request);
     }
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     CompletionStage<Result> notPresent(final Http.RequestHeader request,
                                        final DeadboltHandler handler,
@@ -86,9 +80,6 @@ public class SubjectPresentAction extends AbstractSubjectAction<SubjectPresent>
                                                      ConstraintPoint.CONTROLLER).toCompletableFuture();
     }
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     protected boolean deferred() {
         return configuration.deferred();

--- a/code/app/be/objectify/deadbolt/java/actions/Unrestricted.java
+++ b/code/app/be/objectify/deadbolt/java/actions/Unrestricted.java
@@ -15,7 +15,7 @@
  */
 package be.objectify.deadbolt.java.actions;
 
-import be.objectify.deadbolt.java.ConfigKeys;
+import be.objectify.deadbolt.java.Constants;
 import play.mvc.With;
 
 import java.lang.annotation.Documented;
@@ -52,7 +52,7 @@ public @interface Unrestricted
      *
      * @return the ky of the handler
      */
-    String handlerKey() default ConfigKeys.DEFAULT_HANDLER_KEY;
+    String handlerKey() default Constants.DEFAULT_HANDLER_KEY;
 
     /**
      * If true, the annotation will only be run if there is a {@link DeferredDeadbolt} annotation at the class level.

--- a/code/app/be/objectify/deadbolt/java/actions/UnrestrictedAction.java
+++ b/code/app/be/objectify/deadbolt/java/actions/UnrestrictedAction.java
@@ -46,9 +46,9 @@ public class UnrestrictedAction extends AbstractDeadboltAction<Unrestricted>
      * {@inheritDoc}
      */
     @Override
-    public CompletionStage<Result> execute(final Http.Context ctx) throws Exception
+    public CompletionStage<Result> execute(final Http.RequestHeader request) throws Exception
     {
-        return authorizeAndExecute(ctx);
+        return authorizeAndExecute(request);
     }
 
     /**

--- a/code/app/be/objectify/deadbolt/java/actions/UnrestrictedAction.java
+++ b/code/app/be/objectify/deadbolt/java/actions/UnrestrictedAction.java
@@ -42,18 +42,12 @@ public class UnrestrictedAction extends AbstractDeadboltAction<Unrestricted>
               config);
     }
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public CompletionStage<Result> execute(final Http.RequestHeader request) throws Exception
     {
         return authorizeAndExecute(request);
     }
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     protected boolean deferred() {
         return configuration.deferred();

--- a/code/app/be/objectify/deadbolt/java/cache/BeforeAuthCheckCache.java
+++ b/code/app/be/objectify/deadbolt/java/cache/BeforeAuthCheckCache.java
@@ -17,6 +17,7 @@ package be.objectify.deadbolt.java.cache;
 
 import be.objectify.deadbolt.java.DeadboltHandler;
 import be.objectify.deadbolt.java.utils.TriFunction;
+import play.libs.F;
 import play.mvc.Http;
 import play.mvc.Result;
 
@@ -26,6 +27,6 @@ import java.util.concurrent.CompletionStage;
 /**
  * @author Matthias Kurz (m.kurz@irregular.at)
  */
-public interface BeforeAuthCheckCache extends TriFunction<DeadboltHandler, Http.Context, Optional<String>, CompletionStage<Optional<Result>>>
+public interface BeforeAuthCheckCache extends TriFunction<DeadboltHandler, Http.RequestHeader, Optional<String>, CompletionStage<F.Tuple<Optional<Result>, Http.RequestHeader>>>
 {
 }

--- a/code/app/be/objectify/deadbolt/java/cache/DefaultBeforeAuthCheckCache.java
+++ b/code/app/be/objectify/deadbolt/java/cache/DefaultBeforeAuthCheckCache.java
@@ -15,10 +15,8 @@
  */
 package be.objectify.deadbolt.java.cache;
 
-import be.objectify.deadbolt.java.ConfigKeys;
 import be.objectify.deadbolt.java.DeadboltHandler;
 import com.typesafe.config.Config;
-import com.typesafe.config.ConfigFactory;
 import play.libs.F;
 import play.libs.typedmap.TypedKey;
 import play.mvc.Http;
@@ -26,7 +24,6 @@ import play.mvc.Result;
 
 import javax.inject.Inject;
 import javax.inject.Singleton;
-import java.util.HashMap;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
@@ -45,11 +42,7 @@ public class DefaultBeforeAuthCheckCache implements BeforeAuthCheckCache
     @Inject
     public DefaultBeforeAuthCheckCache(final Config config)
     {
-        final HashMap<String, Object> defaults = new HashMap<>();
-        defaults.put(ConfigKeys.CACHE_BEFORE_AUTH_CHECK_DEFAULT._1,
-                     ConfigKeys.CACHE_BEFORE_AUTH_CHECK_DEFAULT._2);
-        final Config configWithFallback = config.withFallback(ConfigFactory.parseMap(defaults));
-        this.cacheBeforeAuthCheckPerRequestEnabled = configWithFallback.getBoolean(ConfigKeys.CACHE_BEFORE_AUTH_CHECK_DEFAULT._1);
+        this.cacheBeforeAuthCheckPerRequestEnabled = config.getBoolean("deadbolt.java.cache-before-auth-check");
     }
 
     @Override
@@ -60,7 +53,7 @@ public class DefaultBeforeAuthCheckCache implements BeforeAuthCheckCache
         final CompletionStage<Optional<Result>> promise;
         if (cacheBeforeAuthCheckPerRequestEnabled)
         {
-            final TypedKey<Boolean> deadboltHandlerCacheId = this.typedKeyCache.computeIfAbsent(deadboltHandler.getId(), k -> TypedKey.create(ConfigKeys.CACHE_BEFORE_AUTH_CHECK_DEFAULT._1 + "." + k)); // results into "deadbolt.java.cache-before-auth-check.0"
+            final TypedKey<Boolean> deadboltHandlerCacheId = this.typedKeyCache.computeIfAbsent(deadboltHandler.getId(), k -> TypedKey.create("deadbolt.java.cache-before-auth-check." + k));
             if (requestHeader.attrs().containsKey(deadboltHandlerCacheId))
             {
                 return CompletableFuture.completedFuture(F.Tuple(Optional.empty(), requestHeader));

--- a/code/app/be/objectify/deadbolt/java/cache/DefaultSubjectCache.java
+++ b/code/app/be/objectify/deadbolt/java/cache/DefaultSubjectCache.java
@@ -15,18 +15,15 @@
  */
 package be.objectify.deadbolt.java.cache;
 
-import be.objectify.deadbolt.java.ConfigKeys;
 import be.objectify.deadbolt.java.DeadboltHandler;
 import be.objectify.deadbolt.java.models.Subject;
 import com.typesafe.config.Config;
-import com.typesafe.config.ConfigFactory;
 import play.libs.F;
 import play.libs.typedmap.TypedKey;
 import play.mvc.Http;
 
 import javax.inject.Inject;
 import javax.inject.Singleton;
-import java.util.HashMap;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
@@ -45,11 +42,7 @@ public class DefaultSubjectCache implements SubjectCache
     @Inject
     public DefaultSubjectCache(final Config config)
     {
-        final HashMap<String, Object> defaults = new HashMap<>();
-        defaults.put(ConfigKeys.CACHE_DEADBOLT_USER_DEFAULT._1,
-                     ConfigKeys.CACHE_DEADBOLT_USER_DEFAULT._2);
-        final Config configWithFallback = config.withFallback(ConfigFactory.parseMap(defaults));
-        this.cacheUserPerRequestEnabled = configWithFallback.getBoolean(ConfigKeys.CACHE_DEADBOLT_USER_DEFAULT._1);
+        this.cacheUserPerRequestEnabled = config.getBoolean("deadbolt.java.cache-user");
     }
 
     @Override
@@ -58,7 +51,7 @@ public class DefaultSubjectCache implements SubjectCache
     {
         if (cacheUserPerRequestEnabled)
         {
-            final TypedKey<Subject> deadboltHandlerCacheId = this.typedKeyCache.computeIfAbsent(deadboltHandler.getId(), k -> TypedKey.create(ConfigKeys.CACHE_DEADBOLT_USER_DEFAULT._1 + "." + k)); // results into "deadbolt.java.cache-user.0"
+            final TypedKey<Subject> deadboltHandlerCacheId = this.typedKeyCache.computeIfAbsent(deadboltHandler.getId(), k -> TypedKey.create("deadbolt.java.cache-user." + k));
             final Optional<? extends Subject> cachedUser = requestHeader.attrs().getOptional(deadboltHandlerCacheId);
             if (cachedUser.isPresent())
             {

--- a/code/app/be/objectify/deadbolt/java/cache/DefaultSubjectCache.java
+++ b/code/app/be/objectify/deadbolt/java/cache/DefaultSubjectCache.java
@@ -20,6 +20,8 @@ import be.objectify.deadbolt.java.DeadboltHandler;
 import be.objectify.deadbolt.java.models.Subject;
 import com.typesafe.config.Config;
 import com.typesafe.config.ConfigFactory;
+import play.libs.F;
+import play.libs.typedmap.TypedKey;
 import play.mvc.Http;
 
 import javax.inject.Inject;
@@ -28,6 +30,8 @@ import java.util.HashMap;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
 
 /**
  * @author Steve Chaloner (steve@objectify.be)
@@ -36,6 +40,7 @@ import java.util.concurrent.CompletionStage;
 public class DefaultSubjectCache implements SubjectCache
 {
     private final boolean cacheUserPerRequestEnabled;
+    private final ConcurrentMap<Long, TypedKey<Subject>> typedKeyCache = new ConcurrentHashMap<>();
 
     @Inject
     public DefaultSubjectCache(final Config config)
@@ -48,34 +53,22 @@ public class DefaultSubjectCache implements SubjectCache
     }
 
     @Override
-    public CompletionStage<Optional<? extends Subject>> apply(final DeadboltHandler deadboltHandler,
-                                                              final Http.Context context)
+    public CompletionStage<F.Tuple<Optional<? extends Subject>, Http.RequestHeader>> apply(final DeadboltHandler deadboltHandler,
+                                                                       final Http.RequestHeader requestHeader)
     {
-        final CompletionStage<Optional<? extends Subject>> promise;
         if (cacheUserPerRequestEnabled)
         {
-            final String deadboltHandlerCacheId = ConfigKeys.CACHE_DEADBOLT_USER_DEFAULT._1 + "." + deadboltHandler.getId(); // results into "deadbolt.java.cache-user.0"
-            final Optional<? extends Subject> cachedUser = Optional.ofNullable((Subject) context.args.get(deadboltHandlerCacheId));
+            final TypedKey<Subject> deadboltHandlerCacheId = this.typedKeyCache.computeIfAbsent(deadboltHandler.getId(), k -> TypedKey.create(ConfigKeys.CACHE_DEADBOLT_USER_DEFAULT._1 + "." + k)); // results into "deadbolt.java.cache-user.0"
+            final Optional<? extends Subject> cachedUser = requestHeader.attrs().getOptional(deadboltHandlerCacheId);
             if (cachedUser.isPresent())
             {
-                promise = CompletableFuture.completedFuture(cachedUser);
+                return CompletableFuture.completedFuture(F.Tuple(cachedUser, requestHeader));
             }
             else
             {
-                promise = deadboltHandler.getSubject(context)
-                                         .thenApply(subjectOption ->
-                                                         {
-                                                             subjectOption.ifPresent(subject -> context.args.put(deadboltHandlerCacheId,
-                                                                                                                 subject));
-                                                             return subjectOption;
-                                                         });
+                return deadboltHandler.getSubject(requestHeader).thenApply(subjectOption -> subjectOption.map(s -> F.<Optional<? extends Subject>, Http.RequestHeader>Tuple(Optional.of(s), requestHeader.addAttr(deadboltHandlerCacheId, s))).orElseGet(() -> F.Tuple(Optional.empty(), requestHeader)));
             }
         }
-        else
-        {
-            promise = deadboltHandler.getSubject(context);
-        }
-
-        return promise;
+        return deadboltHandler.getSubject(requestHeader).thenApply(subjectOption -> subjectOption.map(s -> F.<Optional<? extends Subject>, Http.RequestHeader>Tuple(Optional.of(s), requestHeader)).orElseGet(() -> F.Tuple(Optional.empty(), requestHeader)));
     }
 }

--- a/code/app/be/objectify/deadbolt/java/cache/SubjectCache.java
+++ b/code/app/be/objectify/deadbolt/java/cache/SubjectCache.java
@@ -17,6 +17,7 @@ package be.objectify.deadbolt.java.cache;
 
 import be.objectify.deadbolt.java.DeadboltHandler;
 import be.objectify.deadbolt.java.models.Subject;
+import play.libs.F;
 import play.mvc.Http;
 
 import java.util.Optional;
@@ -26,6 +27,6 @@ import java.util.function.BiFunction;
 /**
  * @author Steve Chaloner (steve@objectify.be)
  */
-public interface SubjectCache extends BiFunction<DeadboltHandler, Http.Context, CompletionStage<Optional<? extends Subject>>>
+public interface SubjectCache extends BiFunction<DeadboltHandler, Http.RequestHeader, CompletionStage<F.Tuple<Optional<? extends Subject>, Http.RequestHeader>>>
 {
 }

--- a/code/app/be/objectify/deadbolt/java/composite/Constraint.java
+++ b/code/app/be/objectify/deadbolt/java/composite/Constraint.java
@@ -47,21 +47,21 @@ public interface Constraint
     default Constraint and(final Constraint other)
     {
         Objects.requireNonNull(other);
-        return (ctx, handler, global, fMeta) ->
-                test(ctx, handler, global, fMeta).thenCompose(passed1 -> passed1 ? other.test(ctx, handler, global, fMeta).thenApply(passed2 -> passed2)
+        return (rh, handler, global, fMeta) ->
+                test(rh, handler, global, fMeta).thenCompose(passed1 -> passed1 ? other.test(rh, handler, global, fMeta).thenApply(passed2 -> passed2)
                                                                                  : CompletableFuture.completedFuture(false));
     }
 
     default Constraint negate()
     {
-        return (ctx, handler, global, fMeta) -> test(ctx, handler, global, fMeta).thenApply(p -> !p);
+        return (rh, handler, global, fMeta) -> test(rh, handler, global, fMeta).thenApply(p -> !p);
     }
 
     default Constraint or(final Constraint other)
     {
         Objects.requireNonNull(other);
-        return (ctx, handler, global, fMeta) ->
-                test(ctx, handler, global, fMeta).thenCompose(passed1 -> passed1 ? CompletableFuture.completedFuture(true)
-                                                                                                : other.test(ctx, handler, global, fMeta).thenApply(passed2 -> passed2));
+        return (rh, handler, global, fMeta) ->
+                test(rh, handler, global, fMeta).thenCompose(passed1 -> passed1 ? CompletableFuture.completedFuture(true)
+                                                                                                : other.test(rh, handler, global, fMeta).thenApply(passed2 -> passed2));
     }
 }

--- a/code/app/be/objectify/deadbolt/java/composite/Constraint.java
+++ b/code/app/be/objectify/deadbolt/java/composite/Constraint.java
@@ -30,16 +30,16 @@ import java.util.function.BiFunction;
 @FunctionalInterface
 public interface Constraint
 {
-    default CompletionStage<Boolean> test(Http.Context context,
+    default CompletionStage<Boolean> test(Http.RequestHeader requestHeader,
                                           DeadboltHandler handler)
     {
-        return test(context,
+        return test(requestHeader,
                     handler,
                     Optional.empty(),
                     (globalMeta, localMeta) -> localMeta);
     }
 
-    CompletionStage<Boolean> test(Http.Context context,
+    CompletionStage<Boolean> test(Http.RequestHeader requestHeader,
                                   DeadboltHandler handler,
                                   Optional<String> globalMetaData,
                                   BiFunction<Optional<String>, Optional<String>, Optional<String>> metaFn);

--- a/code/app/be/objectify/deadbolt/java/composite/ConstraintTree.java
+++ b/code/app/be/objectify/deadbolt/java/composite/ConstraintTree.java
@@ -16,6 +16,7 @@
 package be.objectify.deadbolt.java.composite;
 
 import be.objectify.deadbolt.java.DeadboltHandler;
+import play.libs.F;
 import play.mvc.Http;
 
 import java.util.Arrays;
@@ -49,15 +50,15 @@ public class ConstraintTree implements Constraint
     }
 
     @Override
-    public CompletionStage<Boolean> test(final Http.Context context,
+    public CompletionStage<F.Tuple<Boolean, Http.RequestHeader>> test(final Http.RequestHeader requestHeader,
                                          final DeadboltHandler handler,
                                          final Optional<String> globalMetaData,
                                          final BiFunction<Optional<String>, Optional<String>, Optional<String>> metaFn)
     {
-        final CompletionStage<Boolean> result;
+        final CompletionStage<F.Tuple<Boolean, Http.RequestHeader>> result;
         if (constraints.isEmpty())
         {
-            result = CompletableFuture.completedFuture(false);
+            result = CompletableFuture.completedFuture(F.Tuple(false, requestHeader));
         }
         else
         {
@@ -67,7 +68,7 @@ public class ConstraintTree implements Constraint
                 current = operator.apply(current,
                                          constraints.get(i));
             }
-            result = current.test(context,
+            result = current.test(requestHeader,
                                   handler,
                                   globalMetaData,
                                   metaFn);

--- a/code/app/be/objectify/deadbolt/java/composite/DynamicConstraint.java
+++ b/code/app/be/objectify/deadbolt/java/composite/DynamicConstraint.java
@@ -18,6 +18,7 @@ package be.objectify.deadbolt.java.composite;
 import be.objectify.deadbolt.java.ConstraintLogic;
 import be.objectify.deadbolt.java.ConstraintPoint;
 import be.objectify.deadbolt.java.DeadboltHandler;
+import play.libs.F;
 import play.mvc.Http;
 
 import java.util.Optional;
@@ -47,18 +48,18 @@ public class DynamicConstraint implements Constraint
     }
 
     @Override
-    public CompletionStage<Boolean> test(final Http.Context context,
+    public CompletionStage<F.Tuple<Boolean, Http.RequestHeader>> test(final Http.RequestHeader requestHeader,
                                          final DeadboltHandler handler,
                                          final Optional<String> globalMetaData,
                                          final BiFunction<Optional<String>, Optional<String>, Optional<String>> metaFn)
     {
-        return constraintLogic.dynamic(context,
+        return constraintLogic.dynamic(requestHeader,
                                        handler,
                                        content,
                                        name,
                                        metaFn.apply(globalMetaData, meta),
-                                       ctx -> CompletableFuture.completedFuture(Boolean.TRUE),
-                                       (ctx, dh, cnt) -> CompletableFuture.completedFuture(Boolean.FALSE),
+                                       rh -> CompletableFuture.completedFuture(F.Tuple(Boolean.TRUE, rh)),
+                                       (rh, dh, cnt) -> CompletableFuture.completedFuture(F.Tuple(Boolean.FALSE, rh)),
                                        ConstraintPoint.CONTROLLER);
     }
 }

--- a/code/app/be/objectify/deadbolt/java/composite/ExceptionThrowingConstraint.java
+++ b/code/app/be/objectify/deadbolt/java/composite/ExceptionThrowingConstraint.java
@@ -16,6 +16,7 @@
 package be.objectify.deadbolt.java.composite;
 
 import be.objectify.deadbolt.java.DeadboltHandler;
+import play.libs.F;
 import play.mvc.Http;
 
 import java.util.Optional;
@@ -35,7 +36,7 @@ public class ExceptionThrowingConstraint implements Constraint
     }
 
     @Override
-    public CompletionStage<Boolean> test(final Http.Context context,
+    public CompletionStage<F.Tuple<Boolean, Http.RequestHeader>> test(final Http.RequestHeader requestHeader,
                                          final DeadboltHandler handler,
                                          final Optional<String> globalMetaData,
                                          final BiFunction<Optional<String>, Optional<String>, Optional<String>> metaFn)

--- a/code/app/be/objectify/deadbolt/java/composite/PatternConstraint.java
+++ b/code/app/be/objectify/deadbolt/java/composite/PatternConstraint.java
@@ -19,6 +19,7 @@ import be.objectify.deadbolt.java.ConstraintLogic;
 import be.objectify.deadbolt.java.ConstraintPoint;
 import be.objectify.deadbolt.java.DeadboltHandler;
 import be.objectify.deadbolt.java.models.PatternType;
+import play.libs.F;
 import play.mvc.Http;
 
 import java.util.Optional;
@@ -54,20 +55,20 @@ public class PatternConstraint implements Constraint
     }
 
     @Override
-    public CompletionStage<Boolean> test(final Http.Context context,
+    public CompletionStage<F.Tuple<Boolean, Http.RequestHeader>> test(final Http.RequestHeader requestHeader,
                                          final DeadboltHandler handler,
                                          final Optional<String> globalMetaData,
                                          final BiFunction<Optional<String>, Optional<String>, Optional<String>> metaFn)
     {
-        return constraintLogic.pattern(context,
+        return constraintLogic.pattern(requestHeader,
                                        handler,
                                        content,
                                        value,
                                        patternType,
                                        metaFn.apply(globalMetaData, meta),
                                        invert,
-                                       ctx -> CompletableFuture.completedFuture(Boolean.TRUE),
-                                       (ctx, dh, ctn) -> CompletableFuture.completedFuture(Boolean.FALSE),
+                                       rh -> CompletableFuture.completedFuture(F.Tuple(Boolean.TRUE, rh)),
+                                       (rh, dh, ctn) -> CompletableFuture.completedFuture(F.Tuple(Boolean.FALSE, rh)),
                                        ConstraintPoint.CONTROLLER);
     }
 }

--- a/code/app/be/objectify/deadbolt/java/composite/RestrictConstraint.java
+++ b/code/app/be/objectify/deadbolt/java/composite/RestrictConstraint.java
@@ -18,6 +18,7 @@ package be.objectify.deadbolt.java.composite;
 import be.objectify.deadbolt.java.ConstraintLogic;
 import be.objectify.deadbolt.java.ConstraintPoint;
 import be.objectify.deadbolt.java.DeadboltHandler;
+import play.libs.F;
 import play.mvc.Http;
 
 import java.util.LinkedList;
@@ -50,17 +51,17 @@ public class RestrictConstraint implements Constraint
     }
 
     @Override
-    public CompletionStage<Boolean> test(final Http.Context context,
+    public CompletionStage<F.Tuple<Boolean, Http.RequestHeader>> test(final Http.RequestHeader requestHeader,
                                          final DeadboltHandler handler,
                                          final Optional<String> globalMetaData,
                                          final BiFunction<Optional<String>, Optional<String>, Optional<String>> metaFn)
     {
-        return constraintLogic.restrict(context,
+        return constraintLogic.restrict(requestHeader,
                                         handler,
                                         content,
                                         () -> roleGroups,
-                                        ctx -> CompletableFuture.completedFuture(Boolean.TRUE),
-                                        (ctx, dh, cnt) -> CompletableFuture.completedFuture(Boolean.FALSE),
+                                        rh -> CompletableFuture.completedFuture(F.Tuple(Boolean.TRUE, rh)),
+                                        (rh, dh, cnt) -> CompletableFuture.completedFuture(F.Tuple(Boolean.FALSE, rh)),
                                         ConstraintPoint.CONTROLLER);
     }
 }

--- a/code/app/be/objectify/deadbolt/java/composite/SubjectNotPresentConstraint.java
+++ b/code/app/be/objectify/deadbolt/java/composite/SubjectNotPresentConstraint.java
@@ -18,6 +18,7 @@ package be.objectify.deadbolt.java.composite;
 import be.objectify.deadbolt.java.ConstraintLogic;
 import be.objectify.deadbolt.java.ConstraintPoint;
 import be.objectify.deadbolt.java.DeadboltHandler;
+import play.libs.F;
 import play.mvc.Http;
 
 import java.util.Optional;
@@ -40,16 +41,17 @@ public class SubjectNotPresentConstraint implements Constraint
         this.constraintLogic = constraintLogic;
     }
 
-    public CompletionStage<Boolean> test(final Http.Context context,
+    @Override
+    public CompletionStage<F.Tuple<Boolean, Http.RequestHeader>> test(final Http.RequestHeader requestHeader,
                                          final DeadboltHandler handler,
                                          final Optional<String> globalMetaData,
                                          final BiFunction<Optional<String>, Optional<String>, Optional<String>> metaFn)
     {
-        return constraintLogic.subjectNotPresent(context,
+        return constraintLogic.subjectNotPresent(requestHeader,
                                                  handler,
                                                  content,
-                                                 (ctx, dh, cnt) -> CompletableFuture.completedFuture(Boolean.FALSE),
-                                                 (ctx, dh, cnt) -> CompletableFuture.completedFuture(Boolean.TRUE),
+                                                 (rh, dh, cnt) -> CompletableFuture.completedFuture(F.Tuple(Boolean.FALSE, rh)),
+                                                 (rh, dh, cnt) -> CompletableFuture.completedFuture(F.Tuple(Boolean.TRUE, rh)),
                                                  ConstraintPoint.CONTROLLER);
 
     }

--- a/code/app/be/objectify/deadbolt/java/composite/SubjectPresentConstraint.java
+++ b/code/app/be/objectify/deadbolt/java/composite/SubjectPresentConstraint.java
@@ -18,6 +18,7 @@ package be.objectify.deadbolt.java.composite;
 import be.objectify.deadbolt.java.ConstraintLogic;
 import be.objectify.deadbolt.java.ConstraintPoint;
 import be.objectify.deadbolt.java.DeadboltHandler;
+import play.libs.F;
 import play.mvc.Http;
 
 import java.util.Optional;
@@ -40,16 +41,16 @@ public class SubjectPresentConstraint implements Constraint
         this.constraintLogic = constraintLogic;
     }
 
-    public CompletionStage<Boolean> test(final Http.Context context,
+    public CompletionStage<F.Tuple<Boolean, Http.RequestHeader>> test(final Http.RequestHeader requestHeader,
                                          final DeadboltHandler handler,
                                          final Optional<String> globalMetaData,
                                          final BiFunction<Optional<String>, Optional<String>, Optional<String>> metaFn)
     {
-        return constraintLogic.subjectPresent(context,
+        return constraintLogic.subjectPresent(requestHeader,
                                               handler,
                                               content,
-                                              (ctx, dh, cnt) -> CompletableFuture.completedFuture(Boolean.TRUE),
-                                              (ctx, dh, cnt) -> CompletableFuture.completedFuture(Boolean.FALSE),
+                                              (rh, dh, cnt) -> CompletableFuture.completedFuture(F.Tuple(Boolean.TRUE, rh)),
+                                              (rh, dh, cnt) -> CompletableFuture.completedFuture(F.Tuple(Boolean.FALSE, rh)),
                                               ConstraintPoint.CONTROLLER);
 
     }

--- a/code/app/be/objectify/deadbolt/java/filters/AbstractDeadboltFilter.java
+++ b/code/app/be/objectify/deadbolt/java/filters/AbstractDeadboltFilter.java
@@ -18,7 +18,6 @@ package be.objectify.deadbolt.java.filters;
 import akka.stream.Materializer;
 import play.core.j.JavaContextComponents;
 import play.mvc.Filter;
-import play.mvc.Http;
 
 /**
  * @author Steve Chaloner (steve@objectify.be)
@@ -32,26 +31,5 @@ public abstract class AbstractDeadboltFilter extends Filter
     {
         super(mat);
         this.javaContextComponents = javaContextComponents;
-    }
-
-    Http.Context context(final Http.RequestHeader requestHeader)
-    {
-        final Http.RequestBuilder requestBuilder = new Http.RequestBuilder().headers(requestHeader.getHeaders())
-                                                                            .host(requestHeader.host())
-                                                                            .method(requestHeader.method())
-                                                                            .path(requestHeader.path())
-                                                                            .remoteAddress(requestHeader.remoteAddress())
-                                                                            .secure(requestHeader.secure())
-                                                                            .attrs(requestHeader.attrs())
-                                                                            .host(requestHeader.host())
-                                                                            .uri(requestHeader.uri())
-                                                                            .version(requestHeader.version());
-        requestHeader.clientCertificateChain().ifPresent(requestBuilder::clientCertificateChain);
-        for (Http.Cookie cookie : requestHeader.cookies())
-        {
-            requestBuilder.cookie(cookie);
-        }
-        return new Http.Context(requestBuilder,
-                                javaContextComponents);
     }
 }

--- a/code/app/be/objectify/deadbolt/java/filters/AbstractDeadboltFilter.java
+++ b/code/app/be/objectify/deadbolt/java/filters/AbstractDeadboltFilter.java
@@ -16,7 +16,6 @@
 package be.objectify.deadbolt.java.filters;
 
 import akka.stream.Materializer;
-import play.core.j.JavaContextComponents;
 import play.mvc.Filter;
 
 /**
@@ -24,12 +23,9 @@ import play.mvc.Filter;
  */
 public abstract class AbstractDeadboltFilter extends Filter
 {
-    private final JavaContextComponents javaContextComponents;
 
-    public AbstractDeadboltFilter(final Materializer mat,
-                                  final JavaContextComponents javaContextComponents)
+    public AbstractDeadboltFilter(final Materializer mat)
     {
         super(mat);
-        this.javaContextComponents = javaContextComponents;
     }
 }

--- a/code/app/be/objectify/deadbolt/java/filters/DeadboltRouteCommentFilter.java
+++ b/code/app/be/objectify/deadbolt/java/filters/DeadboltRouteCommentFilter.java
@@ -37,7 +37,7 @@ import play.routing.Router;
 /**
  * Filters all incoming HTTP requests and applies constraints based on the route's comment.  If a comment is present, the constraint
  * for that route will be applied.  If access is allowed, the next filter in the chain is invoked; if access is not allowed,
- * {@link DeadboltHandler#onAuthFailure(Http.Context, Optional)} is invoked.
+ * {@link DeadboltHandler#onAuthFailure(Http.RequestHeader, Optional)} is invoked.
  * <p>
  * The format of the comment is deadbolt:constraintType:config.  Individual configurations have the form :label[value] - to omit an optional config,
  * remove :label[value],
@@ -126,7 +126,7 @@ public class DeadboltRouteCommentFilter extends AbstractDeadboltFilter
                                                     {
                                                         LOGGER.error("Unknown Deadbolt route comment [{}], denying access with default handler",
                                                                      requestHeader.attrs().get(Router.Attrs.HANDLER_DEF).comments());
-                                                        return dh.onAuthFailure(context, Optional.empty());
+                                                        return dh.onAuthFailure(requestHeader, Optional.empty());
                                                     }, handler);
     }
 

--- a/code/app/be/objectify/deadbolt/java/filters/DeadboltRouteCommentFilter.java
+++ b/code/app/be/objectify/deadbolt/java/filters/DeadboltRouteCommentFilter.java
@@ -125,7 +125,7 @@ public class DeadboltRouteCommentFilter extends AbstractDeadboltFilter
         this.handler = handlerCache.get();
         this.filterConstraints = filterConstraints;
 
-        this.unknownDeadboltComment = new F.Tuple<>((context, requestHeader, dh, onSuccess) ->
+        this.unknownDeadboltComment = new F.Tuple<>((requestHeader, dh, onSuccess) ->
                                                     {
                                                         LOGGER.error("Unknown Deadbolt route comment [{}], denying access with default handler",
                                                                      requestHeader.attrs().get(Router.Attrs.HANDLER_DEF).comments());
@@ -157,8 +157,7 @@ public class DeadboltRouteCommentFilter extends AbstractDeadboltFilter
                                             .orElseGet(() -> pattern(comment)
                                                     .orElseGet(() -> roleBasedPermissionsComment(comment)
                                                             .orElse(unknownDeadboltComment)))))));
-            result = tuple._1.apply(context(requestHeader),
-                                    requestHeader,
+            result = tuple._1.apply(requestHeader,
                                     tuple._2,
                                     next);
         }

--- a/code/app/be/objectify/deadbolt/java/filters/DeadboltRouteCommentFilter.java
+++ b/code/app/be/objectify/deadbolt/java/filters/DeadboltRouteCommentFilter.java
@@ -29,7 +29,6 @@ import be.objectify.deadbolt.java.models.PatternType;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import play.api.routing.HandlerDef;
-import play.core.j.JavaContextComponents;
 import play.libs.F;
 import play.mvc.Http;
 import play.mvc.Result;
@@ -115,12 +114,10 @@ public class DeadboltRouteCommentFilter extends AbstractDeadboltFilter
 
     @Inject
     public DeadboltRouteCommentFilter(final Materializer mat,
-                                      final JavaContextComponents javaContextComponents,
                                       final HandlerCache handlerCache,
                                       final FilterConstraints filterConstraints)
     {
-        super(mat,
-              javaContextComponents);
+        super(mat);
         this.handlerCache = handlerCache;
         this.handler = handlerCache.get();
         this.filterConstraints = filterConstraints;

--- a/code/app/be/objectify/deadbolt/java/filters/DeadboltRouteCommentFilterModule.java
+++ b/code/app/be/objectify/deadbolt/java/filters/DeadboltRouteCommentFilterModule.java
@@ -15,11 +15,13 @@
  */
 package be.objectify.deadbolt.java.filters;
 
-import play.api.Configuration;
-import play.api.Environment;
-import play.api.inject.Binding;
-import play.api.inject.Module;
-import scala.collection.Seq;
+import com.typesafe.config.Config;
+import play.Environment;
+import play.inject.Binding;
+import play.inject.Module;
+
+import java.util.Arrays;
+import java.util.List;
 
 /**
  * Provides bindings for {@link DeadboltRouteCommentFilter}.
@@ -30,9 +32,9 @@ import scala.collection.Seq;
 public class DeadboltRouteCommentFilterModule extends Module
 {
     @Override
-    public Seq<Binding<?>> bindings(final Environment environment,
-                                    final Configuration configuration)
+    public List<Binding<?>> bindings(final Environment environment,
+                                     final Config config)
     {
-        return seq(bind(DeadboltRouteCommentFilter.class).toSelf());
+        return Arrays.asList(bindClass(DeadboltRouteCommentFilter.class).toSelf());
     }
 }

--- a/code/app/be/objectify/deadbolt/java/filters/DeadboltRoutePathFilter.java
+++ b/code/app/be/objectify/deadbolt/java/filters/DeadboltRoutePathFilter.java
@@ -65,8 +65,7 @@ public class DeadboltRoutePathFilter extends AbstractDeadboltFilter
     {
         final Optional<AuthorizedRoute> maybeAuthRoute = authorizedRoutes.apply(requestHeader.method(),
                                                                                 requestHeader.attrs().get(Router.Attrs.HANDLER_DEF).path());
-        return maybeAuthRoute.map(authRoute -> authRoute.constraint().apply(context(requestHeader),
-                                                                            requestHeader,
+        return maybeAuthRoute.map(authRoute -> authRoute.constraint().apply(requestHeader,
                                                                             authRoute.handler().orElse(handler),
                                                                             next)
         ).orElseGet(() -> next.apply(requestHeader));

--- a/code/app/be/objectify/deadbolt/java/filters/DeadboltRoutePathFilter.java
+++ b/code/app/be/objectify/deadbolt/java/filters/DeadboltRoutePathFilter.java
@@ -18,7 +18,6 @@ package be.objectify.deadbolt.java.filters;
 import akka.stream.Materializer;
 import be.objectify.deadbolt.java.DeadboltHandler;
 import be.objectify.deadbolt.java.cache.HandlerCache;
-import play.core.j.JavaContextComponents;
 import play.mvc.Http;
 import play.mvc.Result;
 import play.routing.Router;
@@ -42,12 +41,10 @@ public class DeadboltRoutePathFilter extends AbstractDeadboltFilter
 
     @Inject
     public DeadboltRoutePathFilter(final Materializer mat,
-                                   final JavaContextComponents javaContextComponents,
                                    final HandlerCache handlerCache,
                                    final Provider<AuthorizedRoutes> authorizedRoutes)
     {
-        super(mat,
-              javaContextComponents);
+        super(mat);
         this.handler = handlerCache.get();
         this.authorizedRoutes = authorizedRoutes.get();
     }

--- a/code/app/be/objectify/deadbolt/java/filters/DeadboltRoutePathFilterModule.java
+++ b/code/app/be/objectify/deadbolt/java/filters/DeadboltRoutePathFilterModule.java
@@ -15,11 +15,13 @@
  */
 package be.objectify.deadbolt.java.filters;
 
-import play.api.Configuration;
-import play.api.Environment;
-import play.api.inject.Binding;
-import play.api.inject.Module;
-import scala.collection.Seq;
+import com.typesafe.config.Config;
+import play.Environment;
+import play.inject.Binding;
+import play.inject.Module;
+
+import java.util.Arrays;
+import java.util.List;
 
 /**
  * Provides bindings for {@link DeadboltRoutePathFilter} and {@link FilterConstraints}.
@@ -30,9 +32,9 @@ import scala.collection.Seq;
 public class DeadboltRoutePathFilterModule extends Module
 {
     @Override
-    public Seq<Binding<?>> bindings(final Environment environment,
-                                    final Configuration configuration)
+    public List<Binding<?>> bindings(final Environment environment,
+                                     final Config config)
     {
-        return seq(bind(DeadboltRoutePathFilter.class).toSelf());
+        return Arrays.asList(bindClass(DeadboltRoutePathFilter.class).toSelf());
     }
 }

--- a/code/app/be/objectify/deadbolt/java/filters/FilterConstraints.java
+++ b/code/app/be/objectify/deadbolt/java/filters/FilterConstraints.java
@@ -80,8 +80,8 @@ public class FilterConstraints
                 DeadboltHandler handler,
                 Function<Http.RequestHeader, CompletionStage<Result>> next) ->
                 beforeAuthCheckCache.apply(handler, requestHeader, content)
-                       .thenCompose(maybePreAuth -> maybePreAuth.map(preAuthResult -> (CompletionStage<Result>) CompletableFuture.completedFuture(preAuthResult))
-                                                                .orElseGet(() -> constraintLogic.subjectPresent(context,
+                       .thenCompose(maybePreAuth -> maybePreAuth._1.map(preAuthResult -> (CompletionStage<Result>) CompletableFuture.completedFuture(preAuthResult))
+                                                                .orElseGet(() -> constraintLogic.subjectPresent(maybePreAuth._2,
                                                                                                                 handler,
                                                                                                                 content,
                                                                                                                 (ctx, hdlr, cntent) -> next.apply(requestHeader),
@@ -114,8 +114,8 @@ public class FilterConstraints
                 DeadboltHandler handler,
                 Function<Http.RequestHeader, CompletionStage<Result>> next) ->
                 beforeAuthCheckCache.apply(handler, requestHeader, content)
-                       .thenCompose(maybePreAuth -> maybePreAuth.map(preAuthResult -> (CompletionStage<Result>) CompletableFuture.completedFuture(preAuthResult))
-                                                                .orElseGet(() -> constraintLogic.subjectNotPresent(context,
+                       .thenCompose(maybePreAuth -> maybePreAuth._1.map(preAuthResult -> (CompletionStage<Result>) CompletableFuture.completedFuture(preAuthResult))
+                                                                .orElseGet(() -> constraintLogic.subjectNotPresent(maybePreAuth._2,
                                                                                                                    handler,
                                                                                                                    content,
                                                                                                                    (ctx, hdlr, cntent) -> hdlr.onAuthFailure(context,
@@ -152,8 +152,8 @@ public class FilterConstraints
                 DeadboltHandler handler,
                 Function<Http.RequestHeader, CompletionStage<Result>> next) ->
                 beforeAuthCheckCache.apply(handler, requestHeader, content)
-                       .thenCompose(maybePreAuth -> maybePreAuth.map(preAuthResult -> (CompletionStage<Result>) CompletableFuture.completedFuture(preAuthResult))
-                                                                .orElseGet(() -> constraintLogic.restrict(context,
+                       .thenCompose(maybePreAuth -> maybePreAuth._1.map(preAuthResult -> (CompletionStage<Result>) CompletableFuture.completedFuture(preAuthResult))
+                                                                .orElseGet(() -> constraintLogic.restrict(maybePreAuth._2,
                                                                                                           handler,
                                                                                                           content,
                                                                                                           () -> roleGroups,
@@ -248,8 +248,8 @@ public class FilterConstraints
                 DeadboltHandler handler,
                 Function<Http.RequestHeader, CompletionStage<Result>> next) ->
                 beforeAuthCheckCache.apply(handler, requestHeader, content)
-                       .thenCompose(maybePreAuth -> maybePreAuth.map(preAuthResult -> (CompletionStage<Result>) CompletableFuture.completedFuture(preAuthResult))
-                                                                .orElseGet(() -> constraintLogic.pattern(context,
+                       .thenCompose(maybePreAuth -> maybePreAuth._1.map(preAuthResult -> (CompletionStage<Result>) CompletableFuture.completedFuture(preAuthResult))
+                                                                .orElseGet(() -> constraintLogic.pattern(maybePreAuth._2,
                                                                                                          handler,
                                                                                                          content,
                                                                                                          value,
@@ -311,8 +311,8 @@ public class FilterConstraints
                 DeadboltHandler handler,
                 Function<Http.RequestHeader, CompletionStage<Result>> next) ->
                 beforeAuthCheckCache.apply(handler, requestHeader, content)
-                       .thenCompose(maybePreAuth -> maybePreAuth.map(preAuthResult -> (CompletionStage<Result>) CompletableFuture.completedFuture(preAuthResult))
-                                                                .orElseGet(() -> constraintLogic.dynamic(context,
+                       .thenCompose(maybePreAuth -> maybePreAuth._1.map(preAuthResult -> (CompletionStage<Result>) CompletableFuture.completedFuture(preAuthResult))
+                                                                .orElseGet(() -> constraintLogic.dynamic(maybePreAuth._2,
                                                                                                          handler,
                                                                                                          content,
                                                                                                          name,
@@ -383,16 +383,16 @@ public class FilterConstraints
                 DeadboltHandler handler,
                 Function<Http.RequestHeader, CompletionStage<Result>> next) ->
                 beforeAuthCheckCache.apply(handler, requestHeader, content)
-                       .thenCompose(maybePreAuth -> maybePreAuth.map(preAuthResult -> (CompletionStage<Result>) CompletableFuture.completedFuture(preAuthResult))
-                                                                .orElseGet(() -> constraint.test(context,
+                       .thenCompose(maybePreAuth -> maybePreAuth._1.map(preAuthResult -> (CompletionStage<Result>) CompletableFuture.completedFuture(preAuthResult))
+                                                                .orElseGet(() -> constraint.test(maybePreAuth._2,
                                                                                                  handler)
                                                                                            .thenCompose(allowed -> allowed ? ((Supplier<CompletionStage<Result>>) () -> {
-                                                                                               handler.onAuthSuccess(context,
+                                                                                               handler.onAuthSuccess(maybePreAuth._2,
                                                                                                                      "composite",
                                                                                                                      ConstraintPoint.FILTER);
                                                                                                return next.apply(requestHeader);
                                                                                            }).get()
-                                                                                                                           : handler.onAuthFailure(context,
+                                                                                                                           : handler.onAuthFailure(maybePreAuth._2,
                                                                                                                                                    content))));
     }
 
@@ -409,8 +409,8 @@ public class FilterConstraints
                 DeadboltHandler handler,
                 Function<Http.RequestHeader, CompletionStage<Result>> next) ->
                 beforeAuthCheckCache.apply(handler, requestHeader, content)
-                       .thenCompose(maybePreAuth -> maybePreAuth.map(preAuthResult -> (CompletionStage<Result>) CompletableFuture.completedFuture(preAuthResult))
-                                                                .orElseGet(() -> constraintLogic.roleBasedPermissions(context,
+                       .thenCompose(maybePreAuth -> maybePreAuth._1.map(preAuthResult -> (CompletionStage<Result>) CompletableFuture.completedFuture(preAuthResult))
+                                                                .orElseGet(() -> constraintLogic.roleBasedPermissions(maybePreAuth._2,
                                                                                                                       handler,
                                                                                                                       content,
                                                                                                                       roleName,

--- a/code/app/be/objectify/deadbolt/java/filters/FilterConstraints.java
+++ b/code/app/be/objectify/deadbolt/java/filters/FilterConstraints.java
@@ -84,8 +84,8 @@ public class FilterConstraints
                                                                 .orElseGet(() -> constraintLogic.subjectPresent(maybePreAuth._2,
                                                                                                                 handler,
                                                                                                                 content,
-                                                                                                                (ctx, hdlr, cntent) -> next.apply(requestHeader),
-                                                                                                                (ctx, hdlr, cntent) -> hdlr.onAuthFailure(ctx,
+                                                                                                                (rh, hdlr, cntent) -> next.apply(rh),
+                                                                                                                (rh, hdlr, cntent) -> hdlr.onAuthFailure(rh,
                                                                                                                                                           cntent),
                                                                                                                 ConstraintPoint.FILTER)));
     }
@@ -118,9 +118,9 @@ public class FilterConstraints
                                                                 .orElseGet(() -> constraintLogic.subjectNotPresent(maybePreAuth._2,
                                                                                                                    handler,
                                                                                                                    content,
-                                                                                                                   (ctx, hdlr, cntent) -> hdlr.onAuthFailure(context,
+                                                                                                                   (rh, hdlr, cntent) -> hdlr.onAuthFailure(rh,
                                                                                                                                                              cntent),
-                                                                                                                   (ctx, hdlr, cntent) -> next.apply(requestHeader),
+                                                                                                                   (rh, hdlr, cntent) -> next.apply(rh),
                                                                                                                    ConstraintPoint.FILTER)));
     }
 
@@ -157,8 +157,8 @@ public class FilterConstraints
                                                                                                           handler,
                                                                                                           content,
                                                                                                           () -> roleGroups,
-                                                                                                          ctx -> next.apply(requestHeader),
-                                                                                                          (ctx, hdlr, cntent) -> hdlr.onAuthFailure(ctx,
+                                                                                                          rh -> next.apply(rh),
+                                                                                                          (rh, hdlr, cntent) -> hdlr.onAuthFailure(rh,
                                                                                                                                                     cntent),
                                                                                                           ConstraintPoint.FILTER)));
     }
@@ -256,8 +256,8 @@ public class FilterConstraints
                                                                                                          patternType,
                                                                                                          meta,
                                                                                                          invert,
-                                                                                                         ctx -> next.apply(requestHeader),
-                                                                                                         (ctx, hdlr, cntent) -> hdlr.onAuthFailure(ctx,
+                                                                                                         rh -> next.apply(rh),
+                                                                                                         (rh, hdlr, cntent) -> hdlr.onAuthFailure(rh,
                                                                                                                                                    cntent),
                                                                                                          ConstraintPoint.FILTER)));
     }
@@ -317,8 +317,8 @@ public class FilterConstraints
                                                                                                          content,
                                                                                                          name,
                                                                                                          meta,
-                                                                                                              ctx -> next.apply(requestHeader),
-                                                                                                         (ctx, hdlr, cntent) -> hdlr.onAuthFailure(ctx,
+                                                                                                         rh -> next.apply(rh),
+                                                                                                         (rh, hdlr, cntent) -> hdlr.onAuthFailure(rh,
                                                                                                                                                    cntent),
                                                                                                          ConstraintPoint.FILTER)));
     }
@@ -390,7 +390,7 @@ public class FilterConstraints
                                                                                                handler.onAuthSuccess(maybePreAuth._2,
                                                                                                                      "composite",
                                                                                                                      ConstraintPoint.FILTER);
-                                                                                               return next.apply(requestHeader);
+                                                                                               return next.apply(maybePreAuth._2);
                                                                                            }).get()
                                                                                                                            : handler.onAuthFailure(maybePreAuth._2,
                                                                                                                                                    content))));
@@ -414,8 +414,8 @@ public class FilterConstraints
                                                                                                                       handler,
                                                                                                                       content,
                                                                                                                       roleName,
-                                                                                                                      ctx -> next.apply(requestHeader),
-                                                                                                                      (ctx, hdlr, cntent) -> hdlr.onAuthFailure(ctx,
+                                                                                                                      rh -> next.apply(rh),
+                                                                                                                      (rh, hdlr, cntent) -> hdlr.onAuthFailure(rh,
                                                                                                                                                                 cntent),
                                                                                                                       ConstraintPoint.FILTER)));
     }

--- a/code/app/be/objectify/deadbolt/java/filters/FilterConstraints.java
+++ b/code/app/be/objectify/deadbolt/java/filters/FilterConstraints.java
@@ -76,8 +76,7 @@ public class FilterConstraints
      */
     public FilterFunction subjectPresent(final Optional<String> content)
     {
-        return (Http.Context context,
-                Http.RequestHeader requestHeader,
+        return (Http.RequestHeader requestHeader,
                 DeadboltHandler handler,
                 Function<Http.RequestHeader, CompletionStage<Result>> next) ->
                 beforeAuthCheckCache.apply(handler, context, content)
@@ -111,8 +110,7 @@ public class FilterConstraints
      */
     public FilterFunction subjectNotPresent(final Optional<String> content)
     {
-        return (Http.Context context,
-                Http.RequestHeader requestHeader,
+        return (Http.RequestHeader requestHeader,
                 DeadboltHandler handler,
                 Function<Http.RequestHeader, CompletionStage<Result>> next) ->
                 beforeAuthCheckCache.apply(handler, context, content)
@@ -150,8 +148,7 @@ public class FilterConstraints
     public FilterFunction restrict(final List<String[]> roleGroups,
                                    final Optional<String> content)
     {
-        return (Http.Context context,
-                Http.RequestHeader requestHeader,
+        return (Http.RequestHeader requestHeader,
                 DeadboltHandler handler,
                 Function<Http.RequestHeader, CompletionStage<Result>> next) ->
                 beforeAuthCheckCache.apply(handler, context, content)
@@ -247,8 +244,7 @@ public class FilterConstraints
                                   final boolean invert,
                                   final Optional<String> content)
     {
-        return (Http.Context context,
-                Http.RequestHeader requestHeader,
+        return (Http.RequestHeader requestHeader,
                 DeadboltHandler handler,
                 Function<Http.RequestHeader, CompletionStage<Result>> next) ->
                 beforeAuthCheckCache.apply(handler, context, content)
@@ -311,8 +307,7 @@ public class FilterConstraints
                                   final Optional<String> meta,
                                   final Optional<String> content)
     {
-        return (Http.Context context,
-                Http.RequestHeader requestHeader,
+        return (Http.RequestHeader requestHeader,
                 DeadboltHandler handler,
                 Function<Http.RequestHeader, CompletionStage<Result>> next) ->
                 beforeAuthCheckCache.apply(handler, context, content)
@@ -384,8 +379,7 @@ public class FilterConstraints
     public FilterFunction composite(final Constraint constraint,
                                     final Optional<String> content)
     {
-        return (Http.Context context,
-                Http.RequestHeader requestHeader,
+        return (Http.RequestHeader requestHeader,
                 DeadboltHandler handler,
                 Function<Http.RequestHeader, CompletionStage<Result>> next) ->
                 beforeAuthCheckCache.apply(handler, context, content)
@@ -411,8 +405,7 @@ public class FilterConstraints
     public FilterFunction roleBasedPermissions(final String roleName,
                                                final Optional<String> content)
     {
-        return (Http.Context context,
-                Http.RequestHeader requestHeader,
+        return (Http.RequestHeader requestHeader,
                 DeadboltHandler handler,
                 Function<Http.RequestHeader, CompletionStage<Result>> next) ->
                 beforeAuthCheckCache.apply(handler, context, content)

--- a/code/app/be/objectify/deadbolt/java/filters/FilterConstraints.java
+++ b/code/app/be/objectify/deadbolt/java/filters/FilterConstraints.java
@@ -386,11 +386,11 @@ public class FilterConstraints
                        .thenCompose(maybePreAuth -> maybePreAuth._1.map(preAuthResult -> (CompletionStage<Result>) CompletableFuture.completedFuture(preAuthResult))
                                                                 .orElseGet(() -> constraint.test(maybePreAuth._2,
                                                                                                  handler)
-                                                                                           .thenCompose(allowed -> allowed ? ((Supplier<CompletionStage<Result>>) () -> {
-                                                                                               handler.onAuthSuccess(maybePreAuth._2,
+                                                                                           .thenCompose(allowed -> allowed._1 ? ((Supplier<CompletionStage<Result>>) () -> {
+                                                                                               handler.onAuthSuccess(allowed._2,
                                                                                                                      "composite",
                                                                                                                      ConstraintPoint.FILTER);
-                                                                                               return next.apply(maybePreAuth._2);
+                                                                                               return next.apply(allowed._2);
                                                                                            }).get()
                                                                                                                            : handler.onAuthFailure(maybePreAuth._2,
                                                                                                                                                    content))));

--- a/code/app/be/objectify/deadbolt/java/filters/FilterConstraints.java
+++ b/code/app/be/objectify/deadbolt/java/filters/FilterConstraints.java
@@ -60,7 +60,7 @@ public class FilterConstraints
      * A constraint that requires a subject to be present.
      *
      * @return a function that wraps the constraint
-     * @see ConstraintLogic#subjectPresent(Http.Context, DeadboltHandler, Optional, TriFunction, TriFunction, ConstraintPoint)
+     * @see ConstraintLogic#subjectPresent(Http.RequestHeader, DeadboltHandler, Optional, TriFunction, TriFunction, ConstraintPoint)
      */
     public FilterFunction subjectPresent()
     {
@@ -72,7 +72,7 @@ public class FilterConstraints
      *
      * @param content is passed to {@link DeadboltHandler#onAuthFailure(Http.RequestHeader, Optional)} if the authorization fails
      * @return a function that wraps the constraint
-     * @see ConstraintLogic#subjectPresent(Http.Context, DeadboltHandler, Optional, TriFunction, TriFunction, ConstraintPoint)
+     * @see ConstraintLogic#subjectPresent(Http.RequestHeader, DeadboltHandler, Optional, TriFunction, TriFunction, ConstraintPoint)
      */
     public FilterFunction subjectPresent(final Optional<String> content)
     {
@@ -95,7 +95,7 @@ public class FilterConstraints
      * A constraint that requires a subject to not be present.
      *
      * @return a function that wraps the constraint
-     * @see ConstraintLogic#subjectPresent(Http.Context, DeadboltHandler, Optional, TriFunction, TriFunction, ConstraintPoint)
+     * @see ConstraintLogic#subjectPresent(Http.RequestHeader, DeadboltHandler, Optional, TriFunction, TriFunction, ConstraintPoint)
      */
     public FilterFunction subjectNotPresent()
     {
@@ -107,7 +107,7 @@ public class FilterConstraints
      *
      * @param content is passed to {@link DeadboltHandler#onAuthFailure(Http.RequestHeader, Optional)} if the authorization fails
      * @return a function that wraps the constraint
-     * @see ConstraintLogic#subjectPresent(Http.Context, DeadboltHandler, Optional, TriFunction, TriFunction, ConstraintPoint)
+     * @see ConstraintLogic#subjectPresent(Http.RequestHeader, DeadboltHandler, Optional, TriFunction, TriFunction, ConstraintPoint)
      */
     public FilterFunction subjectNotPresent(final Optional<String> content)
     {
@@ -131,7 +131,7 @@ public class FilterConstraints
      *
      * @param roleGroups
      * @return a function that wraps the constraint
-     * @see ConstraintLogic#restrict(Http.Context, DeadboltHandler, Optional, Supplier, Function, TriFunction, ConstraintPoint)
+     * @see ConstraintLogic#restrict(Http.RequestHeader, DeadboltHandler, Optional, Supplier, Function, TriFunction, ConstraintPoint)
      */
     public FilterFunction restrict(final List<String[]> roleGroups)
     {
@@ -145,7 +145,7 @@ public class FilterConstraints
      * @param roleGroups
      * @param content    is passed to {@link DeadboltHandler#onAuthFailure(Http.RequestHeader, Optional)} if the authorization fails
      * @return a function that wraps the constraint
-     * @see ConstraintLogic#restrict(Http.Context, DeadboltHandler, Optional, Supplier, Function, TriFunction, ConstraintPoint)
+     * @see ConstraintLogic#restrict(Http.RequestHeader, DeadboltHandler, Optional, Supplier, Function, TriFunction, ConstraintPoint)
      */
     public FilterFunction restrict(final List<String[]> roleGroups,
                                    final Optional<String> content)
@@ -168,13 +168,13 @@ public class FilterConstraints
 
     /**
      * A constraint that checks the permissions of a subject (if using {@link PatternType#EQUALITY} or {@link PatternType#REGEX}) or
-     * {@link be.objectify.deadbolt.java.DynamicResourceHandler#checkPermission(String, Optional, DeadboltHandler, Http.Context)} (if
+     * {@link be.objectify.deadbolt.java.DynamicResourceHandler#checkPermission(String, Optional, DeadboltHandler, Http.RequestHeader)} (if
      * using {@link PatternType#CUSTOM}).
      *
      * @param value       the constraint value
      * @param patternType the type of pattern matching
      * @return a function that wraps the constraint
-     * @see ConstraintLogic#pattern(Http.Context, DeadboltHandler, Optional, String, PatternType, Optional, boolean, Function, TriFunction, ConstraintPoint)
+     * @see ConstraintLogic#pattern(Http.RequestHeader, DeadboltHandler, Optional, String, PatternType, Optional, boolean, Function, TriFunction, ConstraintPoint)
      */
     public FilterFunction pattern(final String value,
                                   final PatternType patternType)
@@ -186,14 +186,14 @@ public class FilterConstraints
 
     /**
      * A constraint that checks the permissions of a subject (if using {@link PatternType#EQUALITY} or {@link PatternType#REGEX}) or
-     * {@link be.objectify.deadbolt.java.DynamicResourceHandler#checkPermission(String, Optional, DeadboltHandler, Http.Context)} (if
+     * {@link be.objectify.deadbolt.java.DynamicResourceHandler#checkPermission(String, Optional, DeadboltHandler, Http.RequestHeader)} (if
      * using {@link PatternType#CUSTOM}).
      *
      * @param value       the constraint value
      * @param patternType the type of pattern matching
-     * @param meta        additional information passed to {@link be.objectify.deadbolt.java.DynamicResourceHandler#checkPermission(String, Optional, DeadboltHandler, Http.Context)}
+     * @param meta        additional information passed to {@link be.objectify.deadbolt.java.DynamicResourceHandler#checkPermission(String, Optional, DeadboltHandler, Http.RequestHeader)}
      * @return a function that wraps the constraint
-     * @see ConstraintLogic#pattern(Http.Context, DeadboltHandler, Optional, String, PatternType, Optional, boolean, Function, TriFunction, ConstraintPoint)
+     * @see ConstraintLogic#pattern(Http.RequestHeader, DeadboltHandler, Optional, String, PatternType, Optional, boolean, Function, TriFunction, ConstraintPoint)
      */
     public FilterFunction pattern(final String value,
                                   final PatternType patternType,
@@ -208,14 +208,14 @@ public class FilterConstraints
 
     /**
      * A constraint that checks the permissions of a subject (if using {@link PatternType#EQUALITY} or {@link PatternType#REGEX}) or
-     * {@link be.objectify.deadbolt.java.DynamicResourceHandler#checkPermission(String, Optional, DeadboltHandler, Http.Context)} (if
+     * {@link be.objectify.deadbolt.java.DynamicResourceHandler#checkPermission(String, Optional, DeadboltHandler, Http.RequestHeader)} (if
      * using {@link PatternType#CUSTOM}).
      *
      * @param value       the constraint value
      * @param patternType the type of pattern matching
      * @param invert      invert the meaning of the constraint, where a successful match results in authorization failing
      * @return a function that wraps the constraint
-     * @see ConstraintLogic#pattern(Http.Context, DeadboltHandler, Optional, String, PatternType, Optional, boolean, Function, TriFunction, ConstraintPoint)
+     * @see ConstraintLogic#pattern(Http.RequestHeader, DeadboltHandler, Optional, String, PatternType, Optional, boolean, Function, TriFunction, ConstraintPoint)
      */
     public FilterFunction pattern(final String value,
                                   final PatternType patternType,
@@ -230,16 +230,16 @@ public class FilterConstraints
 
     /**
      * A constraint that checks the permissions of a subject (if using {@link PatternType#EQUALITY} or {@link PatternType#REGEX}) or
-     * {@link be.objectify.deadbolt.java.DynamicResourceHandler#checkPermission(String, Optional, DeadboltHandler, Http.Context)} (if
+     * {@link be.objectify.deadbolt.java.DynamicResourceHandler#checkPermission(String, Optional, DeadboltHandler, Http.RequestHeader)} (if
      * using {@link PatternType#CUSTOM}).
      *
      * @param value       the constraint value
      * @param patternType the type of pattern matching
-     * @param meta        additional information passed to {@link be.objectify.deadbolt.java.DynamicResourceHandler#checkPermission(String, Optional, DeadboltHandler, Http.Context)}
+     * @param meta        additional information passed to {@link be.objectify.deadbolt.java.DynamicResourceHandler#checkPermission(String, Optional, DeadboltHandler, Http.RequestHeader)}
      * @param invert      invert the meaning of the constraint, where a successful match results in authorization failing
      * @param content     is passed to {@link DeadboltHandler#onAuthFailure(Http.RequestHeader, Optional)} if the authorization fails
      * @return a function that wraps the constraint
-     * @see ConstraintLogic#pattern(Http.Context, DeadboltHandler, Optional, String, PatternType, Optional, boolean, Function, TriFunction, ConstraintPoint)
+     * @see ConstraintLogic#pattern(Http.RequestHeader, DeadboltHandler, Optional, String, PatternType, Optional, boolean, Function, TriFunction, ConstraintPoint)
      */
     public FilterFunction pattern(final String value,
                                   final PatternType patternType,
@@ -267,12 +267,12 @@ public class FilterConstraints
     }
 
     /**
-     * An arbitrary constraint that uses {@link be.objectify.deadbolt.java.DynamicResourceHandler#isAllowed(String, Optional, DeadboltHandler, Http.Context)}
+     * An arbitrary constraint that uses {@link be.objectify.deadbolt.java.DynamicResourceHandler#isAllowed(String, Optional, DeadboltHandler, Http.RequestHeader)}
      * to determine access.
      *
      * @param name the name of the constraint
      * @return a function that wraps the constraint
-     * @see ConstraintLogic#dynamic(Http.Context, DeadboltHandler, Optional, String, Optional, Function, TriFunction, ConstraintPoint)
+     * @see ConstraintLogic#dynamic(Http.RequestHeader, DeadboltHandler, Optional, String, Optional, Function, TriFunction, ConstraintPoint)
      */
     public FilterFunction dynamic(final String name)
     {
@@ -281,13 +281,13 @@ public class FilterConstraints
     }
 
     /**
-     * An arbitrary constraint that uses {@link be.objectify.deadbolt.java.DynamicResourceHandler#isAllowed(String, Optional, DeadboltHandler, Http.Context)}
+     * An arbitrary constraint that uses {@link be.objectify.deadbolt.java.DynamicResourceHandler#isAllowed(String, Optional, DeadboltHandler, Http.RequestHeader)}
      * to determine access.
      *
      * @param name the name of the constraint
-     * @param meta additional information passed to {@link be.objectify.deadbolt.java.DynamicResourceHandler#isAllowed(String, Optional, DeadboltHandler, Http.Context)}
+     * @param meta additional information passed to {@link be.objectify.deadbolt.java.DynamicResourceHandler#isAllowed(String, Optional, DeadboltHandler, Http.RequestHeader)}
      * @return a function that wraps the constraint
-     * @see ConstraintLogic#dynamic(Http.Context, DeadboltHandler, Optional, String, Optional, Function, TriFunction, ConstraintPoint)
+     * @see ConstraintLogic#dynamic(Http.RequestHeader, DeadboltHandler, Optional, String, Optional, Function, TriFunction, ConstraintPoint)
      */
     public FilterFunction dynamic(final String name,
                                   final Optional<String> meta)
@@ -298,14 +298,14 @@ public class FilterConstraints
     }
 
     /**
-     * An arbitrary constraint that uses {@link be.objectify.deadbolt.java.DynamicResourceHandler#isAllowed(String, Optional, DeadboltHandler, Http.Context)}
+     * An arbitrary constraint that uses {@link be.objectify.deadbolt.java.DynamicResourceHandler#isAllowed(String, Optional, DeadboltHandler, Http.RequestHeader)}
      * to determine access.
      *
      * @param name    the name of the constraint
-     * @param meta    additional information passed to {@link be.objectify.deadbolt.java.DynamicResourceHandler#isAllowed(String, Optional, DeadboltHandler, Http.Context)}
+     * @param meta    additional information passed to {@link be.objectify.deadbolt.java.DynamicResourceHandler#isAllowed(String, Optional, DeadboltHandler, Http.RequestHeader)}
      * @param content is passed to {@link DeadboltHandler#onAuthFailure(Http.RequestHeader, Optional)} if the authorization fails
      * @return a function that wraps the constraint
-     * @see ConstraintLogic#dynamic(Http.Context, DeadboltHandler, Optional, String, Optional, Function, TriFunction, ConstraintPoint)
+     * @see ConstraintLogic#dynamic(Http.RequestHeader, DeadboltHandler, Optional, String, Optional, Function, TriFunction, ConstraintPoint)
      */
     public FilterFunction dynamic(final String name,
                                   final Optional<String> meta,

--- a/code/app/be/objectify/deadbolt/java/filters/FilterConstraints.java
+++ b/code/app/be/objectify/deadbolt/java/filters/FilterConstraints.java
@@ -79,7 +79,7 @@ public class FilterConstraints
         return (Http.RequestHeader requestHeader,
                 DeadboltHandler handler,
                 Function<Http.RequestHeader, CompletionStage<Result>> next) ->
-                beforeAuthCheckCache.apply(handler, context, content)
+                beforeAuthCheckCache.apply(handler, requestHeader, content)
                        .thenCompose(maybePreAuth -> maybePreAuth.map(preAuthResult -> (CompletionStage<Result>) CompletableFuture.completedFuture(preAuthResult))
                                                                 .orElseGet(() -> constraintLogic.subjectPresent(context,
                                                                                                                 handler,
@@ -113,7 +113,7 @@ public class FilterConstraints
         return (Http.RequestHeader requestHeader,
                 DeadboltHandler handler,
                 Function<Http.RequestHeader, CompletionStage<Result>> next) ->
-                beforeAuthCheckCache.apply(handler, context, content)
+                beforeAuthCheckCache.apply(handler, requestHeader, content)
                        .thenCompose(maybePreAuth -> maybePreAuth.map(preAuthResult -> (CompletionStage<Result>) CompletableFuture.completedFuture(preAuthResult))
                                                                 .orElseGet(() -> constraintLogic.subjectNotPresent(context,
                                                                                                                    handler,
@@ -151,7 +151,7 @@ public class FilterConstraints
         return (Http.RequestHeader requestHeader,
                 DeadboltHandler handler,
                 Function<Http.RequestHeader, CompletionStage<Result>> next) ->
-                beforeAuthCheckCache.apply(handler, context, content)
+                beforeAuthCheckCache.apply(handler, requestHeader, content)
                        .thenCompose(maybePreAuth -> maybePreAuth.map(preAuthResult -> (CompletionStage<Result>) CompletableFuture.completedFuture(preAuthResult))
                                                                 .orElseGet(() -> constraintLogic.restrict(context,
                                                                                                           handler,
@@ -247,7 +247,7 @@ public class FilterConstraints
         return (Http.RequestHeader requestHeader,
                 DeadboltHandler handler,
                 Function<Http.RequestHeader, CompletionStage<Result>> next) ->
-                beforeAuthCheckCache.apply(handler, context, content)
+                beforeAuthCheckCache.apply(handler, requestHeader, content)
                        .thenCompose(maybePreAuth -> maybePreAuth.map(preAuthResult -> (CompletionStage<Result>) CompletableFuture.completedFuture(preAuthResult))
                                                                 .orElseGet(() -> constraintLogic.pattern(context,
                                                                                                          handler,
@@ -310,7 +310,7 @@ public class FilterConstraints
         return (Http.RequestHeader requestHeader,
                 DeadboltHandler handler,
                 Function<Http.RequestHeader, CompletionStage<Result>> next) ->
-                beforeAuthCheckCache.apply(handler, context, content)
+                beforeAuthCheckCache.apply(handler, requestHeader, content)
                        .thenCompose(maybePreAuth -> maybePreAuth.map(preAuthResult -> (CompletionStage<Result>) CompletableFuture.completedFuture(preAuthResult))
                                                                 .orElseGet(() -> constraintLogic.dynamic(context,
                                                                                                          handler,
@@ -382,7 +382,7 @@ public class FilterConstraints
         return (Http.RequestHeader requestHeader,
                 DeadboltHandler handler,
                 Function<Http.RequestHeader, CompletionStage<Result>> next) ->
-                beforeAuthCheckCache.apply(handler, context, content)
+                beforeAuthCheckCache.apply(handler, requestHeader, content)
                        .thenCompose(maybePreAuth -> maybePreAuth.map(preAuthResult -> (CompletionStage<Result>) CompletableFuture.completedFuture(preAuthResult))
                                                                 .orElseGet(() -> constraint.test(context,
                                                                                                  handler)
@@ -408,7 +408,7 @@ public class FilterConstraints
         return (Http.RequestHeader requestHeader,
                 DeadboltHandler handler,
                 Function<Http.RequestHeader, CompletionStage<Result>> next) ->
-                beforeAuthCheckCache.apply(handler, context, content)
+                beforeAuthCheckCache.apply(handler, requestHeader, content)
                        .thenCompose(maybePreAuth -> maybePreAuth.map(preAuthResult -> (CompletionStage<Result>) CompletableFuture.completedFuture(preAuthResult))
                                                                 .orElseGet(() -> constraintLogic.roleBasedPermissions(context,
                                                                                                                       handler,

--- a/code/app/be/objectify/deadbolt/java/filters/FilterConstraints.java
+++ b/code/app/be/objectify/deadbolt/java/filters/FilterConstraints.java
@@ -70,7 +70,7 @@ public class FilterConstraints
     /**
      * A constraint that requires a subject to be present.
      *
-     * @param content is passed to {@link DeadboltHandler#onAuthFailure(Http.Context, Optional)} if the authorization fails
+     * @param content is passed to {@link DeadboltHandler#onAuthFailure(Http.RequestHeader, Optional)} if the authorization fails
      * @return a function that wraps the constraint
      * @see ConstraintLogic#subjectPresent(Http.Context, DeadboltHandler, Optional, TriFunction, TriFunction, ConstraintPoint)
      */
@@ -105,7 +105,7 @@ public class FilterConstraints
     /**
      * A constraint that requires a subject to not be present.
      *
-     * @param content is passed to {@link DeadboltHandler#onAuthFailure(Http.Context, Optional)} if the authorization fails
+     * @param content is passed to {@link DeadboltHandler#onAuthFailure(Http.RequestHeader, Optional)} if the authorization fails
      * @return a function that wraps the constraint
      * @see ConstraintLogic#subjectPresent(Http.Context, DeadboltHandler, Optional, TriFunction, TriFunction, ConstraintPoint)
      */
@@ -143,7 +143,7 @@ public class FilterConstraints
      * A constraint that requires the subject to hold certain roles.
      *
      * @param roleGroups
-     * @param content    is passed to {@link DeadboltHandler#onAuthFailure(Http.Context, Optional)} if the authorization fails
+     * @param content    is passed to {@link DeadboltHandler#onAuthFailure(Http.RequestHeader, Optional)} if the authorization fails
      * @return a function that wraps the constraint
      * @see ConstraintLogic#restrict(Http.Context, DeadboltHandler, Optional, Supplier, Function, TriFunction, ConstraintPoint)
      */
@@ -237,7 +237,7 @@ public class FilterConstraints
      * @param patternType the type of pattern matching
      * @param meta        additional information passed to {@link be.objectify.deadbolt.java.DynamicResourceHandler#checkPermission(String, Optional, DeadboltHandler, Http.Context)}
      * @param invert      invert the meaning of the constraint, where a successful match results in authorization failing
-     * @param content     is passed to {@link DeadboltHandler#onAuthFailure(Http.Context, Optional)} if the authorization fails
+     * @param content     is passed to {@link DeadboltHandler#onAuthFailure(Http.RequestHeader, Optional)} if the authorization fails
      * @return a function that wraps the constraint
      * @see ConstraintLogic#pattern(Http.Context, DeadboltHandler, Optional, String, PatternType, Optional, boolean, Function, TriFunction, ConstraintPoint)
      */
@@ -303,7 +303,7 @@ public class FilterConstraints
      *
      * @param name    the name of the constraint
      * @param meta    additional information passed to {@link be.objectify.deadbolt.java.DynamicResourceHandler#isAllowed(String, Optional, DeadboltHandler, Http.Context)}
-     * @param content is passed to {@link DeadboltHandler#onAuthFailure(Http.Context, Optional)} if the authorization fails
+     * @param content is passed to {@link DeadboltHandler#onAuthFailure(Http.RequestHeader, Optional)} if the authorization fails
      * @return a function that wraps the constraint
      * @see ConstraintLogic#dynamic(Http.Context, DeadboltHandler, Optional, String, Optional, Function, TriFunction, ConstraintPoint)
      */
@@ -347,7 +347,7 @@ public class FilterConstraints
      * tree of constraints.
      *
      * @param name    the name of the composite constraint defined in {@link CompositeCache}.
-     * @param content is passed to {@link DeadboltHandler#onAuthFailure(Http.Context, Optional)} if the authorization fails
+     * @param content is passed to {@link DeadboltHandler#onAuthFailure(Http.RequestHeader, Optional)} if the authorization fails
      * @return a function that wraps the constraint
      * @throws IllegalStateException if no constraint with the given name is present in the composite cache
      */
@@ -378,7 +378,7 @@ public class FilterConstraints
      * tree of constraints.
      *
      * @param constraint the composite constraint
-     * @param content    is passed to {@link DeadboltHandler#onAuthFailure(Http.Context, Optional)} if the authorization fails
+     * @param content    is passed to {@link DeadboltHandler#onAuthFailure(Http.RequestHeader, Optional)} if the authorization fails
      * @return a function that wraps the constraint
      */
     public FilterFunction composite(final Constraint constraint,

--- a/code/app/be/objectify/deadbolt/java/filters/FilterFunction.java
+++ b/code/app/be/objectify/deadbolt/java/filters/FilterFunction.java
@@ -16,7 +16,7 @@
 package be.objectify.deadbolt.java.filters;
 
 import be.objectify.deadbolt.java.DeadboltHandler;
-import be.objectify.deadbolt.java.utils.QuadFunction;
+import be.objectify.deadbolt.java.utils.TriFunction;
 import play.mvc.Http;
 import play.mvc.Result;
 
@@ -27,20 +27,18 @@ import java.util.function.Function;
  * @author Steve Chaloner (steve@objectify.be)
  * @since 2.5.1
  */
-public interface FilterFunction extends QuadFunction<Http.Context, Http.RequestHeader, DeadboltHandler, Function<Http.RequestHeader, CompletionStage<Result>>, CompletionStage<Result>>
+public interface FilterFunction extends TriFunction<Http.RequestHeader, DeadboltHandler, Function<Http.RequestHeader, CompletionStage<Result>>, CompletionStage<Result>>
 {
     /**
      * Test the constraint against the current request.
      *
-     * @param context       the HTTP context
      * @param requestHeader the request header
      * @param handler       the deadbolt handler
      * @param onSuccess     a function to process the request if the constraint test passes
      * @return a future for the result
      */
     @Override
-    CompletionStage<Result> apply(Http.Context context,
-                                  Http.RequestHeader requestHeader,
+    CompletionStage<Result> apply(Http.RequestHeader requestHeader,
                                   DeadboltHandler handler,
                                   Function<Http.RequestHeader, CompletionStage<Result>> onSuccess);
 }

--- a/code/app/be/objectify/deadbolt/java/views/di/dynamic.scala.html
+++ b/code/app/be/objectify/deadbolt/java/views/di/dynamic.scala.html
@@ -1,5 +1,5 @@
 @this(viewSupport: be.objectify.deadbolt.java.ViewSupport, handlerCache: be.objectify.deadbolt.java.cache.HandlerCache)
-@(name: String, meta: Optional[String] = Optional.empty(), handler: be.objectify.deadbolt.java.DeadboltHandler = handlerCache.get(), content: Optional[String] = Optional.empty(), timeout: java.util.function.Supplier[Long] = viewSupport.defaultTimeout)(body: => Html)(implicit requestHeader: play.api.mvc.RequestHeader)
-@if(viewSupport.viewDynamic(name, meta, handler, content, timeout.get(), requestHeader.asJava)) {
+@(name: String, meta: Optional[String] = Optional.empty(), handler: be.objectify.deadbolt.java.DeadboltHandler = handlerCache.get(), content: Optional[String] = Optional.empty(), timeout: Long = viewSupport.timeout)(body: => Html)(implicit requestHeader: play.api.mvc.RequestHeader)
+@if(viewSupport.viewDynamic(name, meta, handler, content, timeout, requestHeader.asJava)) {
     @body
 }

--- a/code/app/be/objectify/deadbolt/java/views/di/dynamic.scala.html
+++ b/code/app/be/objectify/deadbolt/java/views/di/dynamic.scala.html
@@ -1,5 +1,5 @@
 @this(viewSupport: be.objectify.deadbolt.java.ViewSupport, handlerCache: be.objectify.deadbolt.java.cache.HandlerCache)
-@(context: Http.Context, name: String, meta: Optional[String] = Optional.empty(), handler: be.objectify.deadbolt.java.DeadboltHandler = handlerCache.get(), content: Optional[String] = Optional.empty(), timeout: java.util.function.Supplier[Long] = viewSupport.defaultTimeout)(body: => Html)
-@if(viewSupport.viewDynamic(name, meta, handler, content, timeout.get(), context)) {
+@(name: String, meta: Optional[String] = Optional.empty(), handler: be.objectify.deadbolt.java.DeadboltHandler = handlerCache.get(), content: Optional[String] = Optional.empty(), timeout: java.util.function.Supplier[Long] = viewSupport.defaultTimeout)(body: => Html)(implicit requestHeader: play.api.mvc.RequestHeader)
+@if(viewSupport.viewDynamic(name, meta, handler, content, timeout.get(), requestHeader.asJava)) {
     @body
 }

--- a/code/app/be/objectify/deadbolt/java/views/di/dynamicOr.scala.html
+++ b/code/app/be/objectify/deadbolt/java/views/di/dynamicOr.scala.html
@@ -1,6 +1,6 @@
 @this(viewSupport: be.objectify.deadbolt.java.ViewSupport, handlerCache: be.objectify.deadbolt.java.cache.HandlerCache)
-@(name: String, meta: Optional[String] = Optional.empty(), handler: be.objectify.deadbolt.java.DeadboltHandler = handlerCache.get(), content: Optional[String] = Optional.empty(), timeout: java.util.function.Supplier[Long] = viewSupport.defaultTimeout)(body: => Html)(alternativeBody: => Html)(implicit requestHeader: play.api.mvc.RequestHeader)
-@if(viewSupport.viewDynamic(name, meta, handler, content, timeout.get(), requestHeader.asJava)) {
+@(name: String, meta: Optional[String] = Optional.empty(), handler: be.objectify.deadbolt.java.DeadboltHandler = handlerCache.get(), content: Optional[String] = Optional.empty(), timeout: Long = viewSupport.timeout)(body: => Html)(alternativeBody: => Html)(implicit requestHeader: play.api.mvc.RequestHeader)
+@if(viewSupport.viewDynamic(name, meta, handler, content, timeout, requestHeader.asJava)) {
     @body
 } else {
     @alternativeBody

--- a/code/app/be/objectify/deadbolt/java/views/di/dynamicOr.scala.html
+++ b/code/app/be/objectify/deadbolt/java/views/di/dynamicOr.scala.html
@@ -1,6 +1,6 @@
 @this(viewSupport: be.objectify.deadbolt.java.ViewSupport, handlerCache: be.objectify.deadbolt.java.cache.HandlerCache)
-@(context: Http.Context, name: String, meta: Optional[String] = Optional.empty(), handler: be.objectify.deadbolt.java.DeadboltHandler = handlerCache.get(), content: Optional[String] = Optional.empty(), timeout: java.util.function.Supplier[Long] = viewSupport.defaultTimeout)(body: => Html)(alternativeBody: => Html)
-@if(viewSupport.viewDynamic(name, meta, handler, content, timeout.get(), context)) {
+@(name: String, meta: Optional[String] = Optional.empty(), handler: be.objectify.deadbolt.java.DeadboltHandler = handlerCache.get(), content: Optional[String] = Optional.empty(), timeout: java.util.function.Supplier[Long] = viewSupport.defaultTimeout)(body: => Html)(alternativeBody: => Html)(implicit requestHeader: play.api.mvc.RequestHeader)
+@if(viewSupport.viewDynamic(name, meta, handler, content, timeout.get(), requestHeader.asJava)) {
     @body
 } else {
     @alternativeBody

--- a/code/app/be/objectify/deadbolt/java/views/di/pattern.scala.html
+++ b/code/app/be/objectify/deadbolt/java/views/di/pattern.scala.html
@@ -1,5 +1,5 @@
 @this(viewSupport: be.objectify.deadbolt.java.ViewSupport, handlerCache: be.objectify.deadbolt.java.cache.HandlerCache)
-@(value: String, patternType: be.objectify.deadbolt.java.models.PatternType = be.objectify.deadbolt.java.models.PatternType.EQUALITY, meta: Optional[String] = Optional.empty(), invert: java.lang.Boolean = false, handler: be.objectify.deadbolt.java.DeadboltHandler = handlerCache.get(), content: Optional[String] = Optional.empty(), timeout: java.util.function.Supplier[Long] = viewSupport.defaultTimeout)(body: => Html)(implicit requestHeader: play.api.mvc.RequestHeader)
-@if(viewSupport.viewPattern(value, patternType, meta, invert, handler, content, timeout.get(), requestHeader.asJava)) {
+@(value: String, patternType: be.objectify.deadbolt.java.models.PatternType = be.objectify.deadbolt.java.models.PatternType.EQUALITY, meta: Optional[String] = Optional.empty(), invert: java.lang.Boolean = false, handler: be.objectify.deadbolt.java.DeadboltHandler = handlerCache.get(), content: Optional[String] = Optional.empty(), timeout: Long = viewSupport.timeout)(body: => Html)(implicit requestHeader: play.api.mvc.RequestHeader)
+@if(viewSupport.viewPattern(value, patternType, meta, invert, handler, content, timeout, requestHeader.asJava)) {
     @body
 }

--- a/code/app/be/objectify/deadbolt/java/views/di/pattern.scala.html
+++ b/code/app/be/objectify/deadbolt/java/views/di/pattern.scala.html
@@ -1,5 +1,5 @@
 @this(viewSupport: be.objectify.deadbolt.java.ViewSupport, handlerCache: be.objectify.deadbolt.java.cache.HandlerCache)
-@(context: Http.Context, value: String, patternType: be.objectify.deadbolt.java.models.PatternType = be.objectify.deadbolt.java.models.PatternType.EQUALITY, meta: Optional[String] = Optional.empty(), invert: java.lang.Boolean = false, handler: be.objectify.deadbolt.java.DeadboltHandler = handlerCache.get(), content: Optional[String] = Optional.empty(), timeout: java.util.function.Supplier[Long] = viewSupport.defaultTimeout)(body: => Html)
-@if(viewSupport.viewPattern(value, patternType, meta, invert, handler, content, timeout.get(), context)) {
+@(value: String, patternType: be.objectify.deadbolt.java.models.PatternType = be.objectify.deadbolt.java.models.PatternType.EQUALITY, meta: Optional[String] = Optional.empty(), invert: java.lang.Boolean = false, handler: be.objectify.deadbolt.java.DeadboltHandler = handlerCache.get(), content: Optional[String] = Optional.empty(), timeout: java.util.function.Supplier[Long] = viewSupport.defaultTimeout)(body: => Html)(implicit requestHeader: play.api.mvc.RequestHeader)
+@if(viewSupport.viewPattern(value, patternType, meta, invert, handler, content, timeout.get(), requestHeader.asJava)) {
     @body
 }

--- a/code/app/be/objectify/deadbolt/java/views/di/patternOr.scala.html
+++ b/code/app/be/objectify/deadbolt/java/views/di/patternOr.scala.html
@@ -1,6 +1,6 @@
 @this(viewSupport: be.objectify.deadbolt.java.ViewSupport, handlerCache: be.objectify.deadbolt.java.cache.HandlerCache)
-@(value: String, patternType: be.objectify.deadbolt.java.models.PatternType = be.objectify.deadbolt.java.models.PatternType.EQUALITY, meta: Optional[String] = Optional.empty(), invert: java.lang.Boolean = false, handler: be.objectify.deadbolt.java.DeadboltHandler = handlerCache.get(), content: Optional[String] = Optional.empty(), timeout: java.util.function.Supplier[Long] = viewSupport.defaultTimeout)(body: => Html)(alternativeBody: => Html)(implicit requestHeader: play.api.mvc.RequestHeader)
-@if(viewSupport.viewPattern(value, patternType, meta, invert, handler, content, timeout.get(), requestHeader.asJava)) {
+@(value: String, patternType: be.objectify.deadbolt.java.models.PatternType = be.objectify.deadbolt.java.models.PatternType.EQUALITY, meta: Optional[String] = Optional.empty(), invert: java.lang.Boolean = false, handler: be.objectify.deadbolt.java.DeadboltHandler = handlerCache.get(), content: Optional[String] = Optional.empty(), timeout: Long = viewSupport.timeout)(body: => Html)(alternativeBody: => Html)(implicit requestHeader: play.api.mvc.RequestHeader)
+@if(viewSupport.viewPattern(value, patternType, meta, invert, handler, content, timeout, requestHeader.asJava)) {
     @body
 } else {
     @alternativeBody

--- a/code/app/be/objectify/deadbolt/java/views/di/patternOr.scala.html
+++ b/code/app/be/objectify/deadbolt/java/views/di/patternOr.scala.html
@@ -1,6 +1,6 @@
 @this(viewSupport: be.objectify.deadbolt.java.ViewSupport, handlerCache: be.objectify.deadbolt.java.cache.HandlerCache)
-@(context: Http.Context, value: String, patternType: be.objectify.deadbolt.java.models.PatternType = be.objectify.deadbolt.java.models.PatternType.EQUALITY, meta: Optional[String] = Optional.empty(), invert: java.lang.Boolean = false, handler: be.objectify.deadbolt.java.DeadboltHandler = handlerCache.get(), content: Optional[String] = Optional.empty(), timeout: java.util.function.Supplier[Long] = viewSupport.defaultTimeout)(body: => Html)(alternativeBody: => Html)
-@if(viewSupport.viewPattern(value, patternType, meta, invert, handler, content, timeout.get(), context)) {
+@(value: String, patternType: be.objectify.deadbolt.java.models.PatternType = be.objectify.deadbolt.java.models.PatternType.EQUALITY, meta: Optional[String] = Optional.empty(), invert: java.lang.Boolean = false, handler: be.objectify.deadbolt.java.DeadboltHandler = handlerCache.get(), content: Optional[String] = Optional.empty(), timeout: java.util.function.Supplier[Long] = viewSupport.defaultTimeout)(body: => Html)(alternativeBody: => Html)(implicit requestHeader: play.api.mvc.RequestHeader)
+@if(viewSupport.viewPattern(value, patternType, meta, invert, handler, content, timeout.get(), requestHeader.asJava)) {
     @body
 } else {
     @alternativeBody

--- a/code/app/be/objectify/deadbolt/java/views/di/restrict.scala.html
+++ b/code/app/be/objectify/deadbolt/java/views/di/restrict.scala.html
@@ -1,5 +1,5 @@
 @this(viewSupport: be.objectify.deadbolt.java.ViewSupport, handlerCache: be.objectify.deadbolt.java.cache.HandlerCache)
-@(context: Http.Context, roles: java.util.List[Array[String]], handler: be.objectify.deadbolt.java.DeadboltHandler = handlerCache.get(), content: Optional[String] = Optional.empty(), timeout: java.util.function.Supplier[Long] = viewSupport.defaultTimeout)(body: => Html)
-@if(viewSupport.viewRestrict(roles, handler, content, timeout.get(), context)) {
+@(roles: java.util.List[Array[String]], handler: be.objectify.deadbolt.java.DeadboltHandler = handlerCache.get(), content: Optional[String] = Optional.empty(), timeout: java.util.function.Supplier[Long] = viewSupport.defaultTimeout)(body: => Html)(implicit requestHeader: play.api.mvc.RequestHeader)
+@if(viewSupport.viewRestrict(roles, handler, content, timeout.get(), requestHeader.asJava)) {
     @body
 }

--- a/code/app/be/objectify/deadbolt/java/views/di/restrict.scala.html
+++ b/code/app/be/objectify/deadbolt/java/views/di/restrict.scala.html
@@ -1,5 +1,5 @@
 @this(viewSupport: be.objectify.deadbolt.java.ViewSupport, handlerCache: be.objectify.deadbolt.java.cache.HandlerCache)
-@(roles: java.util.List[Array[String]], handler: be.objectify.deadbolt.java.DeadboltHandler = handlerCache.get(), content: Optional[String] = Optional.empty(), timeout: java.util.function.Supplier[Long] = viewSupport.defaultTimeout)(body: => Html)(implicit requestHeader: play.api.mvc.RequestHeader)
-@if(viewSupport.viewRestrict(roles, handler, content, timeout.get(), requestHeader.asJava)) {
+@(roles: java.util.List[Array[String]], handler: be.objectify.deadbolt.java.DeadboltHandler = handlerCache.get(), content: Optional[String] = Optional.empty(), timeout: Long = viewSupport.timeout)(body: => Html)(implicit requestHeader: play.api.mvc.RequestHeader)
+@if(viewSupport.viewRestrict(roles, handler, content, timeout, requestHeader.asJava)) {
     @body
 }

--- a/code/app/be/objectify/deadbolt/java/views/di/restrictOr.scala.html
+++ b/code/app/be/objectify/deadbolt/java/views/di/restrictOr.scala.html
@@ -1,6 +1,6 @@
 @this(viewSupport: be.objectify.deadbolt.java.ViewSupport, handlerCache: be.objectify.deadbolt.java.cache.HandlerCache)
-@(roles: java.util.List[Array[String]], handler: be.objectify.deadbolt.java.DeadboltHandler = handlerCache.get(), content: Optional[String] = Optional.empty(), timeout: java.util.function.Supplier[Long] = viewSupport.defaultTimeout)(body: => Html)(alternativeBody: => Html)(implicit requestHeader: play.api.mvc.RequestHeader)
-@if(viewSupport.viewRestrict(roles, handler, content, timeout.get(), requestHeader.asJava)) {
+@(roles: java.util.List[Array[String]], handler: be.objectify.deadbolt.java.DeadboltHandler = handlerCache.get(), content: Optional[String] = Optional.empty(), timeout: Long = viewSupport.timeout)(body: => Html)(alternativeBody: => Html)(implicit requestHeader: play.api.mvc.RequestHeader)
+@if(viewSupport.viewRestrict(roles, handler, content, timeout, requestHeader.asJava)) {
     @body
 } else {
     @alternativeBody

--- a/code/app/be/objectify/deadbolt/java/views/di/restrictOr.scala.html
+++ b/code/app/be/objectify/deadbolt/java/views/di/restrictOr.scala.html
@@ -1,6 +1,6 @@
 @this(viewSupport: be.objectify.deadbolt.java.ViewSupport, handlerCache: be.objectify.deadbolt.java.cache.HandlerCache)
-@(context: Http.Context, roles: java.util.List[Array[String]], handler: be.objectify.deadbolt.java.DeadboltHandler = handlerCache.get(), content: Optional[String] = Optional.empty(), timeout: java.util.function.Supplier[Long] = viewSupport.defaultTimeout)(body: => Html)(alternativeBody: => Html)
-@if(viewSupport.viewRestrict(roles, handler, content, timeout.get(), context)) {
+@(roles: java.util.List[Array[String]], handler: be.objectify.deadbolt.java.DeadboltHandler = handlerCache.get(), content: Optional[String] = Optional.empty(), timeout: java.util.function.Supplier[Long] = viewSupport.defaultTimeout)(body: => Html)(alternativeBody: => Html)(implicit requestHeader: play.api.mvc.RequestHeader)
+@if(viewSupport.viewRestrict(roles, handler, content, timeout.get(), requestHeader.asJava)) {
     @body
 } else {
     @alternativeBody

--- a/code/app/be/objectify/deadbolt/java/views/di/roleBasedPermissions.scala.html
+++ b/code/app/be/objectify/deadbolt/java/views/di/roleBasedPermissions.scala.html
@@ -1,5 +1,5 @@
 @this(viewSupport: be.objectify.deadbolt.java.ViewSupport, handlerCache: be.objectify.deadbolt.java.cache.HandlerCache)
-@(context: Http.Context, roleName: String, handler: be.objectify.deadbolt.java.DeadboltHandler = handlerCache.get(), content: Optional[String] = Optional.empty(), timeout: java.util.function.Supplier[Long] = viewSupport.defaultTimeout)(body: => Html)
-@if(viewSupport.viewRoleBasedPermissions(roleName, handler, content, timeout.get(), context)) {
+@(roleName: String, handler: be.objectify.deadbolt.java.DeadboltHandler = handlerCache.get(), content: Optional[String] = Optional.empty(), timeout: java.util.function.Supplier[Long] = viewSupport.defaultTimeout)(body: => Html)(implicit requestHeader: play.api.mvc.RequestHeader)
+@if(viewSupport.viewRoleBasedPermissions(roleName, handler, content, timeout.get(), requestHeader.asJava)) {
     @body
 }

--- a/code/app/be/objectify/deadbolt/java/views/di/roleBasedPermissions.scala.html
+++ b/code/app/be/objectify/deadbolt/java/views/di/roleBasedPermissions.scala.html
@@ -1,5 +1,5 @@
 @this(viewSupport: be.objectify.deadbolt.java.ViewSupport, handlerCache: be.objectify.deadbolt.java.cache.HandlerCache)
-@(roleName: String, handler: be.objectify.deadbolt.java.DeadboltHandler = handlerCache.get(), content: Optional[String] = Optional.empty(), timeout: java.util.function.Supplier[Long] = viewSupport.defaultTimeout)(body: => Html)(implicit requestHeader: play.api.mvc.RequestHeader)
-@if(viewSupport.viewRoleBasedPermissions(roleName, handler, content, timeout.get(), requestHeader.asJava)) {
+@(roleName: String, handler: be.objectify.deadbolt.java.DeadboltHandler = handlerCache.get(), content: Optional[String] = Optional.empty(), timeout: Long = viewSupport.timeout)(body: => Html)(implicit requestHeader: play.api.mvc.RequestHeader)
+@if(viewSupport.viewRoleBasedPermissions(roleName, handler, content, timeout, requestHeader.asJava)) {
     @body
 }

--- a/code/app/be/objectify/deadbolt/java/views/di/roleBasedPermissionsOr.scala.html
+++ b/code/app/be/objectify/deadbolt/java/views/di/roleBasedPermissionsOr.scala.html
@@ -1,6 +1,6 @@
 @this(viewSupport: be.objectify.deadbolt.java.ViewSupport, handlerCache: be.objectify.deadbolt.java.cache.HandlerCache)
-@(roleName: String, handler: be.objectify.deadbolt.java.DeadboltHandler = handlerCache.get(), content: Optional[String] = Optional.empty(), timeout: java.util.function.Supplier[Long] = viewSupport.defaultTimeout)(body: => Html)(alternativeBody: => Html)(implicit requestHeader: play.api.mvc.RequestHeader)
-@if(viewSupport.viewRoleBasedPermissions(roleName, handler, content, timeout.get(), requestHeader.asJava)) {
+@(roleName: String, handler: be.objectify.deadbolt.java.DeadboltHandler = handlerCache.get(), content: Optional[String] = Optional.empty(), timeout: Long = viewSupport.timeout)(body: => Html)(alternativeBody: => Html)(implicit requestHeader: play.api.mvc.RequestHeader)
+@if(viewSupport.viewRoleBasedPermissions(roleName, handler, content, timeout, requestHeader.asJava)) {
     @body
 } else {
     @alternativeBody

--- a/code/app/be/objectify/deadbolt/java/views/di/roleBasedPermissionsOr.scala.html
+++ b/code/app/be/objectify/deadbolt/java/views/di/roleBasedPermissionsOr.scala.html
@@ -1,6 +1,6 @@
 @this(viewSupport: be.objectify.deadbolt.java.ViewSupport, handlerCache: be.objectify.deadbolt.java.cache.HandlerCache)
-@(context: Http.Context, roleName: String, handler: be.objectify.deadbolt.java.DeadboltHandler = handlerCache.get(), content: Optional[String] = Optional.empty(), timeout: java.util.function.Supplier[Long] = viewSupport.defaultTimeout)(body: => Html)(alternativeBody: => Html)
-@if(viewSupport.viewRoleBasedPermissions(roleName, handler, content, timeout.get(), context)) {
+@(roleName: String, handler: be.objectify.deadbolt.java.DeadboltHandler = handlerCache.get(), content: Optional[String] = Optional.empty(), timeout: java.util.function.Supplier[Long] = viewSupport.defaultTimeout)(body: => Html)(alternativeBody: => Html)(implicit requestHeader: play.api.mvc.RequestHeader)
+@if(viewSupport.viewRoleBasedPermissions(roleName, handler, content, timeout.get(), requestHeader.asJava)) {
     @body
 } else {
     @alternativeBody

--- a/code/app/be/objectify/deadbolt/java/views/di/subjectNotPresent.scala.html
+++ b/code/app/be/objectify/deadbolt/java/views/di/subjectNotPresent.scala.html
@@ -1,5 +1,5 @@
 @this(viewSupport: be.objectify.deadbolt.java.ViewSupport, handlerCache: be.objectify.deadbolt.java.cache.HandlerCache)
-@(handler: be.objectify.deadbolt.java.DeadboltHandler = handlerCache.get(), content: Optional[String] = Optional.empty(), timeout: java.util.function.Supplier[Long] = viewSupport.defaultTimeout)(body: => Html)(implicit requestHeader: play.api.mvc.RequestHeader)
-@if(viewSupport.viewSubjectNotPresent(handler, content, timeout.get(), requestHeader.asJava)) {
+@(handler: be.objectify.deadbolt.java.DeadboltHandler = handlerCache.get(), content: Optional[String] = Optional.empty(), timeout: Long = viewSupport.timeout)(body: => Html)(implicit requestHeader: play.api.mvc.RequestHeader)
+@if(viewSupport.viewSubjectNotPresent(handler, content, timeout, requestHeader.asJava)) {
     @body
 }

--- a/code/app/be/objectify/deadbolt/java/views/di/subjectNotPresent.scala.html
+++ b/code/app/be/objectify/deadbolt/java/views/di/subjectNotPresent.scala.html
@@ -1,5 +1,5 @@
 @this(viewSupport: be.objectify.deadbolt.java.ViewSupport, handlerCache: be.objectify.deadbolt.java.cache.HandlerCache)
-@(context: Http.Context, handler: be.objectify.deadbolt.java.DeadboltHandler = handlerCache.get(), content: Optional[String] = Optional.empty(), timeout: java.util.function.Supplier[Long] = viewSupport.defaultTimeout)(body: => Html)
-@if(viewSupport.viewSubjectNotPresent(handler, content, timeout.get(), context)) {
+@(handler: be.objectify.deadbolt.java.DeadboltHandler = handlerCache.get(), content: Optional[String] = Optional.empty(), timeout: java.util.function.Supplier[Long] = viewSupport.defaultTimeout)(body: => Html)(implicit requestHeader: play.api.mvc.RequestHeader)
+@if(viewSupport.viewSubjectNotPresent(handler, content, timeout.get(), requestHeader.asJava)) {
     @body
 }

--- a/code/app/be/objectify/deadbolt/java/views/di/subjectNotPresentOr.scala.html
+++ b/code/app/be/objectify/deadbolt/java/views/di/subjectNotPresentOr.scala.html
@@ -1,6 +1,6 @@
 @this(viewSupport: be.objectify.deadbolt.java.ViewSupport, handlerCache: be.objectify.deadbolt.java.cache.HandlerCache)
-@(handler: be.objectify.deadbolt.java.DeadboltHandler = handlerCache.get(), content: Optional[String] = Optional.empty(), timeout: java.util.function.Supplier[Long] = viewSupport.defaultTimeout)(body: => Html)(alternativeBody: => Html)(implicit requestHeader: play.api.mvc.RequestHeader)
-@if(viewSupport.viewSubjectNotPresent(handler, content, timeout.get(), requestHeader.asJava)) {
+@(handler: be.objectify.deadbolt.java.DeadboltHandler = handlerCache.get(), content: Optional[String] = Optional.empty(), timeout: Long = viewSupport.timeout)(body: => Html)(alternativeBody: => Html)(implicit requestHeader: play.api.mvc.RequestHeader)
+@if(viewSupport.viewSubjectNotPresent(handler, content, timeout, requestHeader.asJava)) {
     @body
 } else {
     @alternativeBody

--- a/code/app/be/objectify/deadbolt/java/views/di/subjectNotPresentOr.scala.html
+++ b/code/app/be/objectify/deadbolt/java/views/di/subjectNotPresentOr.scala.html
@@ -1,6 +1,6 @@
 @this(viewSupport: be.objectify.deadbolt.java.ViewSupport, handlerCache: be.objectify.deadbolt.java.cache.HandlerCache)
-@(context: Http.Context, handler: be.objectify.deadbolt.java.DeadboltHandler = handlerCache.get(), content: Optional[String] = Optional.empty(), timeout: java.util.function.Supplier[Long] = viewSupport.defaultTimeout)(body: => Html)(alternativeBody: => Html)
-@if(viewSupport.viewSubjectNotPresent(handler, content, timeout.get(), context)) {
+@(handler: be.objectify.deadbolt.java.DeadboltHandler = handlerCache.get(), content: Optional[String] = Optional.empty(), timeout: java.util.function.Supplier[Long] = viewSupport.defaultTimeout)(body: => Html)(alternativeBody: => Html)(implicit requestHeader: play.api.mvc.RequestHeader)
+@if(viewSupport.viewSubjectNotPresent(handler, content, timeout.get(), requestHeader.asJava)) {
     @body
 } else {
     @alternativeBody

--- a/code/app/be/objectify/deadbolt/java/views/di/subjectPresent.scala.html
+++ b/code/app/be/objectify/deadbolt/java/views/di/subjectPresent.scala.html
@@ -1,5 +1,5 @@
 @this(viewSupport: be.objectify.deadbolt.java.ViewSupport, handlerCache: be.objectify.deadbolt.java.cache.HandlerCache)
-@(context: Http.Context, handler: be.objectify.deadbolt.java.DeadboltHandler = handlerCache.get(), content: Optional[String] = Optional.empty(), timeout: java.util.function.Supplier[Long] = viewSupport.defaultTimeout)(body: => Html)
-@if(viewSupport.viewSubjectPresent(handler, content, timeout.get(), context)) {
+@(handler: be.objectify.deadbolt.java.DeadboltHandler = handlerCache.get(), content: Optional[String] = Optional.empty(), timeout: java.util.function.Supplier[Long] = viewSupport.defaultTimeout)(body: => Html)(implicit requestHeader: play.api.mvc.RequestHeader)
+@if(viewSupport.viewSubjectPresent(handler, content, timeout.get(), requestHeader.asJava)) {
     @body
 }

--- a/code/app/be/objectify/deadbolt/java/views/di/subjectPresent.scala.html
+++ b/code/app/be/objectify/deadbolt/java/views/di/subjectPresent.scala.html
@@ -1,5 +1,5 @@
 @this(viewSupport: be.objectify.deadbolt.java.ViewSupport, handlerCache: be.objectify.deadbolt.java.cache.HandlerCache)
-@(handler: be.objectify.deadbolt.java.DeadboltHandler = handlerCache.get(), content: Optional[String] = Optional.empty(), timeout: java.util.function.Supplier[Long] = viewSupport.defaultTimeout)(body: => Html)(implicit requestHeader: play.api.mvc.RequestHeader)
-@if(viewSupport.viewSubjectPresent(handler, content, timeout.get(), requestHeader.asJava)) {
+@(handler: be.objectify.deadbolt.java.DeadboltHandler = handlerCache.get(), content: Optional[String] = Optional.empty(), timeout: Long = viewSupport.timeout)(body: => Html)(implicit requestHeader: play.api.mvc.RequestHeader)
+@if(viewSupport.viewSubjectPresent(handler, content, timeout, requestHeader.asJava)) {
     @body
 }

--- a/code/app/be/objectify/deadbolt/java/views/di/subjectPresentOr.scala.html
+++ b/code/app/be/objectify/deadbolt/java/views/di/subjectPresentOr.scala.html
@@ -1,6 +1,6 @@
 @this(viewSupport: be.objectify.deadbolt.java.ViewSupport, handlerCache: be.objectify.deadbolt.java.cache.HandlerCache)
-@(context: Http.Context, handler: be.objectify.deadbolt.java.DeadboltHandler = handlerCache.get(), content: Optional[String] = Optional.empty(), timeout: java.util.function.Supplier[Long] = viewSupport.defaultTimeout)(body: => Html)(alternativeBody: => Html)
-@if(viewSupport.viewSubjectPresent(handler, content, timeout.get(), context)) {
+@(handler: be.objectify.deadbolt.java.DeadboltHandler = handlerCache.get(), content: Optional[String] = Optional.empty(), timeout: java.util.function.Supplier[Long] = viewSupport.defaultTimeout)(body: => Html)(alternativeBody: => Html)(implicit requestHeader: play.api.mvc.RequestHeader)
+@if(viewSupport.viewSubjectPresent(handler, content, timeout.get(), requestHeader.asJava)) {
     @body
 } else {
     @alternativeBody

--- a/code/app/be/objectify/deadbolt/java/views/di/subjectPresentOr.scala.html
+++ b/code/app/be/objectify/deadbolt/java/views/di/subjectPresentOr.scala.html
@@ -1,6 +1,6 @@
 @this(viewSupport: be.objectify.deadbolt.java.ViewSupport, handlerCache: be.objectify.deadbolt.java.cache.HandlerCache)
-@(handler: be.objectify.deadbolt.java.DeadboltHandler = handlerCache.get(), content: Optional[String] = Optional.empty(), timeout: java.util.function.Supplier[Long] = viewSupport.defaultTimeout)(body: => Html)(alternativeBody: => Html)(implicit requestHeader: play.api.mvc.RequestHeader)
-@if(viewSupport.viewSubjectPresent(handler, content, timeout.get(), requestHeader.asJava)) {
+@(handler: be.objectify.deadbolt.java.DeadboltHandler = handlerCache.get(), content: Optional[String] = Optional.empty(), timeout: Long = viewSupport.timeout)(body: => Html)(alternativeBody: => Html)(implicit requestHeader: play.api.mvc.RequestHeader)
+@if(viewSupport.viewSubjectPresent(handler, content, timeout, requestHeader.asJava)) {
     @body
 } else {
     @alternativeBody

--- a/code/build.sbt
+++ b/code/build.sbt
@@ -18,7 +18,7 @@ releasePublishArtifactsAction := PgpKeys.publishSigned.value
 // workaround for scaladoc error https://github.com/scala/scala-dev/issues/249
 // also see http://www.scala-lang.org/news/2.12.0/#scaladoc-can-be-used-to-document-java-sources
 scalacOptions in (Compile, doc) ++= {
-  if (scalaBinaryVersion.value == "2.12") Seq("-no-java-comments") else Nil
+  if (scalaBinaryVersion.value == "2.11") Nil else Seq("-no-java-comments")
 }
 
 javacOptions += "-Xlint:deprecation"

--- a/code/build.sbt
+++ b/code/build.sbt
@@ -19,4 +19,7 @@ releasePublishArtifactsAction := PgpKeys.publishSigned.value
 // also see http://www.scala-lang.org/news/2.12.0/#scaladoc-can-be-used-to-document-java-sources
 scalacOptions in (Compile, doc) += "-no-java-comments"
 
+javacOptions += "-Xlint:deprecation"
+scalacOptions += "-deprecation"
+
 resolvers += Resolver.sonatypeRepo("snapshots")

--- a/code/build.sbt
+++ b/code/build.sbt
@@ -2,9 +2,9 @@ name := "deadbolt-java"
 
 lazy val root = (project in file(".")).enablePlugins(PlayJava).disablePlugins(PlayFilters)
 
-scalaVersion := "2.12.6"
+scalaVersion := "2.12.7"
 
-crossScalaVersions := Seq("2.12.6", "2.13.0-M3")
+crossScalaVersions := Seq("2.12.7", "2.13.0-M5")
 
 organization := "be.objectify"
 

--- a/code/build.sbt
+++ b/code/build.sbt
@@ -4,7 +4,8 @@ lazy val root = (project in file(".")).enablePlugins(PlayJava).disablePlugins(Pl
 
 scalaVersion := "2.12.7"
 
-crossScalaVersions := Seq("2.12.7", "2.13.0-M5")
+// TODO: Enable as soon Play supports Scala 2.13:
+//crossScalaVersions := Seq("2.12.7", "2.13.0-M5")
 
 organization := "be.objectify"
 

--- a/code/build.sbt
+++ b/code/build.sbt
@@ -17,7 +17,9 @@ releasePublishArtifactsAction := PgpKeys.publishSigned.value
 
 // workaround for scaladoc error https://github.com/scala/scala-dev/issues/249
 // also see http://www.scala-lang.org/news/2.12.0/#scaladoc-can-be-used-to-document-java-sources
-scalacOptions in (Compile, doc) += "-no-java-comments"
+scalacOptions in (Compile, doc) ++= {
+  if (scalaBinaryVersion.value == "2.12") Seq("-no-java-comments") else Nil
+}
 
 javacOptions += "-Xlint:deprecation"
 scalacOptions += "-deprecation"

--- a/code/conf/reference.conf
+++ b/code/conf/reference.conf
@@ -1,0 +1,13 @@
+deadbolt {
+  java {
+    cache-user = false
+    cache-before-auth-check = false
+
+    view-timeout = 1000
+
+    blocking = false
+    blocking-timeout = 1000
+
+    constraint-mode = "PROCESS_FIRST_CONSTRAINT_ONLY"
+  }
+}

--- a/code/project/build.properties
+++ b/code/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.1.6
+sbt.version=1.2.6

--- a/code/project/plugins.sbt
+++ b/code/project/plugins.sbt
@@ -1,5 +1,5 @@
-addSbtPlugin("com.typesafe.play" % "sbt-plugin" % Option(System.getProperty("play.version")).getOrElse("2.7.0-M1"))
-addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.1.1")
-addSbtPlugin("com.github.gseitz" % "sbt-release" % "1.0.9")
+addSbtPlugin("com.typesafe.play" % "sbt-plugin" % Option(System.getProperty("play.version")).getOrElse("2.7.0-RC3"))
+addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.1.2-1")
+addSbtPlugin("com.github.gseitz" % "sbt-release" % "1.0.10")
 
 resolvers += Resolver.sonatypeRepo("snapshots")

--- a/code/test/be/objectify/deadbolt/java/AbstractDeadboltHandlerTest.java
+++ b/code/test/be/objectify/deadbolt/java/AbstractDeadboltHandlerTest.java
@@ -40,15 +40,15 @@ public class AbstractDeadboltHandlerTest
         DeadboltHandler deadboltHandler = new AbstractDeadboltHandler()
         {
             @Override
-            public CompletionStage<Optional<Result>> beforeAuthCheck(final Http.Context context, final Optional<String> content)
+            public CompletionStage<Optional<Result>> beforeAuthCheck(final Http.RequestHeader requestHeader, final Optional<String> content)
             {
                 return CompletableFuture.completedFuture(Optional.empty());
             }
         };
 
-        final Http.Context context = Mockito.mock(Http.Context.class);
+        final Http.RequestHeader requestHeader = Mockito.mock(Http.Request.class);
 
-        final CompletionStage<Optional<? extends Subject>> promise = deadboltHandler.getSubject(context);
+        final CompletionStage<Optional<? extends Subject>> promise = deadboltHandler.getSubject(requestHeader);
         Assert.assertNotNull(promise);
 
         final Optional<? extends Subject> option = promise.toCompletableFuture().get(1000,
@@ -63,15 +63,15 @@ public class AbstractDeadboltHandlerTest
         DeadboltHandler deadboltHandler = new AbstractDeadboltHandler()
         {
             @Override
-            public CompletionStage<Optional<Result>> beforeAuthCheck(final Http.Context context, final Optional<String> content)
+            public CompletionStage<Optional<Result>> beforeAuthCheck(final Http.RequestHeader requestHeader, final Optional<String> content)
             {
                 return CompletableFuture.completedFuture(Optional.empty());
             }
         };
 
-        final Http.Context context = Mockito.mock(Http.Context.class);
+        final Http.RequestHeader requestHeader = new Http.RequestBuilder().build();
 
-        final CompletionStage<Result> promise = deadboltHandler.onAuthFailure(context,
+        final CompletionStage<Result> promise = deadboltHandler.onAuthFailure(requestHeader,
                                                                               Optional.of("foo"));
         Assert.assertNotNull(promise);
 
@@ -88,15 +88,15 @@ public class AbstractDeadboltHandlerTest
         DeadboltHandler deadboltHandler = new AbstractDeadboltHandler()
         {
             @Override
-            public CompletionStage<Optional<Result>> beforeAuthCheck(final Http.Context context, final Optional<String> content)
+            public CompletionStage<Optional<Result>> beforeAuthCheck(final Http.RequestHeader requestHeader, final Optional<String> content)
             {
                 return CompletableFuture.completedFuture(Optional.empty());
             }
         };
 
-        final Http.Context context = Mockito.mock(Http.Context.class);
+        final Http.RequestHeader requestHeader = Mockito.mock(Http.Request.class);
 
-        final CompletionStage<Optional<DynamicResourceHandler>> promise = deadboltHandler.getDynamicResourceHandler(context);
+        final CompletionStage<Optional<DynamicResourceHandler>> promise = deadboltHandler.getDynamicResourceHandler(requestHeader);
         Assert.assertNotNull(promise);
 
         final Optional<DynamicResourceHandler> option = promise.toCompletableFuture().get(1000,

--- a/code/test/be/objectify/deadbolt/java/AbstractFakeApplicationTest.java
+++ b/code/test/be/objectify/deadbolt/java/AbstractFakeApplicationTest.java
@@ -115,9 +115,10 @@ public abstract class AbstractFakeApplicationTest extends WithApplication
                                                                     (handler, rh) -> handler.getSubject(rh).thenApply(maybeSubject -> F.Tuple(maybeSubject, rh)),
                                                                     new DefaultPatternCache());
 
-        return new ViewSupport(ConfigFactory.empty(),
+        final Application app = provideApplication();
+        return new ViewSupport(app.config(),
                                handlers(),
-                               new TemplateFailureListenerProvider(provideApplication().injector()),
+                               new TemplateFailureListenerProvider(app.injector()),
                                constraintLogic);
     }
 }

--- a/code/test/be/objectify/deadbolt/java/NoPreAuthDeadboltHandler.java
+++ b/code/test/be/objectify/deadbolt/java/NoPreAuthDeadboltHandler.java
@@ -36,6 +36,6 @@ public class NoPreAuthDeadboltHandler extends AbstractDeadboltHandler
     @Override
     public String handlerName()
     {
-        return ConfigKeys.DEFAULT_HANDLER_KEY;
+        return Constants.DEFAULT_HANDLER_KEY;
     }
 }

--- a/code/test/be/objectify/deadbolt/java/NoPreAuthDeadboltHandler.java
+++ b/code/test/be/objectify/deadbolt/java/NoPreAuthDeadboltHandler.java
@@ -28,7 +28,7 @@ import java.util.concurrent.CompletionStage;
 public class NoPreAuthDeadboltHandler extends AbstractDeadboltHandler
 {
     @Override
-    public CompletionStage<Optional<Result>> beforeAuthCheck(final Http.Context context, final Optional<String> content)
+    public CompletionStage<Optional<Result>> beforeAuthCheck(final Http.RequestHeader requestHeader, final Optional<String> content)
     {
         return CompletableFuture.completedFuture(Optional.empty());
     }

--- a/code/test/be/objectify/deadbolt/java/ViewSupportTest.java
+++ b/code/test/be/objectify/deadbolt/java/ViewSupportTest.java
@@ -46,7 +46,7 @@ public class ViewSupportTest extends AbstractFakeApplicationTest
                              public CompletionStage<Boolean> checkPermission(final String permissionValue,
                                                                              final Optional<String> meta,
                                                                              final DeadboltHandler deadboltHandler,
-                                                                             final Http.Context ctx)
+                                                                             final Http.RequestHeader requestHeader)
                              {
                                  return CompletableFuture.completedFuture(true);
                              }
@@ -58,7 +58,7 @@ public class ViewSupportTest extends AbstractFakeApplicationTest
                              public CompletionStage<Boolean> checkPermission(final String permissionValue,
                                                                              final Optional<String> meta,
                                                                              final DeadboltHandler deadboltHandler,
-                                                                             final Http.Context ctx)
+                                                                             final Http.RequestHeader requestHeader)
                              {
                                  return CompletableFuture.completedFuture(false);
                              }
@@ -71,21 +71,21 @@ public class ViewSupportTest extends AbstractFakeApplicationTest
             public CompletionStage<Boolean> checkPermission(final String permissionValue,
                                                             final Optional<String> meta,
                                                             final DeadboltHandler deadboltHandler,
-                                                            final Http.Context ctx)
+                                                            final Http.RequestHeader requestHeader)
             {
                 return specificDrhs.get(permissionValue).checkPermission(permissionValue,
                                                                          meta,
                                                                          deadboltHandler,
-                                                                         ctx);
+                                                                         requestHeader);
             }
         };
 
         final DeadboltHandler handler = Mockito.mock(DeadboltHandler.class);
-        Mockito.when(handler.getDynamicResourceHandler(Mockito.any(Http.Context.class)))
+        Mockito.when(handler.getDynamicResourceHandler(Mockito.any(Http.RequestHeader.class)))
                .thenReturn(CompletableFuture.completedFuture(Optional.of(drh)));
 
         final DeadboltHandler noDrhHandler = Mockito.mock(DeadboltHandler.class);
-        Mockito.when(noDrhHandler.getDynamicResourceHandler(Mockito.any(Http.Context.class)))
+        Mockito.when(noDrhHandler.getDynamicResourceHandler(Mockito.any(Http.RequestHeader.class)))
                .thenReturn(CompletableFuture.completedFuture(Optional.empty()));
 
         Map<String, DeadboltHandler> handlers = new HashMap<>();
@@ -106,7 +106,7 @@ public class ViewSupportTest extends AbstractFakeApplicationTest
                                       handlerCache.apply("noDrh"),
                                       Optional.empty(),
                                       1000L,
-                                      context());
+                                      new Http.RequestBuilder().build());
         }
         catch (Exception e)
         {
@@ -125,7 +125,7 @@ public class ViewSupportTest extends AbstractFakeApplicationTest
                                                          handlerCache.get(),
                                                          Optional.empty(),
                                                          1000L,
-                                                         context());
+                                                         new Http.RequestBuilder().build());
         Assert.assertFalse(result);
     }
 
@@ -139,7 +139,7 @@ public class ViewSupportTest extends AbstractFakeApplicationTest
                                                          handlerCache.get(),
                                                          Optional.empty(),
                                                          1000L,
-                                                         context());
+                                                         new Http.RequestBuilder().build());
         Assert.assertTrue(result);
     }
 

--- a/code/test/be/objectify/deadbolt/java/actions/BeforeAccessActionTest.java
+++ b/code/test/be/objectify/deadbolt/java/actions/BeforeAccessActionTest.java
@@ -22,6 +22,7 @@ import be.objectify.deadbolt.java.cache.HandlerCache;
 import com.typesafe.config.ConfigFactory;
 import org.junit.Test;
 import org.mockito.Mockito;
+import play.libs.typedmap.TypedKey;
 import play.mvc.Action;
 import play.mvc.Http;
 
@@ -37,13 +38,10 @@ public class BeforeAccessActionTest
     @Test
     public void testExecute_alreadyAuthorised_alwaysExecuteTrue() throws Exception
     {
-        final Http.Context ctx = Mockito.mock(Http.Context.class);
-        ctx.args = new HashMap<>();
-        ctx.args.put("deadbolt.action-authorised",
-                     true);
+        final Http.Request request = new Http.RequestBuilder().build().addAttr(AbstractDeadboltAction.ACTION_AUTHORISED, true);
 
         final DeadboltHandler handler = Mockito.mock(DeadboltHandler.class);
-        Mockito.when(handler.beforeAuthCheck(ctx, Optional.empty()))
+        Mockito.when(handler.beforeAuthCheck(request, Optional.empty()))
                .thenReturn(CompletableFuture.completedFuture(Optional.empty()));
 
         final HandlerCache handlerCache = Mockito.mock(HandlerCache.class);
@@ -60,22 +58,19 @@ public class BeforeAccessActionTest
                .thenReturn(true);
         action.delegate = Mockito.mock(Action.class);
 
-        action.call(ctx);
+        action.call(request);
 
-        Mockito.verify(handler).beforeAuthCheck(ctx, Optional.empty());
-        Mockito.verify(action.delegate).call(ctx);
+        Mockito.verify(handler).beforeAuthCheck(request, Optional.empty());
+        Mockito.verify(action.delegate).call(request);
     }
 
     @Test
     public void testExecute_alreadyAuthorised_alwaysExecuteFalse() throws Exception
     {
-        final Http.Context ctx = Mockito.mock(Http.Context.class);
-        ctx.args = new HashMap<>();
-        ctx.args.put("deadbolt.action-authorised",
-                     true);
+        final Http.Request request = new Http.RequestBuilder().build().addAttr(AbstractDeadboltAction.ACTION_AUTHORISED, true);
 
         final DeadboltHandler handler = Mockito.mock(DeadboltHandler.class);
-        Mockito.when(handler.beforeAuthCheck(ctx, Optional.empty()))
+        Mockito.when(handler.beforeAuthCheck(request, Optional.empty()))
                .thenReturn(CompletableFuture.completedFuture(Optional.empty()));
 
         final HandlerCache handlerCache = Mockito.mock(HandlerCache.class);
@@ -89,12 +84,12 @@ public class BeforeAccessActionTest
         Mockito.when(action.configuration.alwaysExecute())
                .thenReturn(false);
         action.delegate = Mockito.mock(Action.class);
-        Mockito.when(action.delegate.call(ctx))
+        Mockito.when(action.delegate.call(request))
                .thenReturn(CompletableFuture.completedFuture(null));
 
-        action.call(ctx);
+        action.call(request);
 
-        Mockito.verify(handler, Mockito.never()).beforeAuthCheck(ctx, Optional.empty());
-        Mockito.verify(action.delegate).call(ctx);
+        Mockito.verify(handler, Mockito.never()).beforeAuthCheck(request, Optional.empty());
+        Mockito.verify(action.delegate).call(request);
     }
 }

--- a/code/test/be/objectify/deadbolt/java/actions/BeforeAccessActionTest.java
+++ b/code/test/be/objectify/deadbolt/java/actions/BeforeAccessActionTest.java
@@ -48,11 +48,11 @@ public class BeforeAccessActionTest
         Mockito.when(handlerCache.get())
                .thenReturn(handler);
 
-        final BeforeAuthCheckCache beforeAuthCheckCache = new DefaultBeforeAuthCheckCache(ConfigFactory.empty());
+        final BeforeAuthCheckCache beforeAuthCheckCache = new DefaultBeforeAuthCheckCache(ConfigFactory.load());
 
         final BeforeAccessAction action = new BeforeAccessAction(handlerCache,
                                                                  beforeAuthCheckCache,
-                                                                 ConfigFactory.empty());
+                                                                 ConfigFactory.load());
         action.configuration = Mockito.mock(BeforeAccess.class);
         Mockito.when(action.configuration.alwaysExecute())
                .thenReturn(true);
@@ -79,7 +79,7 @@ public class BeforeAccessActionTest
 
         final BeforeAccessAction action = new BeforeAccessAction(handlerCache,
                                                                  Mockito.mock(BeforeAuthCheckCache.class),
-                                                                 ConfigFactory.empty());
+                                                                 ConfigFactory.load());
         action.configuration = Mockito.mock(BeforeAccess.class);
         Mockito.when(action.configuration.alwaysExecute())
                .thenReturn(false);

--- a/code/test/be/objectify/deadbolt/java/actions/CompositeActionTest.java
+++ b/code/test/be/objectify/deadbolt/java/actions/CompositeActionTest.java
@@ -62,7 +62,7 @@ public class CompositeActionTest
 
         final CompositeAction action = new CompositeAction(Mockito.mock(HandlerCache.class),
                                                            Mockito.mock(BeforeAuthCheckCache.class),
-                                                           ConfigFactory.empty(),
+                                                           ConfigFactory.load(),
                                                            compositeCache,
                                                            Mockito.mock(ConstraintLogic.class));
         action.configuration = composite;
@@ -86,7 +86,7 @@ public class CompositeActionTest
                .thenReturn("foo");
         final CompositeAction action = new CompositeAction(Mockito.mock(HandlerCache.class),
                                                            Mockito.mock(BeforeAuthCheckCache.class),
-                                                           ConfigFactory.empty(),
+                                                           ConfigFactory.load(),
                                                            Mockito.mock(CompositeCache.class),
                                                            Mockito.mock(ConstraintLogic.class));
         action.configuration = composite;

--- a/code/test/be/objectify/deadbolt/java/actions/CompositeActionTest.java
+++ b/code/test/be/objectify/deadbolt/java/actions/CompositeActionTest.java
@@ -49,7 +49,7 @@ public class CompositeActionTest
         final CompositeCache compositeCache = Mockito.mock(CompositeCache.class);
 
         final Constraint constraint = Mockito.mock(Constraint.class);
-        Mockito.when(constraint.test(Mockito.any(Http.Context.class),
+        Mockito.when(constraint.test(Mockito.any(Http.Request.class),
                                      Mockito.any(DeadboltHandler.class),
                                      Mockito.eq(Optional.of("bar")),
                                      Mockito.any(BiFunction.class)))
@@ -67,12 +67,12 @@ public class CompositeActionTest
                                                            Mockito.mock(ConstraintLogic.class));
         action.configuration = composite;
 
-        final Http.Context ctx = Mockito.mock(Http.Context.class);
+        final Http.Request request = Mockito.mock(Http.Request.class);
         final DeadboltHandler handler = Mockito.mock(DeadboltHandler.class);
-        action.applyRestriction(ctx,
+        action.applyRestriction(request,
                                 handler);
 
-        Mockito.verify(constraint).test(Mockito.eq(ctx),
+        Mockito.verify(constraint).test(Mockito.eq(request),
                                         Mockito.eq(handler),
                                         Mockito.eq(Optional.of("bar")),
                                         Mockito.any(BiFunction.class));

--- a/code/test/be/objectify/deadbolt/java/actions/DynamicActionTest.java
+++ b/code/test/be/objectify/deadbolt/java/actions/DynamicActionTest.java
@@ -49,7 +49,7 @@ public class DynamicActionTest
         final ConstraintLogic constraintLogic = Mockito.mock(ConstraintLogic.class);
         final DynamicAction action = new DynamicAction(Mockito.mock(HandlerCache.class),
                                                        Mockito.mock(BeforeAuthCheckCache.class),
-                                                       ConfigFactory.empty(),
+                                                       ConfigFactory.load(),
                                                        dynamic,
                                                        Mockito.mock(Action.class),
                                                        constraintLogic);
@@ -77,7 +77,7 @@ public class DynamicActionTest
                .thenReturn("foo");
         final DynamicAction action = new DynamicAction(Mockito.mock(HandlerCache.class),
                                                        Mockito.mock(BeforeAuthCheckCache.class),
-                                                       ConfigFactory.empty(),
+                                                       ConfigFactory.load(),
                                                        dynamic,
                                                        Mockito.mock(Action.class),
                                                        Mockito.mock(ConstraintLogic.class));

--- a/code/test/be/objectify/deadbolt/java/actions/DynamicActionTest.java
+++ b/code/test/be/objectify/deadbolt/java/actions/DynamicActionTest.java
@@ -54,12 +54,12 @@ public class DynamicActionTest
                                                        Mockito.mock(Action.class),
                                                        constraintLogic);
 
-        final Http.Context ctx = Mockito.mock(Http.Context.class);
+        final Http.Request request = Mockito.mock(Http.Request.class);
         final DeadboltHandler handler = Mockito.mock(DeadboltHandler.class);
-        action.applyRestriction(ctx,
+        action.applyRestriction(request,
                                 handler);
 
-        Mockito.verify(constraintLogic).dynamic(Mockito.eq(ctx),
+        Mockito.verify(constraintLogic).dynamic(Mockito.eq(request),
                                                 Mockito.eq(handler),
                                                 Mockito.eq(Optional.of("x/y")),
                                                 Mockito.eq("foo"),

--- a/code/test/be/objectify/deadbolt/java/actions/PatternActionTest.java
+++ b/code/test/be/objectify/deadbolt/java/actions/PatternActionTest.java
@@ -57,7 +57,7 @@ public class PatternActionTest
         final ConstraintLogic constraintLogic = Mockito.mock(ConstraintLogic.class);
         final PatternAction action = new PatternAction(Mockito.mock(HandlerCache.class),
                                                        Mockito.mock(BeforeAuthCheckCache.class),
-                                                       ConfigFactory.empty(),
+                                                       ConfigFactory.load(),
                                                        pattern,
                                                        Mockito.mock(Action.class),
                                                        constraintLogic);
@@ -88,7 +88,7 @@ public class PatternActionTest
                .thenReturn("foo");
         final PatternAction action = new PatternAction(Mockito.mock(HandlerCache.class),
                                                        Mockito.mock(BeforeAuthCheckCache.class),
-                                                       ConfigFactory.empty(),
+                                                       ConfigFactory.load(),
                                                        pattern,
                                                        Mockito.mock(Action.class),
                                                        Mockito.mock(ConstraintLogic.class));

--- a/code/test/be/objectify/deadbolt/java/actions/PatternActionTest.java
+++ b/code/test/be/objectify/deadbolt/java/actions/PatternActionTest.java
@@ -62,12 +62,12 @@ public class PatternActionTest
                                                        Mockito.mock(Action.class),
                                                        constraintLogic);
 
-        final Http.Context ctx = Mockito.mock(Http.Context.class);
+        final Http.Request request = Mockito.mock(Http.Request.class);
         final DeadboltHandler handler = Mockito.mock(DeadboltHandler.class);
-        action.applyRestriction(ctx,
+        action.applyRestriction(request,
                                 handler);
 
-        Mockito.verify(constraintLogic).pattern(Mockito.eq(ctx),
+        Mockito.verify(constraintLogic).pattern(Mockito.eq(request),
                                                 Mockito.eq(handler),
                                                 Mockito.eq(Optional.of("x/y")),
                                                 Mockito.eq(new String[] {"foo"}),

--- a/code/test/be/objectify/deadbolt/java/actions/SubjectNotPresentActionTest.java
+++ b/code/test/be/objectify/deadbolt/java/actions/SubjectNotPresentActionTest.java
@@ -25,11 +25,11 @@ import com.typesafe.config.ConfigFactory;
 import org.junit.Assert;
 import org.junit.Test;
 import org.mockito.Mockito;
+import play.libs.typedmap.TypedKey;
 import play.mvc.Action;
+import play.mvc.Controller;
 import play.mvc.Http;
-import play.mvc.Results;
 
-import java.util.HashMap;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 
@@ -68,21 +68,16 @@ public class SubjectNotPresentActionTest {
                                                                            Mockito.mock(BeforeAuthCheckCache.class),
                                                                            ConfigFactory.empty(),
                                                                            Mockito.mock(ConstraintLogic.class));
-
-        final Http.Context ctx = Mockito.mock(Http.Context.class);
-        ctx.args = new HashMap<>();
         final Http.Request request = Mockito.mock(Http.Request.class);
         Mockito.when(request.uri())
                .thenReturn("http://localhost/test");
-        Mockito.when(ctx.request())
-               .thenReturn(request);
 
         final DeadboltHandler handler = Mockito.mock(DeadboltHandler.class);
-        action.present(ctx,
+        action.present(request,
                        handler,
                        Optional.empty());
 
-        Mockito.verify(handler).onAuthFailure(ctx,
+        Mockito.verify(handler).onAuthFailure(request,
                                               Optional.empty());
     }
 
@@ -95,28 +90,26 @@ public class SubjectNotPresentActionTest {
                                                                            Mockito.mock(ConstraintLogic.class));
         action.delegate = Mockito.mock(Action.class);
 
-        final Http.Context ctx = Mockito.mock(Http.Context.class);
-        ctx.args = new HashMap<>();
-
-        action.notPresent(ctx,
+        final Http.Request request = new Http.RequestBuilder().build();
+        action.notPresent(request,
                           Mockito.mock(DeadboltHandler.class),
                           Optional.empty());
 
-        Assert.assertTrue((Boolean)ctx.args.get("deadbolt.action-authorised"));
-        Mockito.verify(action.delegate).call(ctx);
+        Assert.assertTrue(action.isAuthorised());
+        Mockito.verify(action.delegate).call(Mockito.any(Http.Request.class));
     }
 
     @Test
     public void testTestSubject() throws Exception
     {
         final ConstraintLogic constraintLogic = Mockito.mock(ConstraintLogic.class);
-        Mockito.when(constraintLogic.subjectNotPresent(Mockito.any(Http.Context.class),
+        Mockito.when(constraintLogic.subjectNotPresent(Mockito.any(Http.Request.class),
                                                        Mockito.any(DeadboltHandler.class),
                                                        Mockito.eq(Optional.empty()),
                                                        Mockito.any(TriFunction.class),
                                                        Mockito.any(TriFunction.class),
                                                        Mockito.eq(ConstraintPoint.CONTROLLER)))
-               .thenReturn(CompletableFuture.completedFuture(Results.TODO));
+               .thenReturn(CompletableFuture.completedFuture(Controller.TODO(new Http.RequestBuilder().build())));
 
         final SubjectNotPresentAction action = new SubjectNotPresentAction(Mockito.mock(HandlerCache.class),
                                                                            Mockito.mock(BeforeAuthCheckCache.class),
@@ -125,9 +118,9 @@ public class SubjectNotPresentActionTest {
         action.configuration = Mockito.mock(SubjectNotPresent.class);
 
         action.testSubject(constraintLogic,
-                           Mockito.mock(Http.Context.class),
+                           Mockito.mock(Http.Request.class),
                            Mockito.mock(DeadboltHandler.class)).get();
-        Mockito.verify(constraintLogic).subjectNotPresent(Mockito.any(Http.Context.class),
+        Mockito.verify(constraintLogic).subjectNotPresent(Mockito.any(Http.Request.class),
                                                           Mockito.any(DeadboltHandler.class),
                                                           Mockito.eq(Optional.empty()),
                                                           Mockito.any(TriFunction.class),

--- a/code/test/be/objectify/deadbolt/java/actions/SubjectNotPresentActionTest.java
+++ b/code/test/be/objectify/deadbolt/java/actions/SubjectNotPresentActionTest.java
@@ -50,7 +50,7 @@ public class SubjectNotPresentActionTest {
                .thenReturn("x/y");
         final SubjectNotPresentAction action = new SubjectNotPresentAction(Mockito.mock(HandlerCache.class),
                                                                            Mockito.mock(BeforeAuthCheckCache.class),
-                                                                           ConfigFactory.empty(),
+                                                                           ConfigFactory.load(),
                                                                            Mockito.mock(ConstraintLogic.class));
         action.configuration = subjectNotPresent;
 
@@ -66,7 +66,7 @@ public class SubjectNotPresentActionTest {
     {
         final SubjectNotPresentAction action = new SubjectNotPresentAction(Mockito.mock(HandlerCache.class),
                                                                            Mockito.mock(BeforeAuthCheckCache.class),
-                                                                           ConfigFactory.empty(),
+                                                                           ConfigFactory.load(),
                                                                            Mockito.mock(ConstraintLogic.class));
         final Http.Request request = Mockito.mock(Http.Request.class);
         Mockito.when(request.uri())
@@ -86,7 +86,7 @@ public class SubjectNotPresentActionTest {
     {
         final SubjectNotPresentAction action = new SubjectNotPresentAction(Mockito.mock(HandlerCache.class),
                                                                            Mockito.mock(BeforeAuthCheckCache.class),
-                                                                           ConfigFactory.empty(),
+                                                                           ConfigFactory.load(),
                                                                            Mockito.mock(ConstraintLogic.class));
         action.delegate = Mockito.mock(Action.class);
 
@@ -113,7 +113,7 @@ public class SubjectNotPresentActionTest {
 
         final SubjectNotPresentAction action = new SubjectNotPresentAction(Mockito.mock(HandlerCache.class),
                                                                            Mockito.mock(BeforeAuthCheckCache.class),
-                                                                           ConfigFactory.empty(),
+                                                                           ConfigFactory.load(),
                                                                            constraintLogic);
         action.configuration = Mockito.mock(SubjectNotPresent.class);
 

--- a/code/test/be/objectify/deadbolt/java/actions/SubjectPresentActionTest.java
+++ b/code/test/be/objectify/deadbolt/java/actions/SubjectPresentActionTest.java
@@ -52,7 +52,7 @@ public class SubjectPresentActionTest {
                .thenReturn("x/y");
         final SubjectPresentAction action = new SubjectPresentAction(Mockito.mock(HandlerCache.class),
                                                                      Mockito.mock(BeforeAuthCheckCache.class),
-                                                                     ConfigFactory.empty(),
+                                                                     ConfigFactory.load(),
                                                                      Mockito.mock(ConstraintLogic.class));
         action.configuration = subjectPresent;
 
@@ -68,7 +68,7 @@ public class SubjectPresentActionTest {
     {
         final SubjectPresentAction action = new SubjectPresentAction(Mockito.mock(HandlerCache.class),
                                                                      Mockito.mock(BeforeAuthCheckCache.class),
-                                                                     ConfigFactory.empty(),
+                                                                     ConfigFactory.load(),
                                                                      Mockito.mock(ConstraintLogic.class));
         action.delegate = Mockito.mock(Action.class);
 
@@ -86,7 +86,7 @@ public class SubjectPresentActionTest {
     {
         final SubjectPresentAction action = new SubjectPresentAction(Mockito.mock(HandlerCache.class),
                                                                      Mockito.mock(BeforeAuthCheckCache.class),
-                                                                     ConfigFactory.empty(),
+                                                                     ConfigFactory.load(),
                                                                      Mockito.mock(ConstraintLogic.class));
 
         final Http.Request request = Mockito.mock(Http.Request.class);
@@ -115,7 +115,7 @@ public class SubjectPresentActionTest {
 
         final SubjectPresentAction action = new SubjectPresentAction(Mockito.mock(HandlerCache.class),
                                                                      Mockito.mock(BeforeAuthCheckCache.class),
-                                                                     ConfigFactory.empty(),
+                                                                     ConfigFactory.load(),
                                                                      constraintLogic);
         action.configuration = Mockito.mock(SubjectPresent.class);
 

--- a/code/test/be/objectify/deadbolt/java/composite/AbstractCompositeTest.java
+++ b/code/test/be/objectify/deadbolt/java/composite/AbstractCompositeTest.java
@@ -21,6 +21,7 @@ import be.objectify.deadbolt.java.DynamicResourceHandler;
 import be.objectify.deadbolt.java.models.Permission;
 import be.objectify.deadbolt.java.models.Role;
 import be.objectify.deadbolt.java.models.Subject;
+import play.libs.F;
 import play.mvc.Http;
 import play.mvc.Result;
 
@@ -42,13 +43,13 @@ public abstract class AbstractCompositeTest
         return new AbstractDeadboltHandler()
         {
             @Override
-            public CompletionStage<Optional<Result>> beforeAuthCheck(Http.Context context, Optional<String> content)
+            public CompletionStage<Optional<Result>> beforeAuthCheck(Http.RequestHeader requestHeader, Optional<String> content)
             {
                 return CompletableFuture.completedFuture(Optional.empty());
             }
 
             @Override
-            public CompletionStage<Optional<DynamicResourceHandler>> getDynamicResourceHandler(Http.Context context)
+            public CompletionStage<Optional<DynamicResourceHandler>> getDynamicResourceHandler(Http.RequestHeader requestHeader)
             {
                 return CompletableFuture.completedFuture(Optional.of(drh));
             }
@@ -60,13 +61,13 @@ public abstract class AbstractCompositeTest
         return new AbstractDeadboltHandler()
         {
             @Override
-            public CompletionStage<Optional<Result>> beforeAuthCheck(final Http.Context context, final Optional<String> content)
+            public CompletionStage<Optional<Result>> beforeAuthCheck(final Http.RequestHeader requestHeader, final Optional<String> content)
             {
                 return CompletableFuture.completedFuture(Optional.empty());
             }
 
             @Override
-            public CompletionStage<Optional<? extends Subject>> getSubject(final Http.Context context)
+            public CompletionStage<Optional<? extends Subject>> getSubject(final Http.RequestHeader requestHeader)
             {
                 return CompletableFuture.completedFuture(Optional.ofNullable(subject.get()));
             }
@@ -91,9 +92,9 @@ public abstract class AbstractCompositeTest
                        Collections::emptyList);
     }
 
-    protected boolean toBoolean(final CompletionStage<Boolean> cs) throws Exception
+    protected boolean toBoolean(final CompletionStage<F.Tuple<Boolean, Http.RequestHeader>> cs) throws Exception
     {
-        return ((CompletableFuture<Boolean>) cs).get();
+        return ((CompletableFuture<F.Tuple<Boolean, Http.RequestHeader>>) cs).get()._1;
     }
 
     protected Subject subject(Supplier<List<? extends Role>> roles,

--- a/code/test/be/objectify/deadbolt/java/composite/AbstractDynamicConstraintTest.java
+++ b/code/test/be/objectify/deadbolt/java/composite/AbstractDynamicConstraintTest.java
@@ -43,13 +43,13 @@ public abstract class AbstractDynamicConstraintTest extends AbstractConstraintTe
             public CompletionStage<Boolean> isAllowed(final String name,
                                                       final Optional<String> meta,
                                                       final DeadboltHandler deadboltHandler,
-                                                      final Http.Context ctx)
+                                                      final Http.RequestHeader requestHeader)
             {
                 return CompletableFuture.completedFuture(true);
             }
         });
         final DynamicConstraint constraint = constraint(handler);
-        final CompletionStage<Boolean> result = constraint.test(context,
+        final CompletionStage<F.Tuple<Boolean, Http.RequestHeader>> result = constraint.test(new Http.RequestBuilder().build(),
                                                                 handler);
         Assert.assertTrue(toBoolean(result));
     }
@@ -63,19 +63,19 @@ public abstract class AbstractDynamicConstraintTest extends AbstractConstraintTe
             public CompletionStage<Boolean> isAllowed(final String name,
                                                       final Optional<String> meta,
                                                       final DeadboltHandler deadboltHandler,
-                                                      final Http.Context ctx)
+                                                      final Http.RequestHeader requestHeader)
             {
                 return CompletableFuture.completedFuture(false);
             }
         });
         final DynamicConstraint constraint = constraint(handler);
-        final CompletionStage<Boolean> result = constraint.test(context,
+        final CompletionStage<F.Tuple<Boolean, Http.RequestHeader>> result = constraint.test(new Http.RequestBuilder().build(),
                                                                 handler);
         Assert.assertFalse(toBoolean(result));
     }
 
     @Override
-    protected F.Tuple<Constraint, Function<Constraint, CompletionStage<Boolean>>> satisfy()
+    protected F.Tuple<Constraint, Function<Constraint, CompletionStage<F.Tuple<Boolean, Http.RequestHeader>>>> satisfy()
     {
         final DeadboltHandler handler = withDrh(new AbstractDynamicResourceHandler()
         {
@@ -83,13 +83,13 @@ public abstract class AbstractDynamicConstraintTest extends AbstractConstraintTe
             public CompletionStage<Boolean> isAllowed(final String name,
                                                       final Optional<String> meta,
                                                       final DeadboltHandler deadboltHandler,
-                                                      final Http.Context ctx)
+                                                      final Http.RequestHeader requestHeader)
             {
                 return CompletableFuture.completedFuture(true);
             }
         });
         return new F.Tuple<>(constraint(handler),
-                             c -> c.test(context,
+                             c -> c.test(new Http.RequestBuilder().build(),
                                          handler));
     }
 }

--- a/code/test/be/objectify/deadbolt/java/composite/AbstractPatternConstraintTest.java
+++ b/code/test/be/objectify/deadbolt/java/composite/AbstractPatternConstraintTest.java
@@ -34,12 +34,17 @@ import java.util.function.Function;
  */
 public abstract class AbstractPatternConstraintTest extends AbstractConstraintTest
 {
+
+    private Http.Request newRequest() {
+        return new Http.RequestBuilder().build();
+    }
+
     @Test
     public void testEquality_subjectHasPermission() throws Exception
     {
         final Constraint constraint = constraint(PatternType.EQUALITY,
                                                  withSubject(() -> subject(new TestPermission("foo"))));
-        final CompletionStage<Boolean> result = constraint.test(context,
+        final CompletionStage<F.Tuple<Boolean, Http.RequestHeader>> result = constraint.test(newRequest(),
                                                                 withSubject(() -> subject(new TestPermission("foo"))));
         Assert.assertTrue(toBoolean(result));
     }
@@ -49,7 +54,7 @@ public abstract class AbstractPatternConstraintTest extends AbstractConstraintTe
     {
         final Constraint constraint = constraint(PatternType.EQUALITY,
                                                  withSubject(() -> subject(new TestPermission("bar"))));
-        final CompletionStage<Boolean> result = constraint.test(context,
+        final CompletionStage<F.Tuple<Boolean, Http.RequestHeader>> result = constraint.test(newRequest(),
                                                                 withSubject(() -> subject(new TestPermission("bar"))));
         Assert.assertFalse(toBoolean(result));
     }
@@ -59,7 +64,7 @@ public abstract class AbstractPatternConstraintTest extends AbstractConstraintTe
     {
         final Constraint constraint = constraint(PatternType.REGEX,
                                                  withSubject(() -> subject(new TestPermission("1"))));
-        final CompletionStage<Boolean> result = constraint.test(context,
+        final CompletionStage<F.Tuple<Boolean, Http.RequestHeader>> result = constraint.test(newRequest(),
                                                                 withSubject(() -> subject(new TestPermission("1"))));
         Assert.assertTrue(toBoolean(result));
     }
@@ -69,7 +74,7 @@ public abstract class AbstractPatternConstraintTest extends AbstractConstraintTe
     {
         final Constraint constraint = constraint(PatternType.REGEX,
                                                  withSubject(() -> subject(new TestPermission("3"))));
-        final CompletionStage<Boolean> result = constraint.test(context,
+        final CompletionStage<F.Tuple<Boolean, Http.RequestHeader>> result = constraint.test(newRequest(),
                                                                 withSubject(() -> subject(new TestPermission("3"))));
         Assert.assertFalse(toBoolean(result));
     }
@@ -83,14 +88,14 @@ public abstract class AbstractPatternConstraintTest extends AbstractConstraintTe
             public CompletionStage<Boolean> checkPermission(final String permissionValue,
                                                             final Optional<String> meta,
                                                             final DeadboltHandler deadboltHandler,
-                                                            final Http.Context ctx)
+                                                            final Http.RequestHeader requestHeader)
             {
                 return CompletableFuture.completedFuture(true);
             }
         });
         final Constraint constraint = constraint(PatternType.CUSTOM,
                                                  handler);
-        final CompletionStage<Boolean> result = constraint.test(context,
+        final CompletionStage<F.Tuple<Boolean, Http.RequestHeader>> result = constraint.test(newRequest(),
                                                                 handler);
         Assert.assertTrue(toBoolean(result));
     }
@@ -104,14 +109,14 @@ public abstract class AbstractPatternConstraintTest extends AbstractConstraintTe
             public CompletionStage<Boolean> checkPermission(final String permissionValue,
                                                             final Optional<String> meta,
                                                             final DeadboltHandler deadboltHandler,
-                                                            final Http.Context ctx)
+                                                            final Http.RequestHeader requestHeader)
             {
                 return CompletableFuture.completedFuture(false);
             }
         });
         final Constraint constraint = constraint(PatternType.CUSTOM,
                                                  handler);
-        final CompletionStage<Boolean> result = constraint.test(context,
+        final CompletionStage<F.Tuple<Boolean, Http.RequestHeader>> result = constraint.test(newRequest(),
                                                                 handler);
         Assert.assertFalse(toBoolean(result));
     }
@@ -120,11 +125,11 @@ public abstract class AbstractPatternConstraintTest extends AbstractConstraintTe
                                                     final DeadboltHandler handler);
 
     @Override
-    protected F.Tuple<Constraint, Function<Constraint, CompletionStage<Boolean>>> satisfy()
+    protected F.Tuple<Constraint, Function<Constraint, CompletionStage<F.Tuple<Boolean, Http.RequestHeader>>>> satisfy()
     {
         return new F.Tuple<>(constraint(PatternType.EQUALITY,
                                         withSubject(() -> subject(new TestPermission("foo")))),
-                             c -> c.test(context,
+                             c -> c.test(newRequest(),
                                          withSubject(() -> subject(new TestPermission("foo")))));
     }
 }

--- a/code/test/be/objectify/deadbolt/java/composite/AbstractRestrictConstraintTest.java
+++ b/code/test/be/objectify/deadbolt/java/composite/AbstractRestrictConstraintTest.java
@@ -20,6 +20,7 @@ import be.objectify.deadbolt.java.testsupport.TestRole;
 import org.junit.Assert;
 import org.junit.Test;
 import play.libs.F;
+import play.mvc.Http;
 
 import java.util.Arrays;
 import java.util.Collections;
@@ -37,7 +38,7 @@ public abstract class AbstractRestrictConstraintTest extends AbstractConstraintT
     {
         final Constraint constraint = constraint(withSubject(() -> subject(new TestRole("foo"))),
                                                  Collections.singletonList(new String[]{"foo"}));
-        final CompletionStage<Boolean> result = constraint.test(context,
+        final CompletionStage<F.Tuple<Boolean, Http.RequestHeader>> result = constraint.test(new Http.RequestBuilder().build(),
                                                                 withSubject(() -> subject(new TestRole("foo"))));
         Assert.assertTrue(toBoolean(result));
     }
@@ -47,7 +48,7 @@ public abstract class AbstractRestrictConstraintTest extends AbstractConstraintT
     {
         final Constraint constraint = constraint(withSubject(() -> subject(new TestRole("bar"))),
                                                  Collections.singletonList(new String[]{"foo"}));
-        final CompletionStage<Boolean> result = constraint.test(context,
+        final CompletionStage<F.Tuple<Boolean, Http.RequestHeader>> result = constraint.test(new Http.RequestBuilder().build(),
                                                                 withSubject(() -> subject(new TestRole("bar"))));
         Assert.assertFalse(toBoolean(result));
     }
@@ -57,7 +58,7 @@ public abstract class AbstractRestrictConstraintTest extends AbstractConstraintT
     {
         final Constraint constraint = constraint(withSubject(() -> subject(new TestRole("foo"))),
                                                  Collections.singletonList(new String[]{"!foo"}));
-        final CompletionStage<Boolean> result = constraint.test(context,
+        final CompletionStage<F.Tuple<Boolean, Http.RequestHeader>> result = constraint.test(new Http.RequestBuilder().build(),
                                                                 withSubject(() -> subject(new TestRole("foo"))));
         Assert.assertFalse(toBoolean(result));
     }
@@ -67,7 +68,7 @@ public abstract class AbstractRestrictConstraintTest extends AbstractConstraintT
     {
         final Constraint constraint = constraint(withSubject(() -> subject(new TestRole("bar"))),
                                                  Collections.singletonList(new String[]{"!foo"}));
-        final CompletionStage<Boolean> result = constraint.test(context,
+        final CompletionStage<F.Tuple<Boolean, Http.RequestHeader>> result = constraint.test(new Http.RequestBuilder().build(),
                                                                 withSubject(() -> subject(new TestRole("bar"))));
         Assert.assertTrue(toBoolean(result));
     }
@@ -78,7 +79,7 @@ public abstract class AbstractRestrictConstraintTest extends AbstractConstraintT
         final Constraint constraint = constraint(withSubject(() -> subject(new TestRole("foo"),
                                                                            new TestRole("bar"))),
                                                  Collections.singletonList(new String[]{"foo", "bar"}));
-        final CompletionStage<Boolean> result = constraint.test(context,
+        final CompletionStage<F.Tuple<Boolean, Http.RequestHeader>> result = constraint.test(new Http.RequestBuilder().build(),
                                                                 withSubject(() -> subject(new TestRole("foo"),
                                                                                           new TestRole("bar"))));
         Assert.assertTrue(toBoolean(result));
@@ -90,7 +91,7 @@ public abstract class AbstractRestrictConstraintTest extends AbstractConstraintT
         final Constraint constraint = constraint(withSubject(() -> subject(new TestRole("foo"),
                                                                            new TestRole("hurdy"))),
                                                  Collections.singletonList(new String[]{"foo", "bar"}));
-        final CompletionStage<Boolean> result = constraint.test(context,
+        final CompletionStage<F.Tuple<Boolean, Http.RequestHeader>> result = constraint.test(new Http.RequestBuilder().build(),
                                                                 withSubject(() -> subject(new TestRole("foo"),
                                                                                           new TestRole("hurdy"))));
         Assert.assertFalse(toBoolean(result));
@@ -103,7 +104,7 @@ public abstract class AbstractRestrictConstraintTest extends AbstractConstraintT
                                                                            new TestRole("bar"))),
                                                  Arrays.asList(new String[]{"foo", "bar"},
                                                                new String[]{"hurdy", "gurdy"}));
-        final CompletionStage<Boolean> result = constraint.test(context,
+        final CompletionStage<F.Tuple<Boolean, Http.RequestHeader>> result = constraint.test(new Http.RequestBuilder().build(),
                                                                 withSubject(() -> subject(new TestRole("foo"),
                                                                                           new TestRole("bar"))));
         Assert.assertTrue(toBoolean(result));
@@ -115,17 +116,17 @@ public abstract class AbstractRestrictConstraintTest extends AbstractConstraintT
         final Constraint constraint = constraint(withSubject(() -> subject(new TestRole("hurdy"))),
                                                  Arrays.asList(new String[]{"foo"},
                                                                new String[]{"bar"}));
-        final CompletionStage<Boolean> result = constraint.test(context,
+        final CompletionStage<F.Tuple<Boolean, Http.RequestHeader>> result = constraint.test(new Http.RequestBuilder().build(),
                                                                 withSubject(() -> subject(new TestRole("hurdy"))));
         Assert.assertFalse(toBoolean(result));
     }
 
     @Override
-    protected F.Tuple<Constraint, Function<Constraint, CompletionStage<Boolean>>> satisfy()
+    protected F.Tuple<Constraint, Function<Constraint, CompletionStage<F.Tuple<Boolean, Http.RequestHeader>>>> satisfy()
     {
         return new F.Tuple<>(constraint(withSubject(() -> subject(new TestRole("foo"))),
                                         Collections.singletonList(new String[]{"foo"})),
-                             c -> c.test(context,
+                             c -> c.test(new Http.RequestBuilder().build(),
                                          withSubject(() -> subject(new TestRole("foo")))));
     }
 

--- a/code/test/be/objectify/deadbolt/java/composite/AbstractSubjectNotPresentConstraintTest.java
+++ b/code/test/be/objectify/deadbolt/java/composite/AbstractSubjectNotPresentConstraintTest.java
@@ -19,6 +19,7 @@ import be.objectify.deadbolt.java.DeadboltHandler;
 import org.junit.Assert;
 import org.junit.Test;
 import play.libs.F;
+import play.mvc.Http;
 
 import java.util.concurrent.CompletionStage;
 import java.util.function.Function;
@@ -32,7 +33,7 @@ public abstract class AbstractSubjectNotPresentConstraintTest extends AbstractCo
     public void testSubjectPresent() throws Exception
     {
         final Constraint constraint = constraint(withSubject(this::subject));
-        final CompletionStage<Boolean> result = constraint.test(context,
+        final CompletionStage<F.Tuple<Boolean, Http.RequestHeader>> result = constraint.test(new Http.RequestBuilder().build(),
                                                                 withSubject(this::subject));
         Assert.assertFalse(toBoolean(result));
     }
@@ -41,16 +42,16 @@ public abstract class AbstractSubjectNotPresentConstraintTest extends AbstractCo
     public void testSubjectNotPresent() throws Exception
     {
         final Constraint constraint = constraint(withSubject(() -> null));
-        final CompletionStage<Boolean> result = constraint.test(context,
+        final CompletionStage<F.Tuple<Boolean, Http.RequestHeader>> result = constraint.test(new Http.RequestBuilder().build(),
                                                                 withSubject(() -> null));
         Assert.assertTrue(toBoolean(result));
     }
 
     @Override
-    protected F.Tuple<Constraint, Function<Constraint, CompletionStage<Boolean>>> satisfy()
+    protected F.Tuple<Constraint, Function<Constraint, CompletionStage<F.Tuple<Boolean, Http.RequestHeader>>>> satisfy()
     {
         return new F.Tuple<>(constraint(withSubject(() -> null)),
-                             c -> c.test(context,
+                             c -> c.test(new Http.RequestBuilder().build(),
                                          withSubject(() -> null)));
     }
 

--- a/code/test/be/objectify/deadbolt/java/composite/AbstractSubjectPresentConstraintTest.java
+++ b/code/test/be/objectify/deadbolt/java/composite/AbstractSubjectPresentConstraintTest.java
@@ -19,6 +19,7 @@ import be.objectify.deadbolt.java.DeadboltHandler;
 import org.junit.Assert;
 import org.junit.Test;
 import play.libs.F;
+import play.mvc.Http;
 
 import java.util.concurrent.CompletionStage;
 import java.util.function.Function;
@@ -32,7 +33,7 @@ public abstract class AbstractSubjectPresentConstraintTest extends AbstractConst
     public void testSubjectPresent() throws Exception
     {
         final Constraint constraint = constraint(withSubject(this::subject));
-        final CompletionStage<Boolean> result = constraint.test(context,
+        final CompletionStage<F.Tuple<Boolean, Http.RequestHeader>> result = constraint.test(new Http.RequestBuilder().build(),
                                                                 withSubject(this::subject));
         Assert.assertTrue(toBoolean(result));
     }
@@ -41,7 +42,7 @@ public abstract class AbstractSubjectPresentConstraintTest extends AbstractConst
     public void testSubjectNotPresent() throws Exception
     {
         final Constraint constraint = constraint(withSubject(() -> null));
-        final CompletionStage<Boolean> result = constraint.test(context,
+        final CompletionStage<F.Tuple<Boolean, Http.RequestHeader>> result = constraint.test(new Http.RequestBuilder().build(),
                                                                 withSubject(() -> null));
         Assert.assertFalse(toBoolean(result));
     }
@@ -49,10 +50,10 @@ public abstract class AbstractSubjectPresentConstraintTest extends AbstractConst
     public abstract SubjectPresentConstraint constraint(final DeadboltHandler handler);
 
     @Override
-    protected F.Tuple<Constraint, Function<Constraint, CompletionStage<Boolean>>> satisfy()
+    protected F.Tuple<Constraint, Function<Constraint, CompletionStage<F.Tuple<Boolean, Http.RequestHeader>>>> satisfy()
     {
         return new F.Tuple<>(constraint(withSubject(this::subject)),
-                             c -> c.test(context,
+                             c -> c.test(new Http.RequestBuilder().build(),
                                          withSubject(this::subject)));
     }
 }

--- a/code/test/be/objectify/deadbolt/java/composite/ConstraintBuildersTest.java
+++ b/code/test/be/objectify/deadbolt/java/composite/ConstraintBuildersTest.java
@@ -25,6 +25,7 @@ import be.objectify.deadbolt.java.testsupport.TestSubject;
 import org.junit.Assert;
 import org.junit.Test;
 import org.mockito.Mockito;
+import play.libs.F;
 import play.mvc.Http;
 
 import java.util.List;
@@ -41,8 +42,8 @@ public class ConstraintBuildersTest extends AbstractCompositeTest
     {
         final SubjectCache subjectCache = Mockito.mock(SubjectCache.class);
         Mockito.when(subjectCache.apply(Mockito.any(DeadboltHandler.class),
-                                        Mockito.any(Http.Context.class)))
-               .thenReturn(CompletableFuture.completedFuture(Optional.of(new TestSubject.Builder().role(new TestRole("foo")).build())));
+                                        Mockito.any(Http.Request.class)))
+               .thenReturn(CompletableFuture.completedFuture(F.Tuple(Optional.of(new TestSubject.Builder().role(new TestRole("foo")).build()), new Http.RequestBuilder().build())));
         final ConstraintLogic logic = new ConstraintLogic(new DeadboltAnalyzer(),
                                                           subjectCache,
                                                           new DefaultPatternCache());
@@ -64,8 +65,8 @@ public class ConstraintBuildersTest extends AbstractCompositeTest
     {
         final SubjectCache subjectCache = Mockito.mock(SubjectCache.class);
         Mockito.when(subjectCache.apply(Mockito.any(DeadboltHandler.class),
-                                        Mockito.any(Http.Context.class)))
-               .thenReturn(CompletableFuture.completedFuture(Optional.of(new TestSubject.Builder().role(new TestRole("foo")).build())));
+                                        Mockito.any(Http.Request.class)))
+               .thenReturn(CompletableFuture.completedFuture(F.Tuple(Optional.of(new TestSubject.Builder().role(new TestRole("foo")).build()), new Http.RequestBuilder().build())));
         final ConstraintLogic logic = new ConstraintLogic(new DeadboltAnalyzer(),
                                                           subjectCache,
                                                           new DefaultPatternCache());

--- a/code/test/be/objectify/deadbolt/java/composite/ConstraintLogicMixin.java
+++ b/code/test/be/objectify/deadbolt/java/composite/ConstraintLogicMixin.java
@@ -21,6 +21,7 @@ import be.objectify.deadbolt.java.DeadboltHandler;
 import be.objectify.deadbolt.java.cache.DefaultPatternCache;
 import be.objectify.deadbolt.java.cache.SubjectCache;
 import org.mockito.Mockito;
+import play.libs.F;
 import play.mvc.Http;
 
 /**
@@ -32,8 +33,8 @@ public interface ConstraintLogicMixin
     {
         final SubjectCache subjectCache = Mockito.mock(SubjectCache.class);
         Mockito.when(subjectCache.apply(Mockito.any(DeadboltHandler.class),
-                                        Mockito.any(Http.Context.class)))
-               .thenReturn(deadboltHandler.getSubject(Mockito.mock(Http.Context.class)));
+                                        Mockito.any(Http.RequestHeader.class)))
+               .thenReturn(deadboltHandler.getSubject(Mockito.mock(Http.RequestHeader.class)).thenApply(maybeSubject ->F.Tuple(maybeSubject, Mockito.mock(Http.RequestHeader.class))));
         return new ConstraintLogic(new DeadboltAnalyzer(),
                                    subjectCache,
                                    new DefaultPatternCache());

--- a/code/test/be/objectify/deadbolt/java/composite/ConstraintTreeTest.java
+++ b/code/test/be/objectify/deadbolt/java/composite/ConstraintTreeTest.java
@@ -32,18 +32,17 @@ import java.util.function.Function;
  */
 public class ConstraintTreeTest extends AbstractConstraintTest
 {
-    private final Http.Context context = Mockito.mock(Http.Context.class);
     private final DeadboltHandler handler = Mockito.mock(DeadboltHandler.class);
 
     @Test
     public void testAnd_false_false() throws Exception
     {
-        final Constraint constraint = (c, h,  gmd, fnM) -> CompletableFuture.completedFuture(false);
+        final Constraint constraint = (c, h,  gmd, fnM) -> CompletableFuture.completedFuture(F.Tuple(false, Mockito.mock(Http.RequestHeader.class)));
         final Constraint tree = new ConstraintTree(Operator.AND,
                                                    constraint,
                                                    constraint);
 
-        final CompletionStage<Boolean> result = tree.test(context,
+        final CompletionStage<F.Tuple<Boolean, Http.RequestHeader>> result = tree.test(Mockito.mock(Http.RequestHeader.class),
                                                           handler);
         Assert.assertFalse(toBoolean(result));
     }
@@ -51,13 +50,13 @@ public class ConstraintTreeTest extends AbstractConstraintTest
     @Test
     public void testAnd_true_false() throws Exception
     {
-        final Constraint c1 = (c, h, gmd, fnM) -> CompletableFuture.completedFuture(true);
-        final Constraint c2 = (c, h, gmd, fnM) -> CompletableFuture.completedFuture(false);
+        final Constraint c1 = (c, h, gmd, fnM) -> CompletableFuture.completedFuture(F.Tuple(true, Mockito.mock(Http.RequestHeader.class)));
+        final Constraint c2 = (c, h, gmd, fnM) -> CompletableFuture.completedFuture(F.Tuple(false, Mockito.mock(Http.RequestHeader.class)));
         final Constraint tree = new ConstraintTree(Operator.AND,
                                                    c1,
                                                    c2);
 
-        final CompletionStage<Boolean> result = tree.test(context,
+        final CompletionStage<F.Tuple<Boolean, Http.RequestHeader>> result = tree.test(Mockito.mock(Http.RequestHeader.class),
                                                           handler);
         Assert.assertFalse(toBoolean(result));
     }
@@ -65,13 +64,13 @@ public class ConstraintTreeTest extends AbstractConstraintTest
     @Test
     public void testAnd_false_true() throws Exception
     {
-        final Constraint c1 = (c, h, gmd, fnM) -> CompletableFuture.completedFuture(false);
-        final Constraint c2 = (c, h, gmd, fnM) -> CompletableFuture.completedFuture(true);
+        final Constraint c1 = (c, h, gmd, fnM) -> CompletableFuture.completedFuture(F.Tuple(false, Mockito.mock(Http.RequestHeader.class)));
+        final Constraint c2 = (c, h, gmd, fnM) -> CompletableFuture.completedFuture(F.Tuple(true, Mockito.mock(Http.RequestHeader.class)));
         final Constraint tree = new ConstraintTree(Operator.AND,
                                                    c1,
                                                    c2);
 
-        final CompletionStage<Boolean> result = tree.test(context,
+        final CompletionStage<F.Tuple<Boolean, Http.RequestHeader>> result = tree.test(Mockito.mock(Http.RequestHeader.class),
                                                           handler);
         Assert.assertFalse(toBoolean(result));
     }
@@ -79,13 +78,13 @@ public class ConstraintTreeTest extends AbstractConstraintTest
     @Test
     public void testAnd_true_true() throws Exception
     {
-        final Constraint c1 = (c, h, gmd, fnM) -> CompletableFuture.completedFuture(true);
-        final Constraint c2 = (c, h, gmd, fnM) -> CompletableFuture.completedFuture(true);
+        final Constraint c1 = (c, h, gmd, fnM) -> CompletableFuture.completedFuture(F.Tuple(true, Mockito.mock(Http.RequestHeader.class)));
+        final Constraint c2 = (c, h, gmd, fnM) -> CompletableFuture.completedFuture(F.Tuple(true, Mockito.mock(Http.RequestHeader.class)));
         final Constraint tree = new ConstraintTree(Operator.AND,
                                                    c1,
                                                    c2);
 
-        final CompletionStage<Boolean> result = tree.test(context,
+        final CompletionStage<F.Tuple<Boolean, Http.RequestHeader>> result = tree.test(Mockito.mock(Http.RequestHeader.class),
                                                           handler);
         Assert.assertTrue(toBoolean(result));
     }
@@ -93,12 +92,12 @@ public class ConstraintTreeTest extends AbstractConstraintTest
     @Test
     public void testOr_false_false() throws Exception
     {
-        final Constraint constraint = (c, h, gmd, fnM) -> CompletableFuture.completedFuture(false);
+        final Constraint constraint = (c, h, gmd, fnM) -> CompletableFuture.completedFuture(F.Tuple(false, Mockito.mock(Http.RequestHeader.class)));
         final Constraint tree = new ConstraintTree(Operator.OR,
                                                    constraint,
                                                    constraint);
 
-        final CompletionStage<Boolean> result = tree.test(context,
+        final CompletionStage<F.Tuple<Boolean, Http.RequestHeader>> result = tree.test(Mockito.mock(Http.RequestHeader.class),
                                                           handler);
         Assert.assertFalse(toBoolean(result));
     }
@@ -106,13 +105,13 @@ public class ConstraintTreeTest extends AbstractConstraintTest
     @Test
     public void testOr_true_false() throws Exception
     {
-        final Constraint c1 = (c, h, gmd, fnM) -> CompletableFuture.completedFuture(true);
-        final Constraint c2 = (c, h, gmd, fnM) -> CompletableFuture.completedFuture(false);
+        final Constraint c1 = (c, h, gmd, fnM) -> CompletableFuture.completedFuture(F.Tuple(true, Mockito.mock(Http.RequestHeader.class)));
+        final Constraint c2 = (c, h, gmd, fnM) -> CompletableFuture.completedFuture(F.Tuple(false, Mockito.mock(Http.RequestHeader.class)));
         final Constraint tree = new ConstraintTree(Operator.OR,
                                                    c1,
                                                    c2);
 
-        final CompletionStage<Boolean> result = tree.test(context,
+        final CompletionStage<F.Tuple<Boolean, Http.RequestHeader>> result = tree.test(Mockito.mock(Http.RequestHeader.class),
                                                           handler);
         Assert.assertTrue(toBoolean(result));
     }
@@ -120,13 +119,13 @@ public class ConstraintTreeTest extends AbstractConstraintTest
     @Test
     public void testOr_false_true() throws Exception
     {
-        final Constraint c1 = (c, h, gmd, fnM) -> CompletableFuture.completedFuture(false);
-        final Constraint c2 = (c, h, gmd, fnM) -> CompletableFuture.completedFuture(true);
+        final Constraint c1 = (c, h, gmd, fnM) -> CompletableFuture.completedFuture(F.Tuple(false, Mockito.mock(Http.RequestHeader.class)));
+        final Constraint c2 = (c, h, gmd, fnM) -> CompletableFuture.completedFuture(F.Tuple(true, Mockito.mock(Http.RequestHeader.class)));
         final Constraint tree = new ConstraintTree(Operator.OR,
                                                    c1,
                                                    c2);
 
-        final CompletionStage<Boolean> result = tree.test(context,
+        final CompletionStage<F.Tuple<Boolean, Http.RequestHeader>> result = tree.test(Mockito.mock(Http.RequestHeader.class),
                                                           handler);
         Assert.assertTrue(toBoolean(result));
     }
@@ -134,13 +133,13 @@ public class ConstraintTreeTest extends AbstractConstraintTest
     @Test
     public void testOr_true_true() throws Exception
     {
-        final Constraint c1 = (c, h, gmd, fnM) -> CompletableFuture.completedFuture(true);
-        final Constraint c2 = (c, h, gmd, fnM) -> CompletableFuture.completedFuture(true);
+        final Constraint c1 = (c, h, gmd, fnM) -> CompletableFuture.completedFuture(F.Tuple(true, Mockito.mock(Http.RequestHeader.class)));
+        final Constraint c2 = (c, h, gmd, fnM) -> CompletableFuture.completedFuture(F.Tuple(true, Mockito.mock(Http.RequestHeader.class)));
         final Constraint tree = new ConstraintTree(Operator.OR,
                                                    c1,
                                                    c2);
 
-        final CompletionStage<Boolean> result = tree.test(context,
+        final CompletionStage<F.Tuple<Boolean, Http.RequestHeader>> result = tree.test(Mockito.mock(Http.RequestHeader.class),
                                                           handler);
         Assert.assertTrue(toBoolean(result));
     }
@@ -148,14 +147,14 @@ public class ConstraintTreeTest extends AbstractConstraintTest
     @Test
     public void testMeta_and() throws Exception
     {
-        final Constraint c1 = (c, h, gmd, fnM) -> gmd.map(meta -> CompletableFuture.completedFuture("foo".equals(meta)))
-                                                        .orElse(CompletableFuture.completedFuture(false));
-        final Constraint c2 = (c, h, gmd, fnM) -> gmd.map(meta -> CompletableFuture.completedFuture("foo".equals(meta)))
-                                                        .orElse(CompletableFuture.completedFuture(false));
+        final Constraint c1 = (c, h, gmd, fnM) -> gmd.map(meta -> CompletableFuture.completedFuture(F.Tuple("foo".equals(meta), Mockito.mock(Http.RequestHeader.class))))
+                                                        .orElse(CompletableFuture.completedFuture(F.Tuple(false, Mockito.mock(Http.RequestHeader.class))));
+        final Constraint c2 = (c, h, gmd, fnM) -> gmd.map(meta -> CompletableFuture.completedFuture(F.Tuple("foo".equals(meta), Mockito.mock(Http.RequestHeader.class))))
+                                                        .orElse(CompletableFuture.completedFuture(F.Tuple(false, Mockito.mock(Http.RequestHeader.class))));
         final Constraint tree = new ConstraintTree(Operator.AND,
                                                    c1,
                                                    c2);
-        final CompletionStage<Boolean> result = tree.test(context,
+        final CompletionStage<F.Tuple<Boolean, Http.RequestHeader>> result = tree.test(Mockito.mock(Http.RequestHeader.class),
                                                           handler,
                                                           Optional.of("foo"),
                                                           (md1, md2) -> md1);
@@ -165,21 +164,21 @@ public class ConstraintTreeTest extends AbstractConstraintTest
     @Test
     public void testMeta_or() throws Exception
     {
-        final Constraint c1 = (c, h, gmd, fnM) -> gmd.map(meta -> CompletableFuture.completedFuture("foo".equals(meta)))
-                                                        .orElse(CompletableFuture.completedFuture(false));
-        final Constraint c2 = (c, h, gmd, fnM) -> gmd.map(meta -> CompletableFuture.completedFuture("foo".equals(meta)))
-                                                        .orElse(CompletableFuture.completedFuture(false));
-        final CompletionStage<Boolean> leftResult = new ConstraintTree(Operator.OR,
+        final Constraint c1 = (c, h, gmd, fnM) -> gmd.map(meta -> CompletableFuture.completedFuture(F.Tuple("foo".equals(meta), Mockito.mock(Http.RequestHeader.class))))
+                                                        .orElse(CompletableFuture.completedFuture(F.Tuple(false, Mockito.mock(Http.RequestHeader.class))));
+        final Constraint c2 = (c, h, gmd, fnM) -> gmd.map(meta -> CompletableFuture.completedFuture(F.Tuple("foo".equals(meta), Mockito.mock(Http.RequestHeader.class))))
+                                                        .orElse(CompletableFuture.completedFuture(F.Tuple(false, Mockito.mock(Http.RequestHeader.class))));
+        final CompletionStage<F.Tuple<Boolean, Http.RequestHeader>> leftResult = new ConstraintTree(Operator.OR,
                                                                        c1,
-                                                                       c2).test(context,
+                                                                       c2).test(Mockito.mock(Http.RequestHeader.class),
                                                                                 handler,
                                                                                 Optional.of("foo"),
                                                                                 (md1, md2) -> md1);
         Assert.assertTrue(toBoolean(leftResult));
 
-        final CompletionStage<Boolean> rightResult = new ConstraintTree(Operator.OR,
-                                                                        (c, h, gmd, fnM) -> CompletableFuture.completedFuture(false),
-                                                                        c2).test(context,
+        final CompletionStage<F.Tuple<Boolean, Http.RequestHeader>> rightResult = new ConstraintTree(Operator.OR,
+                                                                        (c, h, gmd, fnM) -> CompletableFuture.completedFuture(F.Tuple(false, Mockito.mock(Http.RequestHeader.class))),
+                                                                        c2).test(Mockito.mock(Http.RequestHeader.class),
                                                                                  handler,
                                                                                  Optional.of("foo"),
                                                                                  (md1, md2) -> md1);
@@ -187,14 +186,14 @@ public class ConstraintTreeTest extends AbstractConstraintTest
     }
 
     @Override
-    protected F.Tuple<Constraint, Function<Constraint, CompletionStage<Boolean>>> satisfy()
+    protected F.Tuple<Constraint, Function<Constraint, CompletionStage<F.Tuple<Boolean, Http.RequestHeader>>>> satisfy()
     {
-        final Constraint constraint = (c, h, gmd, fnM) -> CompletableFuture.completedFuture(true);
+        final Constraint constraint = (c, h, gmd, fnM) -> CompletableFuture.completedFuture(F.Tuple(true, Mockito.mock(Http.RequestHeader.class)));
         final Constraint tree = new ConstraintTree(Operator.AND,
                                                    constraint,
                                                    constraint);
         return new F.Tuple<>(tree,
-                             c -> c.test(context,
+                             c -> c.test(Mockito.mock(Http.RequestHeader.class),
                                          handler));
     }
 }

--- a/code/test/be/objectify/deadbolt/java/composite/ExceptionThrowingConstraintTest.java
+++ b/code/test/be/objectify/deadbolt/java/composite/ExceptionThrowingConstraintTest.java
@@ -34,7 +34,7 @@ public class ExceptionThrowingConstraintTest
         try
         {
             new ExceptionThrowingConstraint("testConstraint")
-                    .test(Mockito.mock(Http.Context.class),
+                    .test(Mockito.mock(Http.RequestHeader.class),
                           Mockito.mock(DeadboltHandler.class),
                           Optional.empty(),
                           (md1, md2) -> md1);

--- a/code/test/be/objectify/deadbolt/java/filters/AbstractDeadboltFilterTest.java
+++ b/code/test/be/objectify/deadbolt/java/filters/AbstractDeadboltFilterTest.java
@@ -31,7 +31,7 @@ public abstract class AbstractDeadboltFilterTest {
                                                                     subjectCache,
                                                                     new DefaultPatternCache());
 
-        final BeforeAuthCheckCache beforeAuthCheckCache = new DefaultBeforeAuthCheckCache(ConfigFactory.empty());
+        final BeforeAuthCheckCache beforeAuthCheckCache = new DefaultBeforeAuthCheckCache(ConfigFactory.load());
 
         filterConstraints = new FilterConstraints(constraintLogic,
                                                   Mockito.mock(CompositeCache.class),

--- a/code/test/be/objectify/deadbolt/java/filters/AuthorizedRouteTest.java
+++ b/code/test/be/objectify/deadbolt/java/filters/AuthorizedRouteTest.java
@@ -35,7 +35,7 @@ public class AuthorizedRouteTest
     @Test
     public void constructorWithDefaultHandler()
     {
-        final FilterFunction constraint = (context, requestHeader, handler, onSuccess) -> CompletableFuture.completedFuture(Results.ok());
+        final FilterFunction constraint = (requestHeader, handler, onSuccess) -> CompletableFuture.completedFuture(Results.ok());
         final AuthorizedRoute route = new AuthorizedRoute(GET,
                                                           "/foo",
                                                           constraint);
@@ -53,7 +53,7 @@ public class AuthorizedRouteTest
     @Test
     public void constructorWithSpecificHandler()
     {
-        final FilterFunction constraint = (context, requestHeader, handler, onSuccess) -> CompletableFuture.completedFuture(Results.ok());
+        final FilterFunction constraint = (requestHeader, handler, onSuccess) -> CompletableFuture.completedFuture(Results.ok());
         final DeadboltHandler handler = Mockito.mock(DeadboltHandler.class);
         final AuthorizedRoute route = new AuthorizedRoute(GET,
                                                           "/foo",

--- a/code/test/be/objectify/deadbolt/java/filters/DeadboltRouteCommentFilterTest.java
+++ b/code/test/be/objectify/deadbolt/java/filters/DeadboltRouteCommentFilterTest.java
@@ -33,7 +33,7 @@ import org.junit.Assert;
 import org.junit.Test;
 import org.mockito.Mockito;
 import play.api.routing.HandlerDef;
-import play.core.j.JavaContextComponents;
+import play.libs.F;
 import play.mvc.Filter;
 import play.mvc.Http;
 import play.mvc.Result;
@@ -50,20 +50,19 @@ public class DeadboltRouteCommentFilterTest extends AbstractDeadboltFilterTest
     public void testSubjectPresent_subjectIsPresent_defaultHandler() throws ExecutionException, InterruptedException
     {
         Mockito.when(subjectCache.apply(Mockito.any(DeadboltHandler.class),
-                                        Mockito.any(Http.Context.class)))
-               .thenReturn(CompletableFuture.completedFuture(Optional.of(Mockito.mock(Subject.class))));
+                                        Mockito.any(Http.RequestHeader.class)))
+               .thenReturn(CompletableFuture.completedFuture(F.Tuple(Optional.of(Mockito.mock(Subject.class)), Mockito.mock(Http.RequestHeader.class))));
 
         final HandlerCache handlerCache = Mockito.mock(HandlerCache.class);
         final DeadboltHandler handler = Mockito.mock(DeadboltHandler.class);
         Mockito.when(handlerCache.get())
                .thenReturn(handler);
-        Mockito.when(handler.getSubject(Mockito.any(Http.Context.class)))
+        Mockito.when(handler.getSubject(Mockito.any(Http.RequestHeader.class)))
                .thenReturn(CompletableFuture.completedFuture(Optional.of(Mockito.mock(Subject.class))));
-        Mockito.when(handler.beforeAuthCheck(Mockito.any(Http.Context.class), Mockito.any(Optional.class)))
+        Mockito.when(handler.beforeAuthCheck(Mockito.any(Http.RequestHeader.class), Mockito.any(Optional.class)))
                .thenReturn(CompletableFuture.completedFuture(Optional.empty()));
 
         final Filter filter = new DeadboltRouteCommentFilter(Mockito.mock(Materializer.class),
-                                                             Mockito.mock(JavaContextComponents.class),
                                                              handlerCache,
                                                              filterConstraints);
         final boolean[] flag = {false};
@@ -82,23 +81,22 @@ public class DeadboltRouteCommentFilterTest extends AbstractDeadboltFilterTest
     public void testSubjectPresent_subjectIsNotPresent_defaultHandler() throws ExecutionException, InterruptedException
     {
         Mockito.when(subjectCache.apply(Mockito.any(DeadboltHandler.class),
-                                        Mockito.any(Http.Context.class)))
-               .thenReturn(CompletableFuture.completedFuture(Optional.empty()));
+                                        Mockito.any(Http.RequestHeader.class)))
+               .thenReturn(CompletableFuture.completedFuture(F.Tuple(Optional.empty(), Mockito.mock(Http.RequestHeader.class))));
 
         final HandlerCache handlerCache = Mockito.mock(HandlerCache.class);
         final DeadboltHandler handler = Mockito.mock(DeadboltHandler.class);
         Mockito.when(handlerCache.get())
                .thenReturn(handler);
-        Mockito.when(handler.getSubject(Mockito.any(Http.Context.class)))
+        Mockito.when(handler.getSubject(Mockito.any(Http.RequestHeader.class)))
                .thenReturn(CompletableFuture.completedFuture(Optional.empty()));
-        Mockito.when(handler.beforeAuthCheck(Mockito.any(Http.Context.class), Mockito.any(Optional.class)))
+        Mockito.when(handler.beforeAuthCheck(Mockito.any(Http.RequestHeader.class), Mockito.any(Optional.class)))
                .thenReturn(CompletableFuture.completedFuture(Optional.empty()));
-        Mockito.when(handler.onAuthFailure(Mockito.any(Http.Context.class),
+        Mockito.when(handler.onAuthFailure(Mockito.any(Http.RequestHeader.class),
                                            Mockito.eq(Optional.empty())))
                .thenReturn(CompletableFuture.completedFuture(Results.forbidden()));
 
         final Filter filter = new DeadboltRouteCommentFilter(Mockito.mock(Materializer.class),
-                                                             Mockito.mock(JavaContextComponents.class),
                                                              handlerCache,
                                                              filterConstraints);
         final boolean[] flag = {false};
@@ -113,7 +111,7 @@ public class DeadboltRouteCommentFilterTest extends AbstractDeadboltFilterTest
         Assert.assertFalse(flag[0]);
         Mockito.verify(handler,
                        Mockito.times(1))
-               .onAuthFailure(Mockito.any(Http.Context.class),
+               .onAuthFailure(Mockito.any(Http.RequestHeader.class),
                               Mockito.eq(Optional.empty()));
     }
 
@@ -121,23 +119,22 @@ public class DeadboltRouteCommentFilterTest extends AbstractDeadboltFilterTest
     public void testSubjectPresent_subjectIsNotPresent_withContent() throws ExecutionException, InterruptedException
     {
         Mockito.when(subjectCache.apply(Mockito.any(DeadboltHandler.class),
-                                        Mockito.any(Http.Context.class)))
-               .thenReturn(CompletableFuture.completedFuture(Optional.empty()));
+                                        Mockito.any(Http.RequestHeader.class)))
+               .thenReturn(CompletableFuture.completedFuture(F.Tuple(Optional.empty(), Mockito.mock(Http.RequestHeader.class))));
 
         final HandlerCache handlerCache = Mockito.mock(HandlerCache.class);
         final DeadboltHandler handler = Mockito.mock(DeadboltHandler.class);
         Mockito.when(handlerCache.get())
                .thenReturn(handler);
-        Mockito.when(handler.getSubject(Mockito.any(Http.Context.class)))
+        Mockito.when(handler.getSubject(Mockito.any(Http.RequestHeader.class)))
                .thenReturn(CompletableFuture.completedFuture(Optional.empty()));
-        Mockito.when(handler.beforeAuthCheck(Mockito.any(Http.Context.class), Mockito.any(Optional.class)))
+        Mockito.when(handler.beforeAuthCheck(Mockito.any(Http.RequestHeader.class), Mockito.any(Optional.class)))
                .thenReturn(CompletableFuture.completedFuture(Optional.empty()));
-        Mockito.when(handler.onAuthFailure(Mockito.any(Http.Context.class),
+        Mockito.when(handler.onAuthFailure(Mockito.any(Http.RequestHeader.class),
                                            Mockito.eq(Optional.of("bar"))))
                .thenReturn(CompletableFuture.completedFuture(Results.forbidden()));
 
         final Filter filter = new DeadboltRouteCommentFilter(Mockito.mock(Materializer.class),
-                                                             Mockito.mock(JavaContextComponents.class),
                                                              handlerCache,
                                                              filterConstraints);
         final boolean[] flag = {false};
@@ -152,7 +149,7 @@ public class DeadboltRouteCommentFilterTest extends AbstractDeadboltFilterTest
         Assert.assertFalse(flag[0]);
         Mockito.verify(handler,
                        Mockito.times(1))
-               .onAuthFailure(Mockito.any(Http.Context.class),
+               .onAuthFailure(Mockito.any(Http.RequestHeader.class),
                               Mockito.eq(Optional.of("bar")));
     }
 
@@ -160,21 +157,20 @@ public class DeadboltRouteCommentFilterTest extends AbstractDeadboltFilterTest
     public void testSubjectPresent_subjectIsPresent_specificHandler() throws ExecutionException, InterruptedException
     {
         Mockito.when(subjectCache.apply(Mockito.any(DeadboltHandler.class),
-                                        Mockito.any(Http.Context.class)))
-               .thenReturn(CompletableFuture.completedFuture(Optional.of(Mockito.mock(Subject.class))));
+                                        Mockito.any(Http.RequestHeader.class)))
+               .thenReturn(CompletableFuture.completedFuture(F.Tuple(Optional.of(Mockito.mock(Subject.class)), Mockito.mock(Http.RequestHeader.class))));
 
         final DeadboltHandler defaultHandler = Mockito.mock(DeadboltHandler.class);
         final DeadboltHandler specificHandler = Mockito.mock(DeadboltHandler.class);
         final HandlerCache handlerCache = new TestHandlerCache(defaultHandler,
                                                                Collections.singletonMap("foo",
                                                                                         specificHandler));
-        Mockito.when(specificHandler.getSubject(Mockito.any(Http.Context.class)))
+        Mockito.when(specificHandler.getSubject(Mockito.any(Http.RequestHeader.class)))
                .thenReturn(CompletableFuture.completedFuture(Optional.of(Mockito.mock(Subject.class))));
-        Mockito.when(specificHandler.beforeAuthCheck(Mockito.any(Http.Context.class), Mockito.any(Optional.class)))
+        Mockito.when(specificHandler.beforeAuthCheck(Mockito.any(Http.RequestHeader.class), Mockito.any(Optional.class)))
                .thenReturn(CompletableFuture.completedFuture(Optional.empty()));
 
         final Filter filter = new DeadboltRouteCommentFilter(Mockito.mock(Materializer.class),
-                                                             Mockito.mock(JavaContextComponents.class),
                                                              handlerCache,
                                                              filterConstraints);
         final boolean[] flag = {false};
@@ -194,24 +190,23 @@ public class DeadboltRouteCommentFilterTest extends AbstractDeadboltFilterTest
     public void testSubjectPresent_subjectIsNotPresent_specificHandler() throws ExecutionException, InterruptedException
     {
         Mockito.when(subjectCache.apply(Mockito.any(DeadboltHandler.class),
-                                        Mockito.any(Http.Context.class)))
-               .thenReturn(CompletableFuture.completedFuture(Optional.empty()));
+                                        Mockito.any(Http.RequestHeader.class)))
+               .thenReturn(CompletableFuture.completedFuture(F.Tuple(Optional.empty(), Mockito.mock(Http.RequestHeader.class))));
 
         final DeadboltHandler defaultHandler = Mockito.mock(DeadboltHandler.class);
         final DeadboltHandler specificHandler = Mockito.mock(DeadboltHandler.class);
         final HandlerCache handlerCache = new TestHandlerCache(defaultHandler,
                                                                Collections.singletonMap("foo",
                                                                                         specificHandler));
-        Mockito.when(specificHandler.getSubject(Mockito.any(Http.Context.class)))
+        Mockito.when(specificHandler.getSubject(Mockito.any(Http.RequestHeader.class)))
                .thenReturn(CompletableFuture.completedFuture(Optional.empty()));
-        Mockito.when(specificHandler.beforeAuthCheck(Mockito.any(Http.Context.class), Mockito.any(Optional.class)))
+        Mockito.when(specificHandler.beforeAuthCheck(Mockito.any(Http.RequestHeader.class), Mockito.any(Optional.class)))
                .thenReturn(CompletableFuture.completedFuture(Optional.empty()));
-        Mockito.when(specificHandler.onAuthFailure(Mockito.any(Http.Context.class),
+        Mockito.when(specificHandler.onAuthFailure(Mockito.any(Http.RequestHeader.class),
                                                    Mockito.eq(Optional.empty())))
                .thenReturn(CompletableFuture.completedFuture(Results.forbidden()));
 
         final Filter filter = new DeadboltRouteCommentFilter(Mockito.mock(Materializer.class),
-                                                             Mockito.mock(JavaContextComponents.class),
                                                              handlerCache,
                                                              filterConstraints);
         final boolean[] flag = {false};
@@ -226,7 +221,7 @@ public class DeadboltRouteCommentFilterTest extends AbstractDeadboltFilterTest
         Assert.assertFalse(flag[0]);
         Mockito.verify(specificHandler,
                        Mockito.times(1))
-               .onAuthFailure(Mockito.any(Http.Context.class),
+               .onAuthFailure(Mockito.any(Http.RequestHeader.class),
                               Mockito.eq(Optional.empty()));
         Mockito.verifyZeroInteractions(defaultHandler);
     }
@@ -235,24 +230,23 @@ public class DeadboltRouteCommentFilterTest extends AbstractDeadboltFilterTest
     public void testSubjectPresent_subjectIsNotPresent_specificHandler_withContent() throws ExecutionException, InterruptedException
     {
         Mockito.when(subjectCache.apply(Mockito.any(DeadboltHandler.class),
-                                        Mockito.any(Http.Context.class)))
-               .thenReturn(CompletableFuture.completedFuture(Optional.empty()));
+                                        Mockito.any(Http.RequestHeader.class)))
+               .thenReturn(CompletableFuture.completedFuture(F.Tuple(Optional.empty(), Mockito.mock(Http.RequestHeader.class))));
 
         final DeadboltHandler defaultHandler = Mockito.mock(DeadboltHandler.class);
         final DeadboltHandler specificHandler = Mockito.mock(DeadboltHandler.class);
         final HandlerCache handlerCache = new TestHandlerCache(defaultHandler,
                                                                Collections.singletonMap("foo",
                                                                                         specificHandler));
-        Mockito.when(specificHandler.getSubject(Mockito.any(Http.Context.class)))
+        Mockito.when(specificHandler.getSubject(Mockito.any(Http.RequestHeader.class)))
                .thenReturn(CompletableFuture.completedFuture(Optional.empty()));
-        Mockito.when(specificHandler.beforeAuthCheck(Mockito.any(Http.Context.class), Mockito.any(Optional.class)))
+        Mockito.when(specificHandler.beforeAuthCheck(Mockito.any(Http.RequestHeader.class), Mockito.any(Optional.class)))
                .thenReturn(CompletableFuture.completedFuture(Optional.empty()));
-        Mockito.when(specificHandler.onAuthFailure(Mockito.any(Http.Context.class),
+        Mockito.when(specificHandler.onAuthFailure(Mockito.any(Http.RequestHeader.class),
                                                    Mockito.eq(Optional.of("bar"))))
                .thenReturn(CompletableFuture.completedFuture(Results.forbidden()));
 
         final Filter filter = new DeadboltRouteCommentFilter(Mockito.mock(Materializer.class),
-                                                             Mockito.mock(JavaContextComponents.class),
                                                              handlerCache,
                                                              filterConstraints);
         final boolean[] flag = {false};
@@ -267,7 +261,7 @@ public class DeadboltRouteCommentFilterTest extends AbstractDeadboltFilterTest
         Assert.assertFalse(flag[0]);
         Mockito.verify(specificHandler,
                        Mockito.times(1))
-               .onAuthFailure(Mockito.any(Http.Context.class),
+               .onAuthFailure(Mockito.any(Http.RequestHeader.class),
                               Mockito.eq(Optional.of("bar")));
         Mockito.verifyZeroInteractions(defaultHandler);
     }
@@ -277,23 +271,22 @@ public class DeadboltRouteCommentFilterTest extends AbstractDeadboltFilterTest
     {
 
         Mockito.when(subjectCache.apply(Mockito.any(DeadboltHandler.class),
-                                        Mockito.any(Http.Context.class)))
-               .thenReturn(CompletableFuture.completedFuture(Optional.of(Mockito.mock(Subject.class))));
+                                        Mockito.any(Http.RequestHeader.class)))
+               .thenReturn(CompletableFuture.completedFuture(F.Tuple(Optional.of(Mockito.mock(Subject.class)), Mockito.mock(Http.RequestHeader.class))));
 
         final HandlerCache handlerCache = Mockito.mock(HandlerCache.class);
         final DeadboltHandler handler = Mockito.mock(DeadboltHandler.class);
         Mockito.when(handlerCache.get())
                .thenReturn(handler);
-        Mockito.when(handler.getSubject(Mockito.any(Http.Context.class)))
+        Mockito.when(handler.getSubject(Mockito.any(Http.RequestHeader.class)))
                .thenReturn(CompletableFuture.completedFuture(Optional.of(Mockito.mock(Subject.class))));
-        Mockito.when(handler.beforeAuthCheck(Mockito.any(Http.Context.class), Mockito.any(Optional.class)))
+        Mockito.when(handler.beforeAuthCheck(Mockito.any(Http.RequestHeader.class), Mockito.any(Optional.class)))
                .thenReturn(CompletableFuture.completedFuture(Optional.empty()));
-        Mockito.when(handler.onAuthFailure(Mockito.any(Http.Context.class),
+        Mockito.when(handler.onAuthFailure(Mockito.any(Http.RequestHeader.class),
                                            Mockito.eq(Optional.empty())))
                .thenReturn(CompletableFuture.completedFuture(Results.forbidden()));
 
         final Filter filter = new DeadboltRouteCommentFilter(Mockito.mock(Materializer.class),
-                                                             Mockito.mock(JavaContextComponents.class),
                                                              handlerCache,
                                                              filterConstraints);
         final boolean[] flag = {false};
@@ -308,7 +301,7 @@ public class DeadboltRouteCommentFilterTest extends AbstractDeadboltFilterTest
         Assert.assertFalse(flag[0]);
         Mockito.verify(handler,
                        Mockito.times(1))
-               .onAuthFailure(Mockito.any(Http.Context.class),
+               .onAuthFailure(Mockito.any(Http.RequestHeader.class),
                               Mockito.eq(Optional.empty()));
     }
 
@@ -317,23 +310,22 @@ public class DeadboltRouteCommentFilterTest extends AbstractDeadboltFilterTest
     {
 
         Mockito.when(subjectCache.apply(Mockito.any(DeadboltHandler.class),
-                                        Mockito.any(Http.Context.class)))
-               .thenReturn(CompletableFuture.completedFuture(Optional.of(Mockito.mock(Subject.class))));
+                                        Mockito.any(Http.RequestHeader.class)))
+               .thenReturn(CompletableFuture.completedFuture(F.Tuple(Optional.of(Mockito.mock(Subject.class)), Mockito.mock(Http.RequestHeader.class))));
 
         final HandlerCache handlerCache = Mockito.mock(HandlerCache.class);
         final DeadboltHandler handler = Mockito.mock(DeadboltHandler.class);
         Mockito.when(handlerCache.get())
                .thenReturn(handler);
-        Mockito.when(handler.getSubject(Mockito.any(Http.Context.class)))
+        Mockito.when(handler.getSubject(Mockito.any(Http.RequestHeader.class)))
                .thenReturn(CompletableFuture.completedFuture(Optional.of(Mockito.mock(Subject.class))));
-        Mockito.when(handler.beforeAuthCheck(Mockito.any(Http.Context.class), Mockito.any(Optional.class)))
+        Mockito.when(handler.beforeAuthCheck(Mockito.any(Http.RequestHeader.class), Mockito.any(Optional.class)))
                .thenReturn(CompletableFuture.completedFuture(Optional.empty()));
-        Mockito.when(handler.onAuthFailure(Mockito.any(Http.Context.class),
+        Mockito.when(handler.onAuthFailure(Mockito.any(Http.RequestHeader.class),
                                            Mockito.eq(Optional.of("bar"))))
                .thenReturn(CompletableFuture.completedFuture(Results.forbidden()));
 
         final Filter filter = new DeadboltRouteCommentFilter(Mockito.mock(Materializer.class),
-                                                             Mockito.mock(JavaContextComponents.class),
                                                              handlerCache,
                                                              filterConstraints);
         final boolean[] flag = {false};
@@ -348,7 +340,7 @@ public class DeadboltRouteCommentFilterTest extends AbstractDeadboltFilterTest
         Assert.assertFalse(flag[0]);
         Mockito.verify(handler,
                        Mockito.times(1))
-               .onAuthFailure(Mockito.any(Http.Context.class),
+               .onAuthFailure(Mockito.any(Http.RequestHeader.class),
                               Mockito.eq(Optional.of("bar")));
     }
 
@@ -357,20 +349,19 @@ public class DeadboltRouteCommentFilterTest extends AbstractDeadboltFilterTest
     {
 
         Mockito.when(subjectCache.apply(Mockito.any(DeadboltHandler.class),
-                                        Mockito.any(Http.Context.class)))
-               .thenReturn(CompletableFuture.completedFuture(Optional.empty()));
+                                        Mockito.any(Http.RequestHeader.class)))
+               .thenReturn(CompletableFuture.completedFuture(F.Tuple(Optional.empty(), Mockito.mock(Http.RequestHeader.class))));
 
         final HandlerCache handlerCache = Mockito.mock(HandlerCache.class);
         final DeadboltHandler handler = Mockito.mock(DeadboltHandler.class);
         Mockito.when(handlerCache.get())
                .thenReturn(handler);
-        Mockito.when(handler.getSubject(Mockito.any(Http.Context.class)))
+        Mockito.when(handler.getSubject(Mockito.any(Http.RequestHeader.class)))
                .thenReturn(CompletableFuture.completedFuture(Optional.empty()));
-        Mockito.when(handler.beforeAuthCheck(Mockito.any(Http.Context.class), Mockito.any(Optional.class)))
+        Mockito.when(handler.beforeAuthCheck(Mockito.any(Http.RequestHeader.class), Mockito.any(Optional.class)))
                .thenReturn(CompletableFuture.completedFuture(Optional.empty()));
 
         final Filter filter = new DeadboltRouteCommentFilter(Mockito.mock(Materializer.class),
-                                                             Mockito.mock(JavaContextComponents.class),
                                                              handlerCache,
                                                              filterConstraints);
         final boolean[] flag = {false};
@@ -389,24 +380,23 @@ public class DeadboltRouteCommentFilterTest extends AbstractDeadboltFilterTest
     public void testSubjectNotPresent_subjectIsPresent_specificHandler() throws ExecutionException, InterruptedException
     {
         Mockito.when(subjectCache.apply(Mockito.any(DeadboltHandler.class),
-                                        Mockito.any(Http.Context.class)))
-               .thenReturn(CompletableFuture.completedFuture(Optional.of(Mockito.mock(Subject.class))));
+                                        Mockito.any(Http.RequestHeader.class)))
+               .thenReturn(CompletableFuture.completedFuture(F.Tuple(Optional.of(Mockito.mock(Subject.class)), Mockito.mock(Http.RequestHeader.class))));
 
         final DeadboltHandler defaultHandler = Mockito.mock(DeadboltHandler.class);
         final DeadboltHandler specificHandler = Mockito.mock(DeadboltHandler.class);
         final HandlerCache handlerCache = new TestHandlerCache(defaultHandler,
                                                                Collections.singletonMap("foo",
                                                                                         specificHandler));
-        Mockito.when(specificHandler.getSubject(Mockito.any(Http.Context.class)))
+        Mockito.when(specificHandler.getSubject(Mockito.any(Http.RequestHeader.class)))
                .thenReturn(CompletableFuture.completedFuture(Optional.of(Mockito.mock(Subject.class))));
-        Mockito.when(specificHandler.beforeAuthCheck(Mockito.any(Http.Context.class), Mockito.any(Optional.class)))
+        Mockito.when(specificHandler.beforeAuthCheck(Mockito.any(Http.RequestHeader.class), Mockito.any(Optional.class)))
                .thenReturn(CompletableFuture.completedFuture(Optional.empty()));
-        Mockito.when(specificHandler.onAuthFailure(Mockito.any(Http.Context.class),
+        Mockito.when(specificHandler.onAuthFailure(Mockito.any(Http.RequestHeader.class),
                                                    Mockito.eq(Optional.empty())))
                .thenReturn(CompletableFuture.completedFuture(Results.forbidden()));
 
         final Filter filter = new DeadboltRouteCommentFilter(Mockito.mock(Materializer.class),
-                                                             Mockito.mock(JavaContextComponents.class),
                                                              handlerCache,
                                                              filterConstraints);
         final boolean[] flag = {false};
@@ -421,7 +411,7 @@ public class DeadboltRouteCommentFilterTest extends AbstractDeadboltFilterTest
         Assert.assertFalse(flag[0]);
         Mockito.verify(specificHandler,
                        Mockito.times(1))
-               .onAuthFailure(Mockito.any(Http.Context.class),
+               .onAuthFailure(Mockito.any(Http.RequestHeader.class),
                               Mockito.eq(Optional.empty()));
         Mockito.verifyZeroInteractions(defaultHandler);
     }
@@ -430,24 +420,23 @@ public class DeadboltRouteCommentFilterTest extends AbstractDeadboltFilterTest
     public void testSubjectNotPresent_subjectIsPresent_specificHandler_withContent() throws ExecutionException, InterruptedException
     {
         Mockito.when(subjectCache.apply(Mockito.any(DeadboltHandler.class),
-                                        Mockito.any(Http.Context.class)))
-               .thenReturn(CompletableFuture.completedFuture(Optional.of(Mockito.mock(Subject.class))));
+                                        Mockito.any(Http.RequestHeader.class)))
+               .thenReturn(CompletableFuture.completedFuture(F.Tuple(Optional.of(Mockito.mock(Subject.class)), Mockito.mock(Http.RequestHeader.class))));
 
         final DeadboltHandler defaultHandler = Mockito.mock(DeadboltHandler.class);
         final DeadboltHandler specificHandler = Mockito.mock(DeadboltHandler.class);
         final HandlerCache handlerCache = new TestHandlerCache(defaultHandler,
                                                                Collections.singletonMap("foo",
                                                                                         specificHandler));
-        Mockito.when(specificHandler.getSubject(Mockito.any(Http.Context.class)))
+        Mockito.when(specificHandler.getSubject(Mockito.any(Http.RequestHeader.class)))
                .thenReturn(CompletableFuture.completedFuture(Optional.of(Mockito.mock(Subject.class))));
-        Mockito.when(specificHandler.beforeAuthCheck(Mockito.any(Http.Context.class), Mockito.any(Optional.class)))
+        Mockito.when(specificHandler.beforeAuthCheck(Mockito.any(Http.RequestHeader.class), Mockito.any(Optional.class)))
                .thenReturn(CompletableFuture.completedFuture(Optional.empty()));
-        Mockito.when(specificHandler.onAuthFailure(Mockito.any(Http.Context.class),
+        Mockito.when(specificHandler.onAuthFailure(Mockito.any(Http.RequestHeader.class),
                                                    Mockito.eq(Optional.of("bar"))))
                .thenReturn(CompletableFuture.completedFuture(Results.forbidden()));
 
         final Filter filter = new DeadboltRouteCommentFilter(Mockito.mock(Materializer.class),
-                                                             Mockito.mock(JavaContextComponents.class),
                                                              handlerCache,
                                                              filterConstraints);
         final boolean[] flag = {false};
@@ -462,7 +451,7 @@ public class DeadboltRouteCommentFilterTest extends AbstractDeadboltFilterTest
         Assert.assertFalse(flag[0]);
         Mockito.verify(specificHandler,
                        Mockito.times(1))
-               .onAuthFailure(Mockito.any(Http.Context.class),
+               .onAuthFailure(Mockito.any(Http.RequestHeader.class),
                               Mockito.eq(Optional.of("bar")));
         Mockito.verifyZeroInteractions(defaultHandler);
     }
@@ -471,24 +460,23 @@ public class DeadboltRouteCommentFilterTest extends AbstractDeadboltFilterTest
     public void testSubjectNotPresent_subjectIsNotPresent_specificHandler() throws ExecutionException, InterruptedException
     {
         Mockito.when(subjectCache.apply(Mockito.any(DeadboltHandler.class),
-                                        Mockito.any(Http.Context.class)))
-               .thenReturn(CompletableFuture.completedFuture(Optional.empty()));
+                                        Mockito.any(Http.RequestHeader.class)))
+               .thenReturn(CompletableFuture.completedFuture(F.Tuple(Optional.empty(), Mockito.mock(Http.RequestHeader.class))));
 
         final DeadboltHandler defaultHandler = Mockito.mock(DeadboltHandler.class);
         final DeadboltHandler specificHandler = Mockito.mock(DeadboltHandler.class);
         final HandlerCache handlerCache = new TestHandlerCache(defaultHandler,
                                                                Collections.singletonMap("foo",
                                                                                         specificHandler));
-        Mockito.when(specificHandler.getSubject(Mockito.any(Http.Context.class)))
+        Mockito.when(specificHandler.getSubject(Mockito.any(Http.RequestHeader.class)))
                .thenReturn(CompletableFuture.completedFuture(Optional.empty()));
-        Mockito.when(specificHandler.beforeAuthCheck(Mockito.any(Http.Context.class), Mockito.any(Optional.class)))
+        Mockito.when(specificHandler.beforeAuthCheck(Mockito.any(Http.RequestHeader.class), Mockito.any(Optional.class)))
                .thenReturn(CompletableFuture.completedFuture(Optional.empty()));
-        Mockito.when(specificHandler.onAuthFailure(Mockito.any(Http.Context.class),
+        Mockito.when(specificHandler.onAuthFailure(Mockito.any(Http.RequestHeader.class),
                                                    Mockito.eq(Optional.empty())))
                .thenReturn(CompletableFuture.completedFuture(Results.forbidden()));
 
         final Filter filter = new DeadboltRouteCommentFilter(Mockito.mock(Materializer.class),
-                                                             Mockito.mock(JavaContextComponents.class),
                                                              handlerCache,
                                                              filterConstraints);
         final boolean[] flag = {false};
@@ -508,26 +496,25 @@ public class DeadboltRouteCommentFilterTest extends AbstractDeadboltFilterTest
     public void testDynamic_pass_defaultHandler() throws ExecutionException, InterruptedException
     {
         Mockito.when(subjectCache.apply(Mockito.any(DeadboltHandler.class),
-                                        Mockito.any(Http.Context.class)))
-               .thenReturn(CompletableFuture.completedFuture(Optional.of(Mockito.mock(Subject.class))));
+                                        Mockito.any(Http.RequestHeader.class)))
+               .thenReturn(CompletableFuture.completedFuture(F.Tuple(Optional.of(Mockito.mock(Subject.class)), Mockito.mock(Http.RequestHeader.class))));
 
         final HandlerCache handlerCache = Mockito.mock(HandlerCache.class);
         final DeadboltHandler handler = Mockito.mock(DeadboltHandler.class);
         final DynamicResourceHandler drh = Mockito.mock(DynamicResourceHandler.class);
         Mockito.when(handlerCache.get())
                .thenReturn(handler);
-        Mockito.when(handler.beforeAuthCheck(Mockito.any(Http.Context.class), Mockito.any(Optional.class)))
+        Mockito.when(handler.beforeAuthCheck(Mockito.any(Http.RequestHeader.class), Mockito.any(Optional.class)))
                .thenReturn(CompletableFuture.completedFuture(Optional.empty()));
-        Mockito.when(handler.getDynamicResourceHandler(Mockito.any(Http.Context.class)))
+        Mockito.when(handler.getDynamicResourceHandler(Mockito.any(Http.RequestHeader.class)))
                .thenReturn(CompletableFuture.completedFuture(Optional.of(drh)));
         Mockito.when(drh.isAllowed(Mockito.eq("foo"),
                                    Mockito.eq(Optional.empty()),
                                    Mockito.eq(handler),
-                                   Mockito.any(Http.Context.class)))
+                                   Mockito.any(Http.RequestHeader.class)))
                .thenReturn(CompletableFuture.completedFuture(Boolean.TRUE));
 
         final Filter filter = new DeadboltRouteCommentFilter(Mockito.mock(Materializer.class),
-                                                             Mockito.mock(JavaContextComponents.class),
                                                              handlerCache,
                                                              filterConstraints);
         final boolean[] flag = {false};
@@ -546,29 +533,28 @@ public class DeadboltRouteCommentFilterTest extends AbstractDeadboltFilterTest
     public void testDynamic_fail_defaultHandler() throws ExecutionException, InterruptedException
     {
         Mockito.when(subjectCache.apply(Mockito.any(DeadboltHandler.class),
-                                        Mockito.any(Http.Context.class)))
-               .thenReturn(CompletableFuture.completedFuture(Optional.of(Mockito.mock(Subject.class))));
+                                        Mockito.any(Http.RequestHeader.class)))
+               .thenReturn(CompletableFuture.completedFuture(F.Tuple(Optional.of(Mockito.mock(Subject.class)), Mockito.mock(Http.RequestHeader.class))));
 
         final HandlerCache handlerCache = Mockito.mock(HandlerCache.class);
         final DeadboltHandler handler = Mockito.mock(DeadboltHandler.class);
         final DynamicResourceHandler drh = Mockito.mock(DynamicResourceHandler.class);
         Mockito.when(handlerCache.get())
                .thenReturn(handler);
-        Mockito.when(handler.beforeAuthCheck(Mockito.any(Http.Context.class), Mockito.any(Optional.class)))
+        Mockito.when(handler.beforeAuthCheck(Mockito.any(Http.RequestHeader.class), Mockito.any(Optional.class)))
                .thenReturn(CompletableFuture.completedFuture(Optional.empty()));
-        Mockito.when(handler.getDynamicResourceHandler(Mockito.any(Http.Context.class)))
+        Mockito.when(handler.getDynamicResourceHandler(Mockito.any(Http.RequestHeader.class)))
                .thenReturn(CompletableFuture.completedFuture(Optional.of(drh)));
         Mockito.when(drh.isAllowed(Mockito.eq("foo"),
                                    Mockito.eq(Optional.empty()),
                                    Mockito.eq(handler),
-                                   Mockito.any(Http.Context.class)))
+                                   Mockito.any(Http.RequestHeader.class)))
                .thenReturn(CompletableFuture.completedFuture(Boolean.FALSE));
-        Mockito.when(handler.onAuthFailure(Mockito.any(Http.Context.class),
+        Mockito.when(handler.onAuthFailure(Mockito.any(Http.RequestHeader.class),
                                            Mockito.eq(Optional.empty())))
                .thenReturn(CompletableFuture.completedFuture(Results.forbidden()));
 
         final Filter filter = new DeadboltRouteCommentFilter(Mockito.mock(Materializer.class),
-                                                             Mockito.mock(JavaContextComponents.class),
                                                              handlerCache,
                                                              filterConstraints);
         final boolean[] flag = {false};
@@ -583,7 +569,7 @@ public class DeadboltRouteCommentFilterTest extends AbstractDeadboltFilterTest
         Assert.assertFalse(flag[0]);
         Mockito.verify(handler,
                        Mockito.times(1))
-               .onAuthFailure(Mockito.any(Http.Context.class),
+               .onAuthFailure(Mockito.any(Http.RequestHeader.class),
                               Mockito.eq(Optional.empty()));
     }
 
@@ -591,29 +577,28 @@ public class DeadboltRouteCommentFilterTest extends AbstractDeadboltFilterTest
     public void testDynamic_fail_withContent() throws ExecutionException, InterruptedException
     {
         Mockito.when(subjectCache.apply(Mockito.any(DeadboltHandler.class),
-                                        Mockito.any(Http.Context.class)))
-               .thenReturn(CompletableFuture.completedFuture(Optional.of(Mockito.mock(Subject.class))));
+                                        Mockito.any(Http.RequestHeader.class)))
+               .thenReturn(CompletableFuture.completedFuture(F.Tuple(Optional.of(Mockito.mock(Subject.class)), Mockito.mock(Http.RequestHeader.class))));
 
         final HandlerCache handlerCache = Mockito.mock(HandlerCache.class);
         final DeadboltHandler handler = Mockito.mock(DeadboltHandler.class);
         final DynamicResourceHandler drh = Mockito.mock(DynamicResourceHandler.class);
         Mockito.when(handlerCache.get())
                .thenReturn(handler);
-        Mockito.when(handler.beforeAuthCheck(Mockito.any(Http.Context.class), Mockito.any(Optional.class)))
+        Mockito.when(handler.beforeAuthCheck(Mockito.any(Http.RequestHeader.class), Mockito.any(Optional.class)))
                .thenReturn(CompletableFuture.completedFuture(Optional.empty()));
-        Mockito.when(handler.getDynamicResourceHandler(Mockito.any(Http.Context.class)))
+        Mockito.when(handler.getDynamicResourceHandler(Mockito.any(Http.RequestHeader.class)))
                .thenReturn(CompletableFuture.completedFuture(Optional.of(drh)));
         Mockito.when(drh.isAllowed(Mockito.eq("foo"),
                                    Mockito.eq(Optional.empty()),
                                    Mockito.eq(handler),
-                                   Mockito.any(Http.Context.class)))
+                                   Mockito.any(Http.RequestHeader.class)))
                .thenReturn(CompletableFuture.completedFuture(Boolean.FALSE));
-        Mockito.when(handler.onAuthFailure(Mockito.any(Http.Context.class),
+        Mockito.when(handler.onAuthFailure(Mockito.any(Http.RequestHeader.class),
                                            Mockito.eq(Optional.of("bar"))))
                .thenReturn(CompletableFuture.completedFuture(Results.forbidden()));
 
         final Filter filter = new DeadboltRouteCommentFilter(Mockito.mock(Materializer.class),
-                                                             Mockito.mock(JavaContextComponents.class),
                                                              handlerCache,
                                                              filterConstraints);
         final boolean[] flag = {false};
@@ -628,7 +613,7 @@ public class DeadboltRouteCommentFilterTest extends AbstractDeadboltFilterTest
         Assert.assertFalse(flag[0]);
         Mockito.verify(handler,
                        Mockito.times(1))
-               .onAuthFailure(Mockito.any(Http.Context.class),
+               .onAuthFailure(Mockito.any(Http.RequestHeader.class),
                               Mockito.eq(Optional.of("bar")));
     }
 
@@ -636,8 +621,8 @@ public class DeadboltRouteCommentFilterTest extends AbstractDeadboltFilterTest
     public void testDynamic_pass_specificHandler() throws ExecutionException, InterruptedException
     {
         Mockito.when(subjectCache.apply(Mockito.any(DeadboltHandler.class),
-                                        Mockito.any(Http.Context.class)))
-               .thenReturn(CompletableFuture.completedFuture(Optional.of(Mockito.mock(Subject.class))));
+                                        Mockito.any(Http.RequestHeader.class)))
+               .thenReturn(CompletableFuture.completedFuture(F.Tuple(Optional.of(Mockito.mock(Subject.class)), Mockito.mock(Http.RequestHeader.class))));
 
         final DeadboltHandler defaultHandler = Mockito.mock(DeadboltHandler.class);
         final DeadboltHandler specificHandler = Mockito.mock(DeadboltHandler.class);
@@ -645,18 +630,17 @@ public class DeadboltRouteCommentFilterTest extends AbstractDeadboltFilterTest
         final HandlerCache handlerCache = new TestHandlerCache(defaultHandler,
                                                                Collections.singletonMap("gurdy",
                                                                                         specificHandler));
-        Mockito.when(specificHandler.beforeAuthCheck(Mockito.any(Http.Context.class), Mockito.any(Optional.class)))
+        Mockito.when(specificHandler.beforeAuthCheck(Mockito.any(Http.RequestHeader.class), Mockito.any(Optional.class)))
                .thenReturn(CompletableFuture.completedFuture(Optional.empty()));
-        Mockito.when(specificHandler.getDynamicResourceHandler(Mockito.any(Http.Context.class)))
+        Mockito.when(specificHandler.getDynamicResourceHandler(Mockito.any(Http.RequestHeader.class)))
                .thenReturn(CompletableFuture.completedFuture(Optional.of(drh)));
         Mockito.when(drh.isAllowed(Mockito.eq("foo"),
                                    Mockito.eq(Optional.empty()),
                                    Mockito.eq(specificHandler),
-                                   Mockito.any(Http.Context.class)))
+                                   Mockito.any(Http.RequestHeader.class)))
                .thenReturn(CompletableFuture.completedFuture(Boolean.TRUE));
 
         final Filter filter = new DeadboltRouteCommentFilter(Mockito.mock(Materializer.class),
-                                                             Mockito.mock(JavaContextComponents.class),
                                                              handlerCache,
                                                              filterConstraints);
         final boolean[] flag = {false};
@@ -676,8 +660,8 @@ public class DeadboltRouteCommentFilterTest extends AbstractDeadboltFilterTest
     public void testDynamic_fail_specificHandler() throws ExecutionException, InterruptedException
     {
         Mockito.when(subjectCache.apply(Mockito.any(DeadboltHandler.class),
-                                        Mockito.any(Http.Context.class)))
-               .thenReturn(CompletableFuture.completedFuture(Optional.of(Mockito.mock(Subject.class))));
+                                        Mockito.any(Http.RequestHeader.class)))
+               .thenReturn(CompletableFuture.completedFuture(F.Tuple(Optional.of(Mockito.mock(Subject.class)), Mockito.mock(Http.RequestHeader.class))));
 
         final DeadboltHandler defaultHandler = Mockito.mock(DeadboltHandler.class);
         final DeadboltHandler specificHandler = Mockito.mock(DeadboltHandler.class);
@@ -685,21 +669,20 @@ public class DeadboltRouteCommentFilterTest extends AbstractDeadboltFilterTest
         final HandlerCache handlerCache = new TestHandlerCache(defaultHandler,
                                                                Collections.singletonMap("gurdy",
                                                                                         specificHandler));
-        Mockito.when(specificHandler.beforeAuthCheck(Mockito.any(Http.Context.class), Mockito.any(Optional.class)))
+        Mockito.when(specificHandler.beforeAuthCheck(Mockito.any(Http.RequestHeader.class), Mockito.any(Optional.class)))
                .thenReturn(CompletableFuture.completedFuture(Optional.empty()));
-        Mockito.when(specificHandler.getDynamicResourceHandler(Mockito.any(Http.Context.class)))
+        Mockito.when(specificHandler.getDynamicResourceHandler(Mockito.any(Http.RequestHeader.class)))
                .thenReturn(CompletableFuture.completedFuture(Optional.of(drh)));
         Mockito.when(drh.isAllowed(Mockito.eq("foo"),
                                    Mockito.eq(Optional.empty()),
                                    Mockito.eq(specificHandler),
-                                   Mockito.any(Http.Context.class)))
+                                   Mockito.any(Http.RequestHeader.class)))
                .thenReturn(CompletableFuture.completedFuture(Boolean.FALSE));
-        Mockito.when(specificHandler.onAuthFailure(Mockito.any(Http.Context.class),
+        Mockito.when(specificHandler.onAuthFailure(Mockito.any(Http.RequestHeader.class),
                                                    Mockito.eq(Optional.empty())))
                .thenReturn(CompletableFuture.completedFuture(Results.forbidden()));
 
         final Filter filter = new DeadboltRouteCommentFilter(Mockito.mock(Materializer.class),
-                                                             Mockito.mock(JavaContextComponents.class),
                                                              handlerCache,
                                                              filterConstraints);
         final boolean[] flag = {false};
@@ -714,7 +697,7 @@ public class DeadboltRouteCommentFilterTest extends AbstractDeadboltFilterTest
         Assert.assertFalse(flag[0]);
         Mockito.verify(specificHandler,
                        Mockito.times(1))
-               .onAuthFailure(Mockito.any(Http.Context.class),
+               .onAuthFailure(Mockito.any(Http.RequestHeader.class),
                               Mockito.eq(Optional.empty()));
         Mockito.verifyZeroInteractions(defaultHandler);
     }
@@ -723,8 +706,8 @@ public class DeadboltRouteCommentFilterTest extends AbstractDeadboltFilterTest
     public void testDynamic_fail_specificHandler_withContent() throws ExecutionException, InterruptedException
     {
         Mockito.when(subjectCache.apply(Mockito.any(DeadboltHandler.class),
-                                        Mockito.any(Http.Context.class)))
-               .thenReturn(CompletableFuture.completedFuture(Optional.of(Mockito.mock(Subject.class))));
+                                        Mockito.any(Http.RequestHeader.class)))
+               .thenReturn(CompletableFuture.completedFuture(F.Tuple(Optional.of(Mockito.mock(Subject.class)), Mockito.mock(Http.RequestHeader.class))));
 
         final DeadboltHandler defaultHandler = Mockito.mock(DeadboltHandler.class);
         final DeadboltHandler specificHandler = Mockito.mock(DeadboltHandler.class);
@@ -732,21 +715,20 @@ public class DeadboltRouteCommentFilterTest extends AbstractDeadboltFilterTest
         final HandlerCache handlerCache = new TestHandlerCache(defaultHandler,
                                                                Collections.singletonMap("gurdy",
                                                                                         specificHandler));
-        Mockito.when(specificHandler.beforeAuthCheck(Mockito.any(Http.Context.class), Mockito.any(Optional.class)))
+        Mockito.when(specificHandler.beforeAuthCheck(Mockito.any(Http.RequestHeader.class), Mockito.any(Optional.class)))
                .thenReturn(CompletableFuture.completedFuture(Optional.empty()));
-        Mockito.when(specificHandler.getDynamicResourceHandler(Mockito.any(Http.Context.class)))
+        Mockito.when(specificHandler.getDynamicResourceHandler(Mockito.any(Http.RequestHeader.class)))
                .thenReturn(CompletableFuture.completedFuture(Optional.of(drh)));
         Mockito.when(drh.isAllowed(Mockito.eq("foo"),
                                    Mockito.eq(Optional.empty()),
                                    Mockito.eq(specificHandler),
-                                   Mockito.any(Http.Context.class)))
+                                   Mockito.any(Http.RequestHeader.class)))
                .thenReturn(CompletableFuture.completedFuture(Boolean.FALSE));
-        Mockito.when(specificHandler.onAuthFailure(Mockito.any(Http.Context.class),
+        Mockito.when(specificHandler.onAuthFailure(Mockito.any(Http.RequestHeader.class),
                                                    Mockito.eq(Optional.of("bar"))))
                .thenReturn(CompletableFuture.completedFuture(Results.forbidden()));
 
         final Filter filter = new DeadboltRouteCommentFilter(Mockito.mock(Materializer.class),
-                                                             Mockito.mock(JavaContextComponents.class),
                                                              handlerCache,
                                                              filterConstraints);
         final boolean[] flag = {false};
@@ -761,7 +743,7 @@ public class DeadboltRouteCommentFilterTest extends AbstractDeadboltFilterTest
         Assert.assertFalse(flag[0]);
         Mockito.verify(specificHandler,
                        Mockito.times(1))
-               .onAuthFailure(Mockito.any(Http.Context.class),
+               .onAuthFailure(Mockito.any(Http.RequestHeader.class),
                               Mockito.eq(Optional.of("bar")));
         Mockito.verifyZeroInteractions(defaultHandler);
     }
@@ -773,12 +755,11 @@ public class DeadboltRouteCommentFilterTest extends AbstractDeadboltFilterTest
         final DeadboltHandler handler = Mockito.mock(DeadboltHandler.class);
         Mockito.when(handlerCache.get())
                .thenReturn(handler);
-        Mockito.when(handler.onAuthFailure(Mockito.any(Http.Context.class),
+        Mockito.when(handler.onAuthFailure(Mockito.any(Http.RequestHeader.class),
                                            Mockito.eq(Optional.empty())))
                .thenReturn(CompletableFuture.completedFuture(Results.forbidden()));
 
         final Filter filter = new DeadboltRouteCommentFilter(Mockito.mock(Materializer.class),
-                                                             Mockito.mock(JavaContextComponents.class),
                                                              handlerCache,
                                                              filterConstraints);
         final boolean[] flag = {false};
@@ -793,7 +774,7 @@ public class DeadboltRouteCommentFilterTest extends AbstractDeadboltFilterTest
         Assert.assertFalse(flag[0]);
         Mockito.verify(handler,
                        Mockito.times(1))
-               .onAuthFailure(Mockito.any(Http.Context.class),
+               .onAuthFailure(Mockito.any(Http.RequestHeader.class),
                               Mockito.eq(Optional.empty()));
     }
 
@@ -803,22 +784,21 @@ public class DeadboltRouteCommentFilterTest extends AbstractDeadboltFilterTest
         final Subject subject = new TestSubject.Builder().permission(new TestPermission("bar"))
                                                          .build();
         Mockito.when(subjectCache.apply(Mockito.any(DeadboltHandler.class),
-                                        Mockito.any(Http.Context.class)))
-               .thenReturn(CompletableFuture.completedFuture(Optional.of(subject)));
+                                        Mockito.any(Http.RequestHeader.class)))
+               .thenReturn(CompletableFuture.completedFuture(F.Tuple(Optional.of(subject), Mockito.mock(Http.RequestHeader.class))));
 
         final HandlerCache handlerCache = Mockito.mock(HandlerCache.class);
         final DeadboltHandler handler = Mockito.mock(DeadboltHandler.class);
         Mockito.when(handlerCache.get())
                .thenReturn(handler);
-        Mockito.when(handler.getSubject(Mockito.any(Http.Context.class)))
+        Mockito.when(handler.getSubject(Mockito.any(Http.RequestHeader.class)))
                .thenReturn(CompletableFuture.completedFuture(Optional.of(subject)));
         Mockito.when(handler.getPermissionsForRole("foo"))
                .then(invocation -> CompletableFuture.completedFuture(Collections.singletonList(new TestPermission("bar"))));
-        Mockito.when(handler.beforeAuthCheck(Mockito.any(Http.Context.class), Mockito.any(Optional.class)))
+        Mockito.when(handler.beforeAuthCheck(Mockito.any(Http.RequestHeader.class), Mockito.any(Optional.class)))
                .thenReturn(CompletableFuture.completedFuture(Optional.empty()));
 
         final Filter filter = new DeadboltRouteCommentFilter(Mockito.mock(Materializer.class),
-                                                             Mockito.mock(JavaContextComponents.class),
                                                              handlerCache,
                                                              filterConstraints);
         final boolean[] flag = {false};
@@ -838,25 +818,24 @@ public class DeadboltRouteCommentFilterTest extends AbstractDeadboltFilterTest
         final Subject subject = new TestSubject.Builder().permission(new TestPermission("hurdy"))
                                                          .build();
         Mockito.when(subjectCache.apply(Mockito.any(DeadboltHandler.class),
-                                        Mockito.any(Http.Context.class)))
-               .thenReturn(CompletableFuture.completedFuture(Optional.of(subject)));
+                                        Mockito.any(Http.RequestHeader.class)))
+               .thenReturn(CompletableFuture.completedFuture(F.Tuple(Optional.of(subject), Mockito.mock(Http.RequestHeader.class))));
 
         final HandlerCache handlerCache = Mockito.mock(HandlerCache.class);
         final DeadboltHandler handler = Mockito.mock(DeadboltHandler.class);
         Mockito.when(handlerCache.get())
                .thenReturn(handler);
-        Mockito.when(handler.getSubject(Mockito.any(Http.Context.class)))
+        Mockito.when(handler.getSubject(Mockito.any(Http.RequestHeader.class)))
                .thenReturn(CompletableFuture.completedFuture(Optional.empty()));
-        Mockito.when(handler.beforeAuthCheck(Mockito.any(Http.Context.class), Mockito.any(Optional.class)))
+        Mockito.when(handler.beforeAuthCheck(Mockito.any(Http.RequestHeader.class), Mockito.any(Optional.class)))
                .thenReturn(CompletableFuture.completedFuture(Optional.empty()));
         Mockito.when(handler.getPermissionsForRole("foo"))
                .then(invocation -> CompletableFuture.completedFuture(Collections.singletonList(new TestPermission("bar"))));
-        Mockito.when(handler.onAuthFailure(Mockito.any(Http.Context.class),
+        Mockito.when(handler.onAuthFailure(Mockito.any(Http.RequestHeader.class),
                                            Mockito.eq(Optional.empty())))
                .thenReturn(CompletableFuture.completedFuture(Results.forbidden()));
 
         final Filter filter = new DeadboltRouteCommentFilter(Mockito.mock(Materializer.class),
-                                                             Mockito.mock(JavaContextComponents.class),
                                                              handlerCache,
                                                              filterConstraints);
         final boolean[] flag = {false};
@@ -871,7 +850,7 @@ public class DeadboltRouteCommentFilterTest extends AbstractDeadboltFilterTest
         Assert.assertFalse(flag[0]);
         Mockito.verify(handler,
                        Mockito.times(1))
-               .onAuthFailure(Mockito.any(Http.Context.class),
+               .onAuthFailure(Mockito.any(Http.RequestHeader.class),
                               Mockito.eq(Optional.empty()));
     }
 
@@ -881,25 +860,24 @@ public class DeadboltRouteCommentFilterTest extends AbstractDeadboltFilterTest
         final Subject subject = new TestSubject.Builder().permission(new TestPermission("hurdy"))
                                                          .build();
         Mockito.when(subjectCache.apply(Mockito.any(DeadboltHandler.class),
-                                        Mockito.any(Http.Context.class)))
-               .thenReturn(CompletableFuture.completedFuture(Optional.of(subject)));
+                                        Mockito.any(Http.RequestHeader.class)))
+               .thenReturn(CompletableFuture.completedFuture(F.Tuple(Optional.of(subject), Mockito.mock(Http.RequestHeader.class))));
 
         final HandlerCache handlerCache = Mockito.mock(HandlerCache.class);
         final DeadboltHandler handler = Mockito.mock(DeadboltHandler.class);
         Mockito.when(handlerCache.get())
                .thenReturn(handler);
-        Mockito.when(handler.getSubject(Mockito.any(Http.Context.class)))
+        Mockito.when(handler.getSubject(Mockito.any(Http.RequestHeader.class)))
                .thenReturn(CompletableFuture.completedFuture(Optional.empty()));
-        Mockito.when(handler.beforeAuthCheck(Mockito.any(Http.Context.class), Mockito.any(Optional.class)))
+        Mockito.when(handler.beforeAuthCheck(Mockito.any(Http.RequestHeader.class), Mockito.any(Optional.class)))
                .thenReturn(CompletableFuture.completedFuture(Optional.empty()));
         Mockito.when(handler.getPermissionsForRole("foo"))
                .then(invocation -> CompletableFuture.completedFuture(Collections.singletonList(new TestPermission("bar"))));
-        Mockito.when(handler.onAuthFailure(Mockito.any(Http.Context.class),
+        Mockito.when(handler.onAuthFailure(Mockito.any(Http.RequestHeader.class),
                                            Mockito.eq(Optional.of("bar"))))
                .thenReturn(CompletableFuture.completedFuture(Results.forbidden()));
 
         final Filter filter = new DeadboltRouteCommentFilter(Mockito.mock(Materializer.class),
-                                                             Mockito.mock(JavaContextComponents.class),
                                                              handlerCache,
                                                              filterConstraints);
         final boolean[] flag = {false};
@@ -914,7 +892,7 @@ public class DeadboltRouteCommentFilterTest extends AbstractDeadboltFilterTest
         Assert.assertFalse(flag[0]);
         Mockito.verify(handler,
                        Mockito.times(1))
-               .onAuthFailure(Mockito.any(Http.Context.class),
+               .onAuthFailure(Mockito.any(Http.RequestHeader.class),
                               Mockito.eq(Optional.of("bar")));
     }
 
@@ -924,23 +902,22 @@ public class DeadboltRouteCommentFilterTest extends AbstractDeadboltFilterTest
         final Subject subject = new TestSubject.Builder().permission(new TestPermission("bar"))
                                                          .build();
         Mockito.when(subjectCache.apply(Mockito.any(DeadboltHandler.class),
-                                        Mockito.any(Http.Context.class)))
-               .thenReturn(CompletableFuture.completedFuture(Optional.of(subject)));
+                                        Mockito.any(Http.RequestHeader.class)))
+               .thenReturn(CompletableFuture.completedFuture(F.Tuple(Optional.of(subject), Mockito.mock(Http.RequestHeader.class))));
 
         final DeadboltHandler defaultHandler = Mockito.mock(DeadboltHandler.class);
         final DeadboltHandler specificHandler = Mockito.mock(DeadboltHandler.class);
         final HandlerCache handlerCache = new TestHandlerCache(defaultHandler,
                                                                Collections.singletonMap("foo",
                                                                                         specificHandler));
-        Mockito.when(specificHandler.getSubject(Mockito.any(Http.Context.class)))
+        Mockito.when(specificHandler.getSubject(Mockito.any(Http.RequestHeader.class)))
                .thenReturn(CompletableFuture.completedFuture(Optional.of(Mockito.mock(Subject.class))));
-        Mockito.when(specificHandler.beforeAuthCheck(Mockito.any(Http.Context.class), Mockito.any(Optional.class)))
+        Mockito.when(specificHandler.beforeAuthCheck(Mockito.any(Http.RequestHeader.class), Mockito.any(Optional.class)))
                .thenReturn(CompletableFuture.completedFuture(Optional.empty()));
         Mockito.when(specificHandler.getPermissionsForRole("foo"))
                .then(invocation -> CompletableFuture.completedFuture(Collections.singletonList(new TestPermission("bar"))));
 
         final Filter filter = new DeadboltRouteCommentFilter(Mockito.mock(Materializer.class),
-                                                             Mockito.mock(JavaContextComponents.class),
                                                              handlerCache,
                                                              filterConstraints);
         final boolean[] flag = {false};
@@ -962,25 +939,24 @@ public class DeadboltRouteCommentFilterTest extends AbstractDeadboltFilterTest
         final Subject subject = new TestSubject.Builder().permission(new TestPermission("hurdy"))
                                                          .build();
         Mockito.when(subjectCache.apply(Mockito.any(DeadboltHandler.class),
-                                        Mockito.any(Http.Context.class)))
-               .thenReturn(CompletableFuture.completedFuture(Optional.of(subject)));
+                                        Mockito.any(Http.RequestHeader.class)))
+               .thenReturn(CompletableFuture.completedFuture(F.Tuple(Optional.of(subject), Mockito.mock(Http.RequestHeader.class))));
 
         final DeadboltHandler defaultHandler = Mockito.mock(DeadboltHandler.class);
         final DeadboltHandler specificHandler = Mockito.mock(DeadboltHandler.class);
         final HandlerCache handlerCache = new TestHandlerCache(defaultHandler,
                                                                Collections.singletonMap("foo",
                                                                                         specificHandler));
-        Mockito.when(specificHandler.getSubject(Mockito.any(Http.Context.class)))
+        Mockito.when(specificHandler.getSubject(Mockito.any(Http.RequestHeader.class)))
                .thenReturn(CompletableFuture.completedFuture(Optional.empty()));
-        Mockito.when(specificHandler.beforeAuthCheck(Mockito.any(Http.Context.class), Mockito.any(Optional.class)))
+        Mockito.when(specificHandler.beforeAuthCheck(Mockito.any(Http.RequestHeader.class), Mockito.any(Optional.class)))
                .thenReturn(CompletableFuture.completedFuture(Optional.empty()));
-        Mockito.when(specificHandler.onAuthFailure(Mockito.any(Http.Context.class),
+        Mockito.when(specificHandler.onAuthFailure(Mockito.any(Http.RequestHeader.class),
                                                    Mockito.eq(Optional.empty())))
                .thenReturn(CompletableFuture.completedFuture(Results.forbidden()));
         Mockito.when(specificHandler.getPermissionsForRole("foo"))
                .then(invocation -> CompletableFuture.completedFuture(Collections.singletonList(new TestPermission("bar"))));
         final Filter filter = new DeadboltRouteCommentFilter(Mockito.mock(Materializer.class),
-                                                             Mockito.mock(JavaContextComponents.class),
                                                              handlerCache,
                                                              filterConstraints);
         final boolean[] flag = {false};
@@ -995,7 +971,7 @@ public class DeadboltRouteCommentFilterTest extends AbstractDeadboltFilterTest
         Assert.assertFalse(flag[0]);
         Mockito.verify(specificHandler,
                        Mockito.times(1))
-               .onAuthFailure(Mockito.any(Http.Context.class),
+               .onAuthFailure(Mockito.any(Http.RequestHeader.class),
                               Mockito.eq(Optional.empty()));
         Mockito.verifyZeroInteractions(defaultHandler);
     }
@@ -1006,25 +982,24 @@ public class DeadboltRouteCommentFilterTest extends AbstractDeadboltFilterTest
         final Subject subject = new TestSubject.Builder().permission(new TestPermission("hurdy"))
                                                          .build();
         Mockito.when(subjectCache.apply(Mockito.any(DeadboltHandler.class),
-                                        Mockito.any(Http.Context.class)))
-               .thenReturn(CompletableFuture.completedFuture(Optional.of(subject)));
+                                        Mockito.any(Http.RequestHeader.class)))
+               .thenReturn(CompletableFuture.completedFuture(F.Tuple(Optional.of(subject), Mockito.mock(Http.RequestHeader.class))));
 
         final DeadboltHandler defaultHandler = Mockito.mock(DeadboltHandler.class);
         final DeadboltHandler specificHandler = Mockito.mock(DeadboltHandler.class);
         final HandlerCache handlerCache = new TestHandlerCache(defaultHandler,
                                                                Collections.singletonMap("foo",
                                                                                         specificHandler));
-        Mockito.when(specificHandler.getSubject(Mockito.any(Http.Context.class)))
+        Mockito.when(specificHandler.getSubject(Mockito.any(Http.RequestHeader.class)))
                .thenReturn(CompletableFuture.completedFuture(Optional.empty()));
-        Mockito.when(specificHandler.beforeAuthCheck(Mockito.any(Http.Context.class), Mockito.any(Optional.class)))
+        Mockito.when(specificHandler.beforeAuthCheck(Mockito.any(Http.RequestHeader.class), Mockito.any(Optional.class)))
                .thenReturn(CompletableFuture.completedFuture(Optional.empty()));
-        Mockito.when(specificHandler.onAuthFailure(Mockito.any(Http.Context.class),
+        Mockito.when(specificHandler.onAuthFailure(Mockito.any(Http.RequestHeader.class),
                                                    Mockito.eq(Optional.of("bar"))))
                .thenReturn(CompletableFuture.completedFuture(Results.forbidden()));
         Mockito.when(specificHandler.getPermissionsForRole("foo"))
                .then(invocation -> CompletableFuture.completedFuture(Collections.singletonList(new TestPermission("bar"))));
         final Filter filter = new DeadboltRouteCommentFilter(Mockito.mock(Materializer.class),
-                                                             Mockito.mock(JavaContextComponents.class),
                                                              handlerCache,
                                                              filterConstraints);
         final boolean[] flag = {false};
@@ -1039,7 +1014,7 @@ public class DeadboltRouteCommentFilterTest extends AbstractDeadboltFilterTest
         Assert.assertFalse(flag[0]);
         Mockito.verify(specificHandler,
                        Mockito.times(1))
-               .onAuthFailure(Mockito.any(Http.Context.class),
+               .onAuthFailure(Mockito.any(Http.RequestHeader.class),
                               Mockito.eq(Optional.of("bar")));
         Mockito.verifyZeroInteractions(defaultHandler);
     }

--- a/code/test/be/objectify/deadbolt/java/filters/DeadboltRoutePathFilterTest.java
+++ b/code/test/be/objectify/deadbolt/java/filters/DeadboltRoutePathFilterTest.java
@@ -29,7 +29,7 @@ import org.junit.Assert;
 import org.junit.Test;
 import org.mockito.Mockito;
 import play.api.routing.HandlerDef;
-import play.core.j.JavaContextComponents;
+import play.libs.F;
 import play.mvc.Http;
 import play.mvc.Result;
 import play.mvc.Results;
@@ -45,19 +45,18 @@ public class DeadboltRoutePathFilterTest extends AbstractDeadboltFilterTest
     public void testPass_defaultHandler() throws ExecutionException, InterruptedException
     {
         Mockito.when(subjectCache.apply(Mockito.any(DeadboltHandler.class),
-                                        Mockito.any(Http.Context.class)))
-               .thenReturn(CompletableFuture.completedFuture(Optional.of(Mockito.mock(Subject.class))));
+                                        Mockito.any(Http.RequestHeader.class)))
+               .thenReturn(CompletableFuture.completedFuture(F.Tuple(Optional.of(Mockito.mock(Subject.class)), Mockito.mock(Http.RequestHeader.class))));
 
         final HandlerCache handlerCache = Mockito.mock(HandlerCache.class);
         final DeadboltHandler handler = Mockito.mock(DeadboltHandler.class);
         Mockito.when(handlerCache.get())
                .thenReturn(handler);
-        Mockito.when(handler.getSubject(Mockito.any(Http.Context.class)))
+        Mockito.when(handler.getSubject(Mockito.any(Http.RequestHeader.class)))
                .thenReturn(CompletableFuture.completedFuture(Optional.of(Mockito.mock(Subject.class))));
-        Mockito.when(handler.beforeAuthCheck(Mockito.any(Http.Context.class), Mockito.any(Optional.class)))
+        Mockito.when(handler.beforeAuthCheck(Mockito.any(Http.RequestHeader.class), Mockito.any(Optional.class)))
                .thenReturn(CompletableFuture.completedFuture(Optional.empty()));
         final DeadboltRoutePathFilter filter = new DeadboltRoutePathFilter(Mockito.mock(Materializer.class),
-                                                                           Mockito.mock(JavaContextComponents.class),
                                                                            handlerCache,
                                                                            () -> new AuthorizedRoutes(() -> filterConstraints)
                                                                            {
@@ -84,22 +83,21 @@ public class DeadboltRoutePathFilterTest extends AbstractDeadboltFilterTest
     public void testFail_defaultHandler_noContent() throws ExecutionException, InterruptedException
     {
         Mockito.when(subjectCache.apply(Mockito.any(DeadboltHandler.class),
-                                        Mockito.any(Http.Context.class)))
-               .thenReturn(CompletableFuture.completedFuture(Optional.empty()));
+                                        Mockito.any(Http.RequestHeader.class)))
+               .thenReturn(CompletableFuture.completedFuture(F.Tuple(Optional.empty(), Mockito.mock(Http.RequestHeader.class))));
 
         final HandlerCache handlerCache = Mockito.mock(HandlerCache.class);
         final DeadboltHandler handler = Mockito.mock(DeadboltHandler.class);
         Mockito.when(handlerCache.get())
                .thenReturn(handler);
-        Mockito.when(handler.getSubject(Mockito.any(Http.Context.class)))
+        Mockito.when(handler.getSubject(Mockito.any(Http.RequestHeader.class)))
                .thenReturn(CompletableFuture.completedFuture(Optional.empty()));
-        Mockito.when(handler.beforeAuthCheck(Mockito.any(Http.Context.class), Mockito.any(Optional.class)))
+        Mockito.when(handler.beforeAuthCheck(Mockito.any(Http.RequestHeader.class), Mockito.any(Optional.class)))
                .thenReturn(CompletableFuture.completedFuture(Optional.empty()));
-        Mockito.when(handler.onAuthFailure(Mockito.any(Http.Context.class),
+        Mockito.when(handler.onAuthFailure(Mockito.any(Http.RequestHeader.class),
                                            Mockito.eq(Optional.empty())))
                .thenReturn(CompletableFuture.completedFuture(Results.forbidden()));
         final DeadboltRoutePathFilter filter = new DeadboltRoutePathFilter(Mockito.mock(Materializer.class),
-                                                                           Mockito.mock(JavaContextComponents.class),
                                                                            handlerCache,
                                                                            () -> new AuthorizedRoutes(() -> filterConstraints)
                                                                            {
@@ -122,7 +120,7 @@ public class DeadboltRoutePathFilterTest extends AbstractDeadboltFilterTest
         Assert.assertFalse(flag[0]);
         Mockito.verify(handler,
                        Mockito.times(1))
-               .onAuthFailure(Mockito.any(Http.Context.class),
+               .onAuthFailure(Mockito.any(Http.RequestHeader.class),
                               Mockito.eq(Optional.empty()));
     }
 
@@ -130,22 +128,21 @@ public class DeadboltRoutePathFilterTest extends AbstractDeadboltFilterTest
     public void testFail_defaultHandler_withContent() throws ExecutionException, InterruptedException
     {
         Mockito.when(subjectCache.apply(Mockito.any(DeadboltHandler.class),
-                                        Mockito.any(Http.Context.class)))
-               .thenReturn(CompletableFuture.completedFuture(Optional.empty()));
+                                        Mockito.any(Http.RequestHeader.class)))
+               .thenReturn(CompletableFuture.completedFuture(F.Tuple(Optional.empty(), Mockito.mock(Http.RequestHeader.class))));
 
         final HandlerCache handlerCache = Mockito.mock(HandlerCache.class);
         final DeadboltHandler handler = Mockito.mock(DeadboltHandler.class);
         Mockito.when(handlerCache.get())
                .thenReturn(handler);
-        Mockito.when(handler.getSubject(Mockito.any(Http.Context.class)))
+        Mockito.when(handler.getSubject(Mockito.any(Http.RequestHeader.class)))
                .thenReturn(CompletableFuture.completedFuture(Optional.empty()));
-        Mockito.when(handler.beforeAuthCheck(Mockito.any(Http.Context.class), Mockito.any(Optional.class)))
+        Mockito.when(handler.beforeAuthCheck(Mockito.any(Http.RequestHeader.class), Mockito.any(Optional.class)))
                .thenReturn(CompletableFuture.completedFuture(Optional.empty()));
-        Mockito.when(handler.onAuthFailure(Mockito.any(Http.Context.class),
+        Mockito.when(handler.onAuthFailure(Mockito.any(Http.RequestHeader.class),
                                            Mockito.eq(Optional.of("foo"))))
                .thenReturn(CompletableFuture.completedFuture(Results.forbidden()));
         final DeadboltRoutePathFilter filter = new DeadboltRoutePathFilter(Mockito.mock(Materializer.class),
-                                                                           Mockito.mock(JavaContextComponents.class),
                                                                            handlerCache,
                                                                            () -> new AuthorizedRoutes(() -> filterConstraints)
                                                                            {
@@ -168,7 +165,7 @@ public class DeadboltRoutePathFilterTest extends AbstractDeadboltFilterTest
         Assert.assertFalse(flag[0]);
         Mockito.verify(handler,
                        Mockito.times(1))
-               .onAuthFailure(Mockito.any(Http.Context.class),
+               .onAuthFailure(Mockito.any(Http.RequestHeader.class),
                               Mockito.eq(Optional.of("foo")));
     }
 
@@ -176,20 +173,19 @@ public class DeadboltRoutePathFilterTest extends AbstractDeadboltFilterTest
     public void testPass_specificHandler() throws ExecutionException, InterruptedException
     {
         Mockito.when(subjectCache.apply(Mockito.any(DeadboltHandler.class),
-                                        Mockito.any(Http.Context.class)))
-               .thenReturn(CompletableFuture.completedFuture(Optional.of(Mockito.mock(Subject.class))));
+                                        Mockito.any(Http.RequestHeader.class)))
+               .thenReturn(CompletableFuture.completedFuture(F.Tuple(Optional.of(Mockito.mock(Subject.class)), Mockito.mock(Http.RequestHeader.class))));
 
         final HandlerCache handlerCache = Mockito.mock(HandlerCache.class);
         final DeadboltHandler defaultHandler = Mockito.mock(DeadboltHandler.class);
         final DeadboltHandler specificHandler = Mockito.mock(DeadboltHandler.class);
         Mockito.when(handlerCache.get())
                .thenReturn(defaultHandler);
-        Mockito.when(specificHandler.getSubject(Mockito.any(Http.Context.class)))
+        Mockito.when(specificHandler.getSubject(Mockito.any(Http.RequestHeader.class)))
                .thenReturn(CompletableFuture.completedFuture(Optional.of(Mockito.mock(Subject.class))));
-        Mockito.when(specificHandler.beforeAuthCheck(Mockito.any(Http.Context.class), Mockito.any(Optional.class)))
+        Mockito.when(specificHandler.beforeAuthCheck(Mockito.any(Http.RequestHeader.class), Mockito.any(Optional.class)))
                .thenReturn(CompletableFuture.completedFuture(Optional.empty()));
         final DeadboltRoutePathFilter filter = new DeadboltRoutePathFilter(Mockito.mock(Materializer.class),
-                                                                           Mockito.mock(JavaContextComponents.class),
                                                                            handlerCache,
                                                                            () -> new AuthorizedRoutes(() -> filterConstraints)
                                                                            {
@@ -218,23 +214,22 @@ public class DeadboltRoutePathFilterTest extends AbstractDeadboltFilterTest
     public void testFail_specificHandler_noContent() throws ExecutionException, InterruptedException
     {
         Mockito.when(subjectCache.apply(Mockito.any(DeadboltHandler.class),
-                                        Mockito.any(Http.Context.class)))
-               .thenReturn(CompletableFuture.completedFuture(Optional.empty()));
+                                        Mockito.any(Http.RequestHeader.class)))
+               .thenReturn(CompletableFuture.completedFuture(F.Tuple(Optional.empty(), Mockito.mock(Http.RequestHeader.class))));
 
         final HandlerCache handlerCache = Mockito.mock(HandlerCache.class);
         final DeadboltHandler defaultHandler = Mockito.mock(DeadboltHandler.class);
         final DeadboltHandler specificHandler = Mockito.mock(DeadboltHandler.class);
         Mockito.when(handlerCache.get())
                .thenReturn(defaultHandler);
-        Mockito.when(specificHandler.getSubject(Mockito.any(Http.Context.class)))
+        Mockito.when(specificHandler.getSubject(Mockito.any(Http.RequestHeader.class)))
                .thenReturn(CompletableFuture.completedFuture(Optional.empty()));
-        Mockito.when(specificHandler.beforeAuthCheck(Mockito.any(Http.Context.class), Mockito.any(Optional.class)))
+        Mockito.when(specificHandler.beforeAuthCheck(Mockito.any(Http.RequestHeader.class), Mockito.any(Optional.class)))
                .thenReturn(CompletableFuture.completedFuture(Optional.empty()));
-        Mockito.when(specificHandler.onAuthFailure(Mockito.any(Http.Context.class),
+        Mockito.when(specificHandler.onAuthFailure(Mockito.any(Http.RequestHeader.class),
                                                    Mockito.eq(Optional.empty())))
                .thenReturn(CompletableFuture.completedFuture(Results.forbidden()));
         final DeadboltRoutePathFilter filter = new DeadboltRoutePathFilter(Mockito.mock(Materializer.class),
-                                                                           Mockito.mock(JavaContextComponents.class),
                                                                            handlerCache,
                                                                            () -> new AuthorizedRoutes(() -> filterConstraints)
                                                                            {
@@ -258,7 +253,7 @@ public class DeadboltRoutePathFilterTest extends AbstractDeadboltFilterTest
         Assert.assertFalse(flag[0]);
         Mockito.verify(specificHandler,
                        Mockito.times(1))
-               .onAuthFailure(Mockito.any(Http.Context.class),
+               .onAuthFailure(Mockito.any(Http.RequestHeader.class),
                               Mockito.eq(Optional.empty()));
         Mockito.verifyZeroInteractions(defaultHandler);
     }
@@ -267,23 +262,22 @@ public class DeadboltRoutePathFilterTest extends AbstractDeadboltFilterTest
     public void testFail_specificHandler_withContent() throws ExecutionException, InterruptedException
     {
         Mockito.when(subjectCache.apply(Mockito.any(DeadboltHandler.class),
-                                        Mockito.any(Http.Context.class)))
-               .thenReturn(CompletableFuture.completedFuture(Optional.empty()));
+                                        Mockito.any(Http.RequestHeader.class)))
+               .thenReturn(CompletableFuture.completedFuture(F.Tuple(Optional.empty(), Mockito.mock(Http.RequestHeader.class))));
 
         final HandlerCache handlerCache = Mockito.mock(HandlerCache.class);
         final DeadboltHandler defaultHandler = Mockito.mock(DeadboltHandler.class);
         final DeadboltHandler specificHandler = Mockito.mock(DeadboltHandler.class);
         Mockito.when(handlerCache.get())
                .thenReturn(defaultHandler);
-        Mockito.when(specificHandler.getSubject(Mockito.any(Http.Context.class)))
+        Mockito.when(specificHandler.getSubject(Mockito.any(Http.RequestHeader.class)))
                .thenReturn(CompletableFuture.completedFuture(Optional.empty()));
-        Mockito.when(specificHandler.beforeAuthCheck(Mockito.any(Http.Context.class), Mockito.any(Optional.class)))
+        Mockito.when(specificHandler.beforeAuthCheck(Mockito.any(Http.RequestHeader.class), Mockito.any(Optional.class)))
                .thenReturn(CompletableFuture.completedFuture(Optional.empty()));
-        Mockito.when(specificHandler.onAuthFailure(Mockito.any(Http.Context.class),
+        Mockito.when(specificHandler.onAuthFailure(Mockito.any(Http.RequestHeader.class),
                                                    Mockito.eq(Optional.of("foo"))))
                .thenReturn(CompletableFuture.completedFuture(Results.forbidden()));
         final DeadboltRoutePathFilter filter = new DeadboltRoutePathFilter(Mockito.mock(Materializer.class),
-                                                                           Mockito.mock(JavaContextComponents.class),
                                                                            handlerCache,
                                                                            () -> new AuthorizedRoutes(() -> filterConstraints)
                                                                            {
@@ -307,7 +301,7 @@ public class DeadboltRoutePathFilterTest extends AbstractDeadboltFilterTest
         Assert.assertFalse(flag[0]);
         Mockito.verify(specificHandler,
                        Mockito.times(1))
-               .onAuthFailure(Mockito.any(Http.Context.class),
+               .onAuthFailure(Mockito.any(Http.RequestHeader.class),
                               Mockito.eq(Optional.of("foo")));
         Mockito.verifyZeroInteractions(defaultHandler);
     }

--- a/code/test/be/objectify/deadbolt/java/filters/FilterConstraintsTest.java
+++ b/code/test/be/objectify/deadbolt/java/filters/FilterConstraintsTest.java
@@ -75,7 +75,7 @@ public class FilterConstraintsTest
                                            Mockito.any(Optional.class)))
                .thenReturn(CompletableFuture.completedFuture(Results.forbidden()));
 
-        subjectCache = new DefaultSubjectCache(ConfigFactory.empty());
+        subjectCache = new DefaultSubjectCache(ConfigFactory.load());
 
         constraintLogic = new ConstraintLogic(analyzer,
                                               subjectCache,
@@ -86,7 +86,7 @@ public class FilterConstraintsTest
                                 new SubjectPresentConstraint(Optional.empty(),
                                                              constraintLogic));
 
-        final BeforeAuthCheckCache beforeAuthCheckCache = new DefaultBeforeAuthCheckCache(ConfigFactory.empty());
+        final BeforeAuthCheckCache beforeAuthCheckCache = new DefaultBeforeAuthCheckCache(ConfigFactory.load());
 
         filterConstraints = new FilterConstraints(constraintLogic,
                                                   compositeCache,

--- a/code/test/be/objectify/deadbolt/java/filters/FilterConstraintsTest.java
+++ b/code/test/be/objectify/deadbolt/java/filters/FilterConstraintsTest.java
@@ -62,7 +62,6 @@ public class FilterConstraintsTest
     private FilterConstraints filterConstraints;
     private Http.RequestHeader requestHeader;
     private SubjectCache subjectCache;
-    private Http.Context context;
     private DeadboltHandler handler;
     private ConstraintLogic constraintLogic;
 
@@ -70,13 +69,12 @@ public class FilterConstraintsTest
     public void setUp()
     {
         handler = Mockito.mock(DeadboltHandler.class);
-        Mockito.when(handler.beforeAuthCheck(Mockito.any(Http.Context.class), Mockito.any(Optional.class)))
+        Mockito.when(handler.beforeAuthCheck(Mockito.any(Http.RequestHeader.class), Mockito.any(Optional.class)))
                .thenReturn(CompletableFuture.completedFuture(Optional.empty()));
-        Mockito.when(handler.onAuthFailure(Mockito.any(Http.Context.class),
+        Mockito.when(handler.onAuthFailure(Mockito.any(Http.RequestHeader.class),
                                            Mockito.any(Optional.class)))
                .thenReturn(CompletableFuture.completedFuture(Results.forbidden()));
 
-        context = Mockito.mock(Http.Context.class);
         subjectCache = new DefaultSubjectCache(ConfigFactory.empty());
 
         constraintLogic = new ConstraintLogic(analyzer,
@@ -121,11 +119,10 @@ public class FilterConstraintsTest
     public void testSubjectPresent_pass() throws Exception
     {
         final boolean[] flag = {false};
-        Mockito.when(handler.getSubject(context))
+        Mockito.when(handler.getSubject(requestHeader))
                .thenReturn(CompletableFuture.completedFuture(Optional.of(Mockito.mock(Subject.class))));
         final CompletionStage<Result> eventualResult = filterConstraints.subjectPresent()
-                                                                        .apply(context,
-                                                                               requestHeader,
+                                                                        .apply(requestHeader,
                                                                                handler,
                                                                                rh ->
                                                                                {
@@ -140,11 +137,10 @@ public class FilterConstraintsTest
     public void testSubjectPresent_withContent_pass() throws Exception
     {
         final boolean[] flag = {false};
-        Mockito.when(handler.getSubject(context))
+        Mockito.when(handler.getSubject(requestHeader))
                .thenReturn(CompletableFuture.completedFuture(Optional.of(Mockito.mock(Subject.class))));
         final CompletionStage<Result> eventualResult = filterConstraints.subjectPresent(Optional.of("json"))
-                                                                        .apply(context,
-                                                                               requestHeader,
+                                                                        .apply(requestHeader,
                                                                                handler,
                                                                                rh ->
                                                                                {
@@ -159,11 +155,10 @@ public class FilterConstraintsTest
     public void testSubjectPresent_fail() throws Exception
     {
         final boolean[] flag = {false};
-        Mockito.when(handler.getSubject(context))
+        Mockito.when(handler.getSubject(requestHeader))
                .thenReturn(CompletableFuture.completedFuture(Optional.empty()));
         final CompletionStage<Result> eventualResult = filterConstraints.subjectPresent()
-                                                                        .apply(context,
-                                                                               requestHeader,
+                                                                        .apply(requestHeader,
                                                                                handler,
                                                                                rh ->
                                                                                {
@@ -173,7 +168,7 @@ public class FilterConstraintsTest
         ((CompletableFuture) eventualResult).get();
         Assert.assertFalse(flag[0]);
         Mockito.verify(handler,
-                       Mockito.times(1)).onAuthFailure(Mockito.any(Http.Context.class),
+                       Mockito.times(1)).onAuthFailure(Mockito.any(Http.RequestHeader.class),
                                                        Mockito.eq(Optional.empty()));
     }
 
@@ -181,11 +176,10 @@ public class FilterConstraintsTest
     public void testSubjectPresent_withContent_fail() throws Exception
     {
         final boolean[] flag = {false};
-        Mockito.when(handler.getSubject(context))
+        Mockito.when(handler.getSubject(requestHeader))
                .thenReturn(CompletableFuture.completedFuture(Optional.empty()));
         final CompletionStage<Result> eventualResult = filterConstraints.subjectPresent(Optional.of("json"))
-                                                                        .apply(context,
-                                                                               requestHeader,
+                                                                        .apply(requestHeader,
                                                                                handler,
                                                                                rh ->
                                                                                {
@@ -195,7 +189,7 @@ public class FilterConstraintsTest
         ((CompletableFuture) eventualResult).get();
         Assert.assertFalse(flag[0]);
         Mockito.verify(handler,
-                       Mockito.times(1)).onAuthFailure(Mockito.any(Http.Context.class),
+                       Mockito.times(1)).onAuthFailure(Mockito.any(Http.RequestHeader.class),
                                                        Mockito.eq(Optional.of("json")));
     }
 
@@ -203,11 +197,10 @@ public class FilterConstraintsTest
     public void testSubjectNotPresent_pass() throws Exception
     {
         final boolean[] flag = {false};
-        Mockito.when(handler.getSubject(context))
+        Mockito.when(handler.getSubject(requestHeader))
                .thenReturn(CompletableFuture.completedFuture(Optional.empty()));
         final CompletionStage<Result> eventualResult = filterConstraints.subjectNotPresent()
-                                                                        .apply(context,
-                                                                               requestHeader,
+                                                                        .apply(requestHeader,
                                                                                handler,
                                                                                rh ->
                                                                                {
@@ -222,11 +215,10 @@ public class FilterConstraintsTest
     public void testSubjectNotPresent_withContent_pass() throws Exception
     {
         final boolean[] flag = {false};
-        Mockito.when(handler.getSubject(context))
+        Mockito.when(handler.getSubject(requestHeader))
                .thenReturn(CompletableFuture.completedFuture(Optional.empty()));
         final CompletionStage<Result> eventualResult = filterConstraints.subjectNotPresent(Optional.of("json"))
-                                                                        .apply(context,
-                                                                               requestHeader,
+                                                                        .apply(requestHeader,
                                                                                handler,
                                                                                rh ->
                                                                                {
@@ -241,11 +233,10 @@ public class FilterConstraintsTest
     public void testSubjectNotPresent_fail() throws Exception
     {
         final boolean[] flag = {false};
-        Mockito.when(handler.getSubject(context))
+        Mockito.when(handler.getSubject(requestHeader))
                .thenReturn(CompletableFuture.completedFuture(Optional.of(Mockito.mock(Subject.class))));
         final CompletionStage<Result> eventualResult = filterConstraints.subjectNotPresent()
-                                                                        .apply(context,
-                                                                               requestHeader,
+                                                                        .apply(requestHeader,
                                                                                handler,
                                                                                rh ->
                                                                                {
@@ -255,7 +246,7 @@ public class FilterConstraintsTest
         ((CompletableFuture) eventualResult).get();
         Assert.assertFalse(flag[0]);
         Mockito.verify(handler,
-                       Mockito.times(1)).onAuthFailure(Mockito.any(Http.Context.class),
+                       Mockito.times(1)).onAuthFailure(Mockito.any(Http.RequestHeader.class),
                                                        Mockito.eq(Optional.empty()));
     }
 
@@ -263,11 +254,10 @@ public class FilterConstraintsTest
     public void testSubjectNotPresent_withContent_fail() throws Exception
     {
         final boolean[] flag = {false};
-        Mockito.when(handler.getSubject(context))
+        Mockito.when(handler.getSubject(requestHeader))
                .thenReturn(CompletableFuture.completedFuture(Optional.of(Mockito.mock(Subject.class))));
         final CompletionStage<Result> eventualResult = filterConstraints.subjectNotPresent(Optional.of("json"))
-                                                                        .apply(context,
-                                                                               requestHeader,
+                                                                        .apply(requestHeader,
                                                                                handler,
                                                                                rh ->
                                                                                {
@@ -277,7 +267,7 @@ public class FilterConstraintsTest
         ((CompletableFuture) eventualResult).get();
         Assert.assertFalse(flag[0]);
         Mockito.verify(handler,
-                       Mockito.times(1)).onAuthFailure(Mockito.any(Http.Context.class),
+                       Mockito.times(1)).onAuthFailure(Mockito.any(Http.RequestHeader.class),
                                                        Mockito.eq(Optional.of("json")));
     }
 
@@ -287,11 +277,10 @@ public class FilterConstraintsTest
         final boolean[] flag = {false};
         final TestSubject subject = new TestSubject.Builder().role(new TestRole("foo"))
                                                              .build();
-        Mockito.when(handler.getSubject(context))
+        Mockito.when(handler.getSubject(requestHeader))
                .thenReturn(CompletableFuture.completedFuture(Optional.of(subject)));
         final CompletionStage<Result> eventualResult = filterConstraints.restrict(Collections.singletonList(new String[]{"foo"}))
-                                                                        .apply(context,
-                                                                               requestHeader,
+                                                                        .apply(requestHeader,
                                                                                handler,
                                                                                rh ->
                                                                                {
@@ -308,12 +297,11 @@ public class FilterConstraintsTest
         final boolean[] flag = {false};
         final TestSubject subject = new TestSubject.Builder().role(new TestRole("foo"))
                                                              .build();
-        Mockito.when(handler.getSubject(context))
+        Mockito.when(handler.getSubject(requestHeader))
                .thenReturn(CompletableFuture.completedFuture(Optional.of(subject)));
         final CompletionStage<Result> eventualResult = filterConstraints.restrict(Collections.singletonList(new String[]{"foo"}),
                                                                                   Optional.of("json"))
-                                                                        .apply(context,
-                                                                               requestHeader,
+                                                                        .apply(requestHeader,
                                                                                handler,
                                                                                rh ->
                                                                                {
@@ -330,11 +318,10 @@ public class FilterConstraintsTest
         final boolean[] flag = {false};
         final TestSubject subject = new TestSubject.Builder().role(new TestRole("foo"))
                                                              .build();
-        Mockito.when(handler.getSubject(context))
+        Mockito.when(handler.getSubject(requestHeader))
                .thenReturn(CompletableFuture.completedFuture(Optional.of(subject)));
         final CompletionStage<Result> eventualResult = filterConstraints.restrict(Collections.singletonList(new String[]{"hurdy"}))
-                                                                        .apply(context,
-                                                                               requestHeader,
+                                                                        .apply(requestHeader,
                                                                                handler,
                                                                                rh ->
                                                                                {
@@ -344,7 +331,7 @@ public class FilterConstraintsTest
         ((CompletableFuture) eventualResult).get();
         Assert.assertFalse(flag[0]);
         Mockito.verify(handler,
-                       Mockito.times(1)).onAuthFailure(Mockito.any(Http.Context.class),
+                       Mockito.times(1)).onAuthFailure(Mockito.any(Http.RequestHeader.class),
                                                        Mockito.eq(Optional.empty()));
     }
 
@@ -354,12 +341,11 @@ public class FilterConstraintsTest
         final boolean[] flag = {false};
         final TestSubject subject = new TestSubject.Builder().role(new TestRole("foo"))
                                                              .build();
-        Mockito.when(handler.getSubject(context))
+        Mockito.when(handler.getSubject(requestHeader))
                .thenReturn(CompletableFuture.completedFuture(Optional.of(subject)));
         final CompletionStage<Result> eventualResult = filterConstraints.restrict(Collections.singletonList(new String[]{"hurdy"}),
                                                                                   Optional.of("json"))
-                                                                        .apply(context,
-                                                                               requestHeader,
+                                                                        .apply(requestHeader,
                                                                                handler,
                                                                                rh ->
                                                                                {
@@ -369,7 +355,7 @@ public class FilterConstraintsTest
         ((CompletableFuture) eventualResult).get();
         Assert.assertFalse(flag[0]);
         Mockito.verify(handler,
-                       Mockito.times(1)).onAuthFailure(Mockito.any(Http.Context.class),
+                       Mockito.times(1)).onAuthFailure(Mockito.any(Http.RequestHeader.class),
                                                        Mockito.eq(Optional.of("json")));
     }
 
@@ -379,12 +365,11 @@ public class FilterConstraintsTest
         final boolean[] flag = {false};
         final TestSubject subject = new TestSubject.Builder().permission(new TestPermission("foo"))
                                                              .build();
-        Mockito.when(handler.getSubject(context))
+        Mockito.when(handler.getSubject(requestHeader))
                .thenReturn(CompletableFuture.completedFuture(Optional.of(subject)));
         final CompletionStage<Result> eventualResult = filterConstraints.pattern("foo",
                                                                                  PatternType.EQUALITY)
-                                                                        .apply(context,
-                                                                               requestHeader,
+                                                                        .apply(requestHeader,
                                                                                handler,
                                                                                rh ->
                                                                                {
@@ -401,12 +386,11 @@ public class FilterConstraintsTest
         final boolean[] flag = {false};
         final TestSubject subject = new TestSubject.Builder().permission(new TestPermission("foo.bar"))
                                                              .build();
-        Mockito.when(handler.getSubject(context))
+        Mockito.when(handler.getSubject(requestHeader))
                .thenReturn(CompletableFuture.completedFuture(Optional.of(subject)));
         final CompletionStage<Result> eventualResult = filterConstraints.pattern("foo.*",
                                                                                  PatternType.REGEX)
-                                                                        .apply(context,
-                                                                               requestHeader,
+                                                                        .apply(requestHeader,
                                                                                handler,
                                                                                rh ->
                                                                                {
@@ -421,25 +405,24 @@ public class FilterConstraintsTest
     public void testPattern_custom_pass() throws Exception
     {
         final boolean[] flag = {false};
-        context.args = new HashMap<>();
-        Mockito.when(handler.getSubject(context))
+        
+        Mockito.when(handler.getSubject(requestHeader))
                .thenReturn(CompletableFuture.completedFuture(Optional.of(Mockito.mock(Subject.class))));
-        Mockito.when(handler.getDynamicResourceHandler(context))
+        Mockito.when(handler.getDynamicResourceHandler(Mockito.any(Http.RequestHeader.class)))
                .thenReturn(CompletableFuture.completedFuture(Optional.of(new AbstractDynamicResourceHandler()
                {
                    @Override
                    public CompletionStage<Boolean> checkPermission(final String permissionValue,
                                                                    final Optional<String> meta,
                                                                    final DeadboltHandler deadboltHandler,
-                                                                   final Http.Context ctx)
+                                                                   final Http.RequestHeader requestHeader)
                    {
                        return CompletableFuture.completedFuture(Boolean.TRUE);
                    }
                })));
         final CompletionStage<Result> eventualResult = filterConstraints.pattern("foo",
                                                                                  PatternType.CUSTOM)
-                                                                        .apply(context,
-                                                                               requestHeader,
+                                                                        .apply(requestHeader,
                                                                                handler,
                                                                                rh ->
                                                                                {
@@ -456,12 +439,11 @@ public class FilterConstraintsTest
         final boolean[] flag = {false};
         final TestSubject subject = new TestSubject.Builder().permission(new TestPermission("foo"))
                                                              .build();
-        Mockito.when(handler.getSubject(context))
+        Mockito.when(handler.getSubject(requestHeader))
                .thenReturn(CompletableFuture.completedFuture(Optional.of(subject)));
         final CompletionStage<Result> eventualResult = filterConstraints.pattern("bar",
                                                                                  PatternType.EQUALITY)
-                                                                        .apply(context,
-                                                                               requestHeader,
+                                                                        .apply(requestHeader,
                                                                                handler,
                                                                                rh ->
                                                                                {
@@ -471,7 +453,7 @@ public class FilterConstraintsTest
         ((CompletableFuture) eventualResult).get();
         Assert.assertFalse(flag[0]);
         Mockito.verify(handler,
-                       Mockito.times(1)).onAuthFailure(Mockito.any(Http.Context.class),
+                       Mockito.times(1)).onAuthFailure(Mockito.any(Http.RequestHeader.class),
                                                        Mockito.eq(Optional.empty()));
     }
 
@@ -481,12 +463,11 @@ public class FilterConstraintsTest
         final boolean[] flag = {false};
         final TestSubject subject = new TestSubject.Builder().permission(new TestPermission("bar.foo"))
                                                              .build();
-        Mockito.when(handler.getSubject(context))
+        Mockito.when(handler.getSubject(requestHeader))
                .thenReturn(CompletableFuture.completedFuture(Optional.of(subject)));
         final CompletionStage<Result> eventualResult = filterConstraints.pattern("foo.*",
                                                                                  PatternType.REGEX)
-                                                                        .apply(context,
-                                                                               requestHeader,
+                                                                        .apply(requestHeader,
                                                                                handler,
                                                                                rh ->
                                                                                {
@@ -496,7 +477,7 @@ public class FilterConstraintsTest
         ((CompletableFuture) eventualResult).get();
         Assert.assertFalse(flag[0]);
         Mockito.verify(handler,
-                       Mockito.times(1)).onAuthFailure(Mockito.any(Http.Context.class),
+                       Mockito.times(1)).onAuthFailure(Mockito.any(Http.RequestHeader.class),
                                                        Mockito.eq(Optional.empty()));
     }
 
@@ -504,25 +485,24 @@ public class FilterConstraintsTest
     public void testPattern_custom_fail() throws Exception
     {
         final boolean[] flag = {false};
-        context.args = new HashMap<>();
-        Mockito.when(handler.getSubject(context))
+
+        Mockito.when(handler.getSubject(requestHeader))
                .thenReturn(CompletableFuture.completedFuture(Optional.of(Mockito.mock(Subject.class))));
-        Mockito.when(handler.getDynamicResourceHandler(context))
+        Mockito.when(handler.getDynamicResourceHandler(Mockito.any(Http.RequestHeader.class)))
                .thenReturn(CompletableFuture.completedFuture(Optional.of(new AbstractDynamicResourceHandler()
                {
                    @Override
                    public CompletionStage<Boolean> checkPermission(final String permissionValue,
                                                                    final Optional<String> meta,
                                                                    final DeadboltHandler deadboltHandler,
-                                                                   final Http.Context ctx)
+                                                                   final Http.RequestHeader requestHeader)
                    {
                        return CompletableFuture.completedFuture(Boolean.FALSE);
                    }
                })));
         final CompletionStage<Result> eventualResult = filterConstraints.pattern("foo",
                                                                                  PatternType.CUSTOM)
-                                                                        .apply(context,
-                                                                               requestHeader,
+                                                                        .apply(requestHeader,
                                                                                handler,
                                                                                rh ->
                                                                                {
@@ -532,7 +512,7 @@ public class FilterConstraintsTest
         ((CompletableFuture) eventualResult).get();
         Assert.assertFalse(flag[0]);
         Mockito.verify(handler,
-                       Mockito.times(1)).onAuthFailure(Mockito.any(Http.Context.class),
+                       Mockito.times(1)).onAuthFailure(Mockito.any(Http.RequestHeader.class),
                                                        Mockito.eq(Optional.empty()));
     }
 
@@ -542,13 +522,12 @@ public class FilterConstraintsTest
         final boolean[] flag = {false};
         final TestSubject subject = new TestSubject.Builder().permission(new TestPermission("foo"))
                                                              .build();
-        Mockito.when(handler.getSubject(context))
+        Mockito.when(handler.getSubject(requestHeader))
                .thenReturn(CompletableFuture.completedFuture(Optional.of(subject)));
         final CompletionStage<Result> eventualResult = filterConstraints.pattern("foo",
                                                                                  PatternType.EQUALITY,
                                                                                  Optional.of("moo"))
-                                                                        .apply(context,
-                                                                               requestHeader,
+                                                                        .apply(requestHeader,
                                                                                handler,
                                                                                rh ->
                                                                                {
@@ -565,13 +544,12 @@ public class FilterConstraintsTest
         final boolean[] flag = {false};
         final TestSubject subject = new TestSubject.Builder().permission(new TestPermission("foo.bar"))
                                                              .build();
-        Mockito.when(handler.getSubject(context))
+        Mockito.when(handler.getSubject(requestHeader))
                .thenReturn(CompletableFuture.completedFuture(Optional.of(subject)));
         final CompletionStage<Result> eventualResult = filterConstraints.pattern("foo.*",
                                                                                  PatternType.REGEX,
                                                                                  Optional.of("moo"))
-                                                                        .apply(context,
-                                                                               requestHeader,
+                                                                        .apply(requestHeader,
                                                                                handler,
                                                                                rh ->
                                                                                {
@@ -586,17 +564,17 @@ public class FilterConstraintsTest
     public void testPattern_custom_withMeta_pass() throws Exception
     {
         final boolean[] flag = {false};
-        context.args = new HashMap<>();
-        Mockito.when(handler.getSubject(context))
+
+        Mockito.when(handler.getSubject(requestHeader))
                .thenReturn(CompletableFuture.completedFuture(Optional.of(Mockito.mock(Subject.class))));
-        Mockito.when(handler.getDynamicResourceHandler(context))
+        Mockito.when(handler.getDynamicResourceHandler(Mockito.any(Http.RequestHeader.class)))
                .thenReturn(CompletableFuture.completedFuture(Optional.of(new AbstractDynamicResourceHandler()
                {
                    @Override
                    public CompletionStage<Boolean> checkPermission(final String permissionValue,
                                                                    final Optional<String> meta,
                                                                    final DeadboltHandler deadboltHandler,
-                                                                   final Http.Context ctx)
+                                                                   final Http.RequestHeader requestHeader)
                    {
                        return CompletableFuture.completedFuture(meta.orElse("meh").equals("moo"));
                    }
@@ -604,8 +582,7 @@ public class FilterConstraintsTest
         final CompletionStage<Result> eventualResult = filterConstraints.pattern("foo",
                                                                                  PatternType.CUSTOM,
                                                                                  Optional.of("moo"))
-                                                                        .apply(context,
-                                                                               requestHeader,
+                                                                        .apply(requestHeader,
                                                                                handler,
                                                                                rh ->
                                                                                {
@@ -622,13 +599,12 @@ public class FilterConstraintsTest
         final boolean[] flag = {false};
         final TestSubject subject = new TestSubject.Builder().permission(new TestPermission("foo"))
                                                              .build();
-        Mockito.when(handler.getSubject(context))
+        Mockito.when(handler.getSubject(requestHeader))
                .thenReturn(CompletableFuture.completedFuture(Optional.of(subject)));
         final CompletionStage<Result> eventualResult = filterConstraints.pattern("bar",
                                                                                  PatternType.EQUALITY,
                                                                                  Optional.of("moo"))
-                                                                        .apply(context,
-                                                                               requestHeader,
+                                                                        .apply(requestHeader,
                                                                                handler,
                                                                                rh ->
                                                                                {
@@ -638,7 +614,7 @@ public class FilterConstraintsTest
         ((CompletableFuture) eventualResult).get();
         Assert.assertFalse(flag[0]);
         Mockito.verify(handler,
-                       Mockito.times(1)).onAuthFailure(Mockito.any(Http.Context.class),
+                       Mockito.times(1)).onAuthFailure(Mockito.any(Http.RequestHeader.class),
                                                        Mockito.eq(Optional.empty()));
     }
 
@@ -648,13 +624,12 @@ public class FilterConstraintsTest
         final boolean[] flag = {false};
         final TestSubject subject = new TestSubject.Builder().permission(new TestPermission("bar.foo"))
                                                              .build();
-        Mockito.when(handler.getSubject(context))
+        Mockito.when(handler.getSubject(requestHeader))
                .thenReturn(CompletableFuture.completedFuture(Optional.of(subject)));
         final CompletionStage<Result> eventualResult = filterConstraints.pattern("foo.*",
                                                                                  PatternType.REGEX,
                                                                                  Optional.of("moo"))
-                                                                        .apply(context,
-                                                                               requestHeader,
+                                                                        .apply(requestHeader,
                                                                                handler,
                                                                                rh ->
                                                                                {
@@ -664,7 +639,7 @@ public class FilterConstraintsTest
         ((CompletableFuture) eventualResult).get();
         Assert.assertFalse(flag[0]);
         Mockito.verify(handler,
-                       Mockito.times(1)).onAuthFailure(Mockito.any(Http.Context.class),
+                       Mockito.times(1)).onAuthFailure(Mockito.any(Http.RequestHeader.class),
                                                        Mockito.eq(Optional.empty()));
     }
 
@@ -672,17 +647,17 @@ public class FilterConstraintsTest
     public void testPattern_custom_withMeta_fail() throws Exception
     {
         final boolean[] flag = {false};
-        context.args = new HashMap<>();
-        Mockito.when(handler.getSubject(context))
+
+        Mockito.when(handler.getSubject(requestHeader))
                .thenReturn(CompletableFuture.completedFuture(Optional.of(Mockito.mock(Subject.class))));
-        Mockito.when(handler.getDynamicResourceHandler(context))
+        Mockito.when(handler.getDynamicResourceHandler(Mockito.any(Http.RequestHeader.class)))
                .thenReturn(CompletableFuture.completedFuture(Optional.of(new AbstractDynamicResourceHandler()
                {
                    @Override
                    public CompletionStage<Boolean> checkPermission(final String permissionValue,
                                                                    final Optional<String> meta,
                                                                    final DeadboltHandler deadboltHandler,
-                                                                   final Http.Context ctx)
+                                                                   final Http.RequestHeader requestHeader)
                    {
                        return CompletableFuture.completedFuture(meta.orElse("meh").equals("moo"));
                    }
@@ -690,8 +665,7 @@ public class FilterConstraintsTest
         final CompletionStage<Result> eventualResult = filterConstraints.pattern("foo",
                                                                                  PatternType.CUSTOM,
                                                                                  Optional.of("bluergh"))
-                                                                        .apply(context,
-                                                                               requestHeader,
+                                                                        .apply(requestHeader,
                                                                                handler,
                                                                                rh ->
                                                                                {
@@ -701,7 +675,7 @@ public class FilterConstraintsTest
         ((CompletableFuture) eventualResult).get();
         Assert.assertFalse(flag[0]);
         Mockito.verify(handler,
-                       Mockito.times(1)).onAuthFailure(Mockito.any(Http.Context.class),
+                       Mockito.times(1)).onAuthFailure(Mockito.any(Http.RequestHeader.class),
                                                        Mockito.eq(Optional.empty()));
     }
 
@@ -711,13 +685,12 @@ public class FilterConstraintsTest
         final boolean[] flag = {false};
         final TestSubject subject = new TestSubject.Builder().permission(new TestPermission("foo"))
                                                              .build();
-        Mockito.when(handler.getSubject(context))
+        Mockito.when(handler.getSubject(requestHeader))
                .thenReturn(CompletableFuture.completedFuture(Optional.of(subject)));
         final CompletionStage<Result> eventualResult = filterConstraints.pattern("foo",
                                                                                  PatternType.EQUALITY,
                                                                                  true)
-                                                                        .apply(context,
-                                                                               requestHeader,
+                                                                        .apply(requestHeader,
                                                                                handler,
                                                                                rh ->
                                                                                {
@@ -727,7 +700,7 @@ public class FilterConstraintsTest
         ((CompletableFuture) eventualResult).get();
         Assert.assertFalse(flag[0]);
         Mockito.verify(handler,
-                       Mockito.times(1)).onAuthFailure(Mockito.any(Http.Context.class),
+                       Mockito.times(1)).onAuthFailure(Mockito.any(Http.RequestHeader.class),
                                                        Mockito.eq(Optional.empty()));
     }
 
@@ -737,13 +710,12 @@ public class FilterConstraintsTest
         final boolean[] flag = {false};
         final TestSubject subject = new TestSubject.Builder().permission(new TestPermission("foo.bar"))
                                                              .build();
-        Mockito.when(handler.getSubject(context))
+        Mockito.when(handler.getSubject(requestHeader))
                .thenReturn(CompletableFuture.completedFuture(Optional.of(subject)));
         final CompletionStage<Result> eventualResult = filterConstraints.pattern("foo.*",
                                                                                  PatternType.REGEX,
                                                                                  true)
-                                                                        .apply(context,
-                                                                               requestHeader,
+                                                                        .apply(requestHeader,
                                                                                handler,
                                                                                rh ->
                                                                                {
@@ -753,7 +725,7 @@ public class FilterConstraintsTest
         ((CompletableFuture) eventualResult).get();
         Assert.assertFalse(flag[0]);
         Mockito.verify(handler,
-                       Mockito.times(1)).onAuthFailure(Mockito.any(Http.Context.class),
+                       Mockito.times(1)).onAuthFailure(Mockito.any(Http.RequestHeader.class),
                                                        Mockito.eq(Optional.empty()));
     }
 
@@ -761,17 +733,17 @@ public class FilterConstraintsTest
     public void testPattern_custom_invert_pass() throws Exception
     {
         final boolean[] flag = {false};
-        context.args = new HashMap<>();
-        Mockito.when(handler.getSubject(context))
+
+        Mockito.when(handler.getSubject(requestHeader))
                .thenReturn(CompletableFuture.completedFuture(Optional.of(Mockito.mock(Subject.class))));
-        Mockito.when(handler.getDynamicResourceHandler(context))
+        Mockito.when(handler.getDynamicResourceHandler(Mockito.any(Http.RequestHeader.class)))
                .thenReturn(CompletableFuture.completedFuture(Optional.of(new AbstractDynamicResourceHandler()
                {
                    @Override
                    public CompletionStage<Boolean> checkPermission(final String permissionValue,
                                                                    final Optional<String> meta,
                                                                    final DeadboltHandler deadboltHandler,
-                                                                   final Http.Context ctx)
+                                                                   final Http.RequestHeader requestHeader)
                    {
                        return CompletableFuture.completedFuture(Boolean.TRUE);
                    }
@@ -779,8 +751,7 @@ public class FilterConstraintsTest
         final CompletionStage<Result> eventualResult = filterConstraints.pattern("foo",
                                                                                  PatternType.CUSTOM,
                                                                                  true)
-                                                                        .apply(context,
-                                                                               requestHeader,
+                                                                        .apply(requestHeader,
                                                                                handler,
                                                                                rh ->
                                                                                {
@@ -790,7 +761,7 @@ public class FilterConstraintsTest
         ((CompletableFuture) eventualResult).get();
         Assert.assertFalse(flag[0]);
         Mockito.verify(handler,
-                       Mockito.times(1)).onAuthFailure(Mockito.any(Http.Context.class),
+                       Mockito.times(1)).onAuthFailure(Mockito.any(Http.RequestHeader.class),
                                                        Mockito.eq(Optional.empty()));
     }
 
@@ -800,13 +771,12 @@ public class FilterConstraintsTest
         final boolean[] flag = {false};
         final TestSubject subject = new TestSubject.Builder().permission(new TestPermission("foo"))
                                                              .build();
-        Mockito.when(handler.getSubject(context))
+        Mockito.when(handler.getSubject(requestHeader))
                .thenReturn(CompletableFuture.completedFuture(Optional.of(subject)));
         final CompletionStage<Result> eventualResult = filterConstraints.pattern("bar",
                                                                                  PatternType.EQUALITY,
                                                                                  true)
-                                                                        .apply(context,
-                                                                               requestHeader,
+                                                                        .apply(requestHeader,
                                                                                handler,
                                                                                rh ->
                                                                                {
@@ -823,13 +793,12 @@ public class FilterConstraintsTest
         final boolean[] flag = {false};
         final TestSubject subject = new TestSubject.Builder().permission(new TestPermission("bar.foo"))
                                                              .build();
-        Mockito.when(handler.getSubject(context))
+        Mockito.when(handler.getSubject(requestHeader))
                .thenReturn(CompletableFuture.completedFuture(Optional.of(subject)));
         final CompletionStage<Result> eventualResult = filterConstraints.pattern("foo.*",
                                                                                  PatternType.REGEX,
                                                                                  true)
-                                                                        .apply(context,
-                                                                               requestHeader,
+                                                                        .apply(requestHeader,
                                                                                handler,
                                                                                rh ->
                                                                                {
@@ -844,17 +813,17 @@ public class FilterConstraintsTest
     public void testPattern_custom_invert_fail() throws Exception
     {
         final boolean[] flag = {false};
-        context.args = new HashMap<>();
-        Mockito.when(handler.getSubject(context))
+
+        Mockito.when(handler.getSubject(requestHeader))
                .thenReturn(CompletableFuture.completedFuture(Optional.of(Mockito.mock(Subject.class))));
-        Mockito.when(handler.getDynamicResourceHandler(context))
+        Mockito.when(handler.getDynamicResourceHandler(Mockito.any(Http.RequestHeader.class)))
                .thenReturn(CompletableFuture.completedFuture(Optional.of(new AbstractDynamicResourceHandler()
                {
                    @Override
                    public CompletionStage<Boolean> checkPermission(final String permissionValue,
                                                                    final Optional<String> meta,
                                                                    final DeadboltHandler deadboltHandler,
-                                                                   final Http.Context ctx)
+                                                                   final Http.RequestHeader requestHeader)
                    {
                        return CompletableFuture.completedFuture(Boolean.FALSE);
                    }
@@ -862,8 +831,7 @@ public class FilterConstraintsTest
         final CompletionStage<Result> eventualResult = filterConstraints.pattern("foo",
                                                                                  PatternType.CUSTOM,
                                                                                  true)
-                                                                        .apply(context,
-                                                                               requestHeader,
+                                                                        .apply(requestHeader,
                                                                                handler,
                                                                                rh ->
                                                                                {
@@ -880,15 +848,14 @@ public class FilterConstraintsTest
         final boolean[] flag = {false};
         final TestSubject subject = new TestSubject.Builder().permission(new TestPermission("foo"))
                                                              .build();
-        Mockito.when(handler.getSubject(context))
+        Mockito.when(handler.getSubject(requestHeader))
                .thenReturn(CompletableFuture.completedFuture(Optional.of(subject)));
         final CompletionStage<Result> eventualResult = filterConstraints.pattern("foo",
                                                                                  PatternType.EQUALITY,
                                                                                  Optional.of("moo"),
                                                                                  false,
                                                                                  Optional.of("json"))
-                                                                        .apply(context,
-                                                                               requestHeader,
+                                                                        .apply(requestHeader,
                                                                                handler,
                                                                                rh ->
                                                                                {
@@ -905,15 +872,14 @@ public class FilterConstraintsTest
         final boolean[] flag = {false};
         final TestSubject subject = new TestSubject.Builder().permission(new TestPermission("foo.bar"))
                                                              .build();
-        Mockito.when(handler.getSubject(context))
+        Mockito.when(handler.getSubject(requestHeader))
                .thenReturn(CompletableFuture.completedFuture(Optional.of(subject)));
         final CompletionStage<Result> eventualResult = filterConstraints.pattern("foo.*",
                                                                                  PatternType.REGEX,
                                                                                  Optional.of("moo"),
                                                                                  false,
                                                                                  Optional.of("json"))
-                                                                        .apply(context,
-                                                                               requestHeader,
+                                                                        .apply(requestHeader,
                                                                                handler,
                                                                                rh ->
                                                                                {
@@ -928,17 +894,17 @@ public class FilterConstraintsTest
     public void testPattern_custom_allArgs_pass() throws Exception
     {
         final boolean[] flag = {false};
-        context.args = new HashMap<>();
-        Mockito.when(handler.getSubject(context))
+
+        Mockito.when(handler.getSubject(requestHeader))
                .thenReturn(CompletableFuture.completedFuture(Optional.of(Mockito.mock(Subject.class))));
-        Mockito.when(handler.getDynamicResourceHandler(context))
+        Mockito.when(handler.getDynamicResourceHandler(Mockito.any(Http.RequestHeader.class)))
                .thenReturn(CompletableFuture.completedFuture(Optional.of(new AbstractDynamicResourceHandler()
                {
                    @Override
                    public CompletionStage<Boolean> checkPermission(final String permissionValue,
                                                                    final Optional<String> meta,
                                                                    final DeadboltHandler deadboltHandler,
-                                                                   final Http.Context ctx)
+                                                                   final Http.RequestHeader requestHeader)
                    {
                        return CompletableFuture.completedFuture(meta.orElse("meh").equals("moo"));
                    }
@@ -948,8 +914,7 @@ public class FilterConstraintsTest
                                                                                  Optional.of("moo"),
                                                                                  false,
                                                                                  Optional.of("json"))
-                                                                        .apply(context,
-                                                                               requestHeader,
+                                                                        .apply(requestHeader,
                                                                                handler,
                                                                                rh ->
                                                                                {
@@ -966,15 +931,14 @@ public class FilterConstraintsTest
         final boolean[] flag = {false};
         final TestSubject subject = new TestSubject.Builder().permission(new TestPermission("foo"))
                                                              .build();
-        Mockito.when(handler.getSubject(context))
+        Mockito.when(handler.getSubject(requestHeader))
                .thenReturn(CompletableFuture.completedFuture(Optional.of(subject)));
         final CompletionStage<Result> eventualResult = filterConstraints.pattern("bar",
                                                                                  PatternType.EQUALITY,
                                                                                  Optional.of("moo"),
                                                                                  false,
                                                                                  Optional.of("json"))
-                                                                        .apply(context,
-                                                                               requestHeader,
+                                                                        .apply(requestHeader,
                                                                                handler,
                                                                                rh ->
                                                                                {
@@ -984,7 +948,7 @@ public class FilterConstraintsTest
         ((CompletableFuture) eventualResult).get();
         Assert.assertFalse(flag[0]);
         Mockito.verify(handler,
-                       Mockito.times(1)).onAuthFailure(Mockito.any(Http.Context.class),
+                       Mockito.times(1)).onAuthFailure(Mockito.any(Http.RequestHeader.class),
                                                        Mockito.eq(Optional.of("json")));
     }
 
@@ -994,15 +958,14 @@ public class FilterConstraintsTest
         final boolean[] flag = {false};
         final TestSubject subject = new TestSubject.Builder().permission(new TestPermission("bar.foo"))
                                                              .build();
-        Mockito.when(handler.getSubject(context))
+        Mockito.when(handler.getSubject(requestHeader))
                .thenReturn(CompletableFuture.completedFuture(Optional.of(subject)));
         final CompletionStage<Result> eventualResult = filterConstraints.pattern("foo.*",
                                                                                  PatternType.REGEX,
                                                                                  Optional.of("moo"),
                                                                                  false,
                                                                                  Optional.of("json"))
-                                                                        .apply(context,
-                                                                               requestHeader,
+                                                                        .apply(requestHeader,
                                                                                handler,
                                                                                rh ->
                                                                                {
@@ -1012,7 +975,7 @@ public class FilterConstraintsTest
         ((CompletableFuture) eventualResult).get();
         Assert.assertFalse(flag[0]);
         Mockito.verify(handler,
-                       Mockito.times(1)).onAuthFailure(Mockito.any(Http.Context.class),
+                       Mockito.times(1)).onAuthFailure(Mockito.any(Http.RequestHeader.class),
                                                        Mockito.eq(Optional.of("json")));
     }
 
@@ -1020,17 +983,17 @@ public class FilterConstraintsTest
     public void testPattern_custom_allArgs_fail() throws Exception
     {
         final boolean[] flag = {false};
-        context.args = new HashMap<>();
-        Mockito.when(handler.getSubject(context))
+
+        Mockito.when(handler.getSubject(requestHeader))
                .thenReturn(CompletableFuture.completedFuture(Optional.of(Mockito.mock(Subject.class))));
-        Mockito.when(handler.getDynamicResourceHandler(context))
+        Mockito.when(handler.getDynamicResourceHandler(Mockito.any(Http.RequestHeader.class)))
                .thenReturn(CompletableFuture.completedFuture(Optional.of(new AbstractDynamicResourceHandler()
                {
                    @Override
                    public CompletionStage<Boolean> checkPermission(final String permissionValue,
                                                                    final Optional<String> meta,
                                                                    final DeadboltHandler deadboltHandler,
-                                                                   final Http.Context ctx)
+                                                                   final Http.RequestHeader requestHeader)
                    {
                        return CompletableFuture.completedFuture(meta.orElse("meh").equals("moo"));
                    }
@@ -1040,8 +1003,7 @@ public class FilterConstraintsTest
                                                                                  Optional.of("bluergh"),
                                                                                  false,
                                                                                  Optional.of("json"))
-                                                                        .apply(context,
-                                                                               requestHeader,
+                                                                        .apply(requestHeader,
                                                                                handler,
                                                                                rh ->
                                                                                {
@@ -1051,7 +1013,7 @@ public class FilterConstraintsTest
         ((CompletableFuture) eventualResult).get();
         Assert.assertFalse(flag[0]);
         Mockito.verify(handler,
-                       Mockito.times(1)).onAuthFailure(Mockito.any(Http.Context.class),
+                       Mockito.times(1)).onAuthFailure(Mockito.any(Http.RequestHeader.class),
                                                        Mockito.eq(Optional.of("json")));
     }
 
@@ -1061,15 +1023,14 @@ public class FilterConstraintsTest
         final boolean[] flag = {false};
         final TestSubject subject = new TestSubject.Builder().permission(new TestPermission("foo"))
                                                              .build();
-        Mockito.when(handler.getSubject(context))
+        Mockito.when(handler.getSubject(requestHeader))
                .thenReturn(CompletableFuture.completedFuture(Optional.of(subject)));
         final CompletionStage<Result> eventualResult = filterConstraints.pattern("foo",
                                                                                  PatternType.EQUALITY,
                                                                                  Optional.of("moo"),
                                                                                  true,
                                                                                  Optional.of("json"))
-                                                                        .apply(context,
-                                                                               requestHeader,
+                                                                        .apply(requestHeader,
                                                                                handler,
                                                                                rh ->
                                                                                {
@@ -1079,7 +1040,7 @@ public class FilterConstraintsTest
         ((CompletableFuture) eventualResult).get();
         Assert.assertFalse(flag[0]);
         Mockito.verify(handler,
-                       Mockito.times(1)).onAuthFailure(Mockito.any(Http.Context.class),
+                       Mockito.times(1)).onAuthFailure(Mockito.any(Http.RequestHeader.class),
                                                        Mockito.eq(Optional.of("json")));
     }
 
@@ -1089,15 +1050,14 @@ public class FilterConstraintsTest
         final boolean[] flag = {false};
         final TestSubject subject = new TestSubject.Builder().permission(new TestPermission("foo.bar"))
                                                              .build();
-        Mockito.when(handler.getSubject(context))
+        Mockito.when(handler.getSubject(requestHeader))
                .thenReturn(CompletableFuture.completedFuture(Optional.of(subject)));
         final CompletionStage<Result> eventualResult = filterConstraints.pattern("foo.*",
                                                                                  PatternType.REGEX,
                                                                                  Optional.of("moo"),
                                                                                  true,
                                                                                  Optional.of("json"))
-                                                                        .apply(context,
-                                                                               requestHeader,
+                                                                        .apply(requestHeader,
                                                                                handler,
                                                                                rh ->
                                                                                {
@@ -1107,7 +1067,7 @@ public class FilterConstraintsTest
         ((CompletableFuture) eventualResult).get();
         Assert.assertFalse(flag[0]);
         Mockito.verify(handler,
-                       Mockito.times(1)).onAuthFailure(Mockito.any(Http.Context.class),
+                       Mockito.times(1)).onAuthFailure(Mockito.any(Http.RequestHeader.class),
                                                        Mockito.eq(Optional.of("json")));
     }
 
@@ -1115,17 +1075,17 @@ public class FilterConstraintsTest
     public void testPattern_custom_allArgs_invert_pass() throws Exception
     {
         final boolean[] flag = {false};
-        context.args = new HashMap<>();
-        Mockito.when(handler.getSubject(context))
+
+        Mockito.when(handler.getSubject(requestHeader))
                .thenReturn(CompletableFuture.completedFuture(Optional.of(Mockito.mock(Subject.class))));
-        Mockito.when(handler.getDynamicResourceHandler(context))
+        Mockito.when(handler.getDynamicResourceHandler(Mockito.any(Http.RequestHeader.class)))
                .thenReturn(CompletableFuture.completedFuture(Optional.of(new AbstractDynamicResourceHandler()
                {
                    @Override
                    public CompletionStage<Boolean> checkPermission(final String permissionValue,
                                                                    final Optional<String> meta,
                                                                    final DeadboltHandler deadboltHandler,
-                                                                   final Http.Context ctx)
+                                                                   final Http.RequestHeader requestHeader)
                    {
                        return CompletableFuture.completedFuture(meta.orElse("meh").equals("moo"));
                    }
@@ -1135,8 +1095,7 @@ public class FilterConstraintsTest
                                                                                  Optional.of("moo"),
                                                                                  true,
                                                                                  Optional.of("json"))
-                                                                        .apply(context,
-                                                                               requestHeader,
+                                                                        .apply(requestHeader,
                                                                                handler,
                                                                                rh ->
                                                                                {
@@ -1146,7 +1105,7 @@ public class FilterConstraintsTest
         ((CompletableFuture) eventualResult).get();
         Assert.assertFalse(flag[0]);
         Mockito.verify(handler,
-                       Mockito.times(1)).onAuthFailure(Mockito.any(Http.Context.class),
+                       Mockito.times(1)).onAuthFailure(Mockito.any(Http.RequestHeader.class),
                                                        Mockito.eq(Optional.of("json")));
     }
 
@@ -1156,15 +1115,14 @@ public class FilterConstraintsTest
         final boolean[] flag = {false};
         final TestSubject subject = new TestSubject.Builder().permission(new TestPermission("foo"))
                                                              .build();
-        Mockito.when(handler.getSubject(context))
+        Mockito.when(handler.getSubject(requestHeader))
                .thenReturn(CompletableFuture.completedFuture(Optional.of(subject)));
         final CompletionStage<Result> eventualResult = filterConstraints.pattern("bar",
                                                                                  PatternType.EQUALITY,
                                                                                  Optional.of("moo"),
                                                                                  true,
                                                                                  Optional.of("json"))
-                                                                        .apply(context,
-                                                                               requestHeader,
+                                                                        .apply(requestHeader,
                                                                                handler,
                                                                                rh ->
                                                                                {
@@ -1181,15 +1139,14 @@ public class FilterConstraintsTest
         final boolean[] flag = {false};
         final TestSubject subject = new TestSubject.Builder().permission(new TestPermission("bar.foo"))
                                                              .build();
-        Mockito.when(handler.getSubject(context))
+        Mockito.when(handler.getSubject(requestHeader))
                .thenReturn(CompletableFuture.completedFuture(Optional.of(subject)));
         final CompletionStage<Result> eventualResult = filterConstraints.pattern("foo.*",
                                                                                  PatternType.REGEX,
                                                                                  Optional.of("moo"),
                                                                                  true,
                                                                                  Optional.of("json"))
-                                                                        .apply(context,
-                                                                               requestHeader,
+                                                                        .apply(requestHeader,
                                                                                handler,
                                                                                rh ->
                                                                                {
@@ -1204,17 +1161,17 @@ public class FilterConstraintsTest
     public void testPattern_custom_allArgs_invert_fail() throws Exception
     {
         final boolean[] flag = {false};
-        context.args = new HashMap<>();
-        Mockito.when(handler.getSubject(context))
+
+        Mockito.when(handler.getSubject(requestHeader))
                .thenReturn(CompletableFuture.completedFuture(Optional.of(Mockito.mock(Subject.class))));
-        Mockito.when(handler.getDynamicResourceHandler(context))
+        Mockito.when(handler.getDynamicResourceHandler(Mockito.any(Http.RequestHeader.class)))
                .thenReturn(CompletableFuture.completedFuture(Optional.of(new AbstractDynamicResourceHandler()
                {
                    @Override
                    public CompletionStage<Boolean> checkPermission(final String permissionValue,
                                                                    final Optional<String> meta,
                                                                    final DeadboltHandler deadboltHandler,
-                                                                   final Http.Context ctx)
+                                                                   final Http.RequestHeader requestHeader)
                    {
                        return CompletableFuture.completedFuture(meta.orElse("meh").equals("moo"));
                    }
@@ -1224,8 +1181,7 @@ public class FilterConstraintsTest
                                                                                  Optional.of("bluergh"),
                                                                                  true,
                                                                                  Optional.of("json"))
-                                                                        .apply(context,
-                                                                               requestHeader,
+                                                                        .apply(requestHeader,
                                                                                handler,
                                                                                rh ->
                                                                                {
@@ -1240,23 +1196,22 @@ public class FilterConstraintsTest
     public void testDynamic_pass() throws Exception
     {
         final boolean[] flag = {false};
-        Mockito.when(handler.getSubject(context))
+        Mockito.when(handler.getSubject(requestHeader))
                .thenReturn(CompletableFuture.completedFuture(Optional.of(Mockito.mock(Subject.class))));
-        Mockito.when(handler.getDynamicResourceHandler(context))
+        Mockito.when(handler.getDynamicResourceHandler(requestHeader))
                .thenReturn(CompletableFuture.completedFuture(Optional.of(new AbstractDynamicResourceHandler()
                {
                    @Override
                    public CompletionStage<Boolean> isAllowed(final String name,
                                                              final Optional<String> meta,
                                                              final DeadboltHandler deadboltHandler,
-                                                             final Http.Context ctx)
+                                                             final Http.RequestHeader requestHeader)
                    {
                        return CompletableFuture.completedFuture(Boolean.TRUE);
                    }
                })));
         final CompletionStage<Result> eventualResult = filterConstraints.dynamic("foo")
-                                                                        .apply(context,
-                                                                               requestHeader,
+                                                                        .apply(requestHeader,
                                                                                handler,
                                                                                rh ->
                                                                                {
@@ -1271,24 +1226,23 @@ public class FilterConstraintsTest
     public void testDynamic_withMeta_pass() throws Exception
     {
         final boolean[] flag = {false};
-        Mockito.when(handler.getSubject(context))
+        Mockito.when(handler.getSubject(requestHeader))
                .thenReturn(CompletableFuture.completedFuture(Optional.of(Mockito.mock(Subject.class))));
-        Mockito.when(handler.getDynamicResourceHandler(context))
+        Mockito.when(handler.getDynamicResourceHandler(requestHeader))
                .thenReturn(CompletableFuture.completedFuture(Optional.of(new AbstractDynamicResourceHandler()
                {
                    @Override
                    public CompletionStage<Boolean> isAllowed(final String name,
                                                              final Optional<String> meta,
                                                              final DeadboltHandler deadboltHandler,
-                                                             final Http.Context ctx)
+                                                             final Http.RequestHeader requestHeader)
                    {
                        return CompletableFuture.completedFuture(meta.orElse("meh").equals("moo"));
                    }
                })));
         final CompletionStage<Result> eventualResult = filterConstraints.dynamic("foo",
                                                                                  Optional.of("moo"))
-                                                                        .apply(context,
-                                                                               requestHeader,
+                                                                        .apply(requestHeader,
                                                                                handler,
                                                                                rh ->
                                                                                {
@@ -1303,16 +1257,16 @@ public class FilterConstraintsTest
     public void testDynamic_withMetaAndContent_pass() throws Exception
     {
         final boolean[] flag = {false};
-        Mockito.when(handler.getSubject(context))
+        Mockito.when(handler.getSubject(requestHeader))
                .thenReturn(CompletableFuture.completedFuture(Optional.of(Mockito.mock(Subject.class))));
-        Mockito.when(handler.getDynamicResourceHandler(context))
+        Mockito.when(handler.getDynamicResourceHandler(requestHeader))
                .thenReturn(CompletableFuture.completedFuture(Optional.of(new AbstractDynamicResourceHandler()
                {
                    @Override
                    public CompletionStage<Boolean> isAllowed(final String name,
                                                              final Optional<String> meta,
                                                              final DeadboltHandler deadboltHandler,
-                                                             final Http.Context ctx)
+                                                             final Http.RequestHeader requestHeader)
                    {
                        return CompletableFuture.completedFuture(meta.orElse("meh").equals("moo"));
                    }
@@ -1320,8 +1274,7 @@ public class FilterConstraintsTest
         final CompletionStage<Result> eventualResult = filterConstraints.dynamic("foo",
                                                                                  Optional.of("moo"),
                                                                                  Optional.of("json"))
-                                                                        .apply(context,
-                                                                               requestHeader,
+                                                                        .apply(requestHeader,
                                                                                handler,
                                                                                rh ->
                                                                                {
@@ -1336,23 +1289,22 @@ public class FilterConstraintsTest
     public void testDynamic_fail() throws Exception
     {
         final boolean[] flag = {false};
-        Mockito.when(handler.getSubject(context))
+        Mockito.when(handler.getSubject(requestHeader))
                .thenReturn(CompletableFuture.completedFuture(Optional.of(Mockito.mock(Subject.class))));
-        Mockito.when(handler.getDynamicResourceHandler(context))
+        Mockito.when(handler.getDynamicResourceHandler(requestHeader))
                .thenReturn(CompletableFuture.completedFuture(Optional.of(new AbstractDynamicResourceHandler()
                {
                    @Override
                    public CompletionStage<Boolean> isAllowed(final String name,
                                                              final Optional<String> meta,
                                                              final DeadboltHandler deadboltHandler,
-                                                             final Http.Context ctx)
+                                                             final Http.RequestHeader requestHeader)
                    {
                        return CompletableFuture.completedFuture(Boolean.FALSE);
                    }
                })));
         final CompletionStage<Result> eventualResult = filterConstraints.dynamic("foo")
-                                                                        .apply(context,
-                                                                               requestHeader,
+                                                                        .apply(requestHeader,
                                                                                handler,
                                                                                rh ->
                                                                                {
@@ -1362,7 +1314,7 @@ public class FilterConstraintsTest
         ((CompletableFuture) eventualResult).get();
         Assert.assertFalse(flag[0]);
         Mockito.verify(handler,
-                       Mockito.times(1)).onAuthFailure(Mockito.any(Http.Context.class),
+                       Mockito.times(1)).onAuthFailure(Mockito.any(Http.RequestHeader.class),
                                                        Mockito.eq(Optional.empty()));
     }
 
@@ -1370,24 +1322,23 @@ public class FilterConstraintsTest
     public void testDynamic_withMeta_fail() throws Exception
     {
         final boolean[] flag = {false};
-        Mockito.when(handler.getSubject(context))
+        Mockito.when(handler.getSubject(requestHeader))
                .thenReturn(CompletableFuture.completedFuture(Optional.of(Mockito.mock(Subject.class))));
-        Mockito.when(handler.getDynamicResourceHandler(context))
+        Mockito.when(handler.getDynamicResourceHandler(requestHeader))
                .thenReturn(CompletableFuture.completedFuture(Optional.of(new AbstractDynamicResourceHandler()
                {
                    @Override
                    public CompletionStage<Boolean> isAllowed(final String name,
                                                              final Optional<String> meta,
                                                              final DeadboltHandler deadboltHandler,
-                                                             final Http.Context ctx)
+                                                             final Http.RequestHeader requestHeader)
                    {
                        return CompletableFuture.completedFuture(meta.orElse("meh").equals("moo"));
                    }
                })));
         final CompletionStage<Result> eventualResult = filterConstraints.dynamic("foo",
                                                                                  Optional.of("bleurgh"))
-                                                                        .apply(context,
-                                                                               requestHeader,
+                                                                        .apply(requestHeader,
                                                                                handler,
                                                                                rh ->
                                                                                {
@@ -1397,7 +1348,7 @@ public class FilterConstraintsTest
         ((CompletableFuture) eventualResult).get();
         Assert.assertFalse(flag[0]);
         Mockito.verify(handler,
-                       Mockito.times(1)).onAuthFailure(Mockito.any(Http.Context.class),
+                       Mockito.times(1)).onAuthFailure(Mockito.any(Http.RequestHeader.class),
                                                        Mockito.eq(Optional.empty()));
     }
 
@@ -1405,16 +1356,16 @@ public class FilterConstraintsTest
     public void testDynamic_withMetaAndContent_fail() throws Exception
     {
         final boolean[] flag = {false};
-        Mockito.when(handler.getSubject(context))
+        Mockito.when(handler.getSubject(requestHeader))
                .thenReturn(CompletableFuture.completedFuture(Optional.of(Mockito.mock(Subject.class))));
-        Mockito.when(handler.getDynamicResourceHandler(context))
+        Mockito.when(handler.getDynamicResourceHandler(requestHeader))
                .thenReturn(CompletableFuture.completedFuture(Optional.of(new AbstractDynamicResourceHandler()
                {
                    @Override
                    public CompletionStage<Boolean> isAllowed(final String name,
                                                              final Optional<String> meta,
                                                              final DeadboltHandler deadboltHandler,
-                                                             final Http.Context ctx)
+                                                             final Http.RequestHeader requestHeader)
                    {
                        return CompletableFuture.completedFuture(meta.orElse("meh").equals("moo"));
                    }
@@ -1422,8 +1373,7 @@ public class FilterConstraintsTest
         final CompletionStage<Result> eventualResult = filterConstraints.dynamic("foo",
                                                                                  Optional.of("bleurgh"),
                                                                                  Optional.of("json"))
-                                                                        .apply(context,
-                                                                               requestHeader,
+                                                                        .apply(requestHeader,
                                                                                handler,
                                                                                rh ->
                                                                                {
@@ -1433,7 +1383,7 @@ public class FilterConstraintsTest
         ((CompletableFuture) eventualResult).get();
         Assert.assertFalse(flag[0]);
         Mockito.verify(handler,
-                       Mockito.times(1)).onAuthFailure(Mockito.any(Http.Context.class),
+                       Mockito.times(1)).onAuthFailure(Mockito.any(Http.RequestHeader.class),
                                                        Mockito.eq(Optional.of("json")));
     }
 
@@ -1441,11 +1391,10 @@ public class FilterConstraintsTest
     public void testComposite_byName_pass() throws Exception
     {
         final boolean[] flag = {false};
-        Mockito.when(handler.getSubject(context))
+        Mockito.when(handler.getSubject(requestHeader))
                .thenReturn(CompletableFuture.completedFuture(Optional.of(Mockito.mock(Subject.class))));
         final CompletionStage<Result> eventualResult = filterConstraints.composite("testConstraint")
-                                                                        .apply(context,
-                                                                               requestHeader,
+                                                                        .apply(requestHeader,
                                                                                handler,
                                                                                rh ->
                                                                                {
@@ -1460,12 +1409,11 @@ public class FilterConstraintsTest
     public void testComposite_byName_withContent_pass() throws Exception
     {
         final boolean[] flag = {false};
-        Mockito.when(handler.getSubject(context))
+        Mockito.when(handler.getSubject(requestHeader))
                .thenReturn(CompletableFuture.completedFuture(Optional.of(Mockito.mock(Subject.class))));
         final CompletionStage<Result> eventualResult = filterConstraints.composite("testConstraint",
                                                                                    Optional.of("json"))
-                                                                        .apply(context,
-                                                                               requestHeader,
+                                                                        .apply(requestHeader,
                                                                                handler,
                                                                                rh ->
                                                                                {
@@ -1480,11 +1428,10 @@ public class FilterConstraintsTest
     public void testComposite_byName_fail() throws Exception
     {
         final boolean[] flag = {false};
-        Mockito.when(handler.getSubject(context))
+        Mockito.when(handler.getSubject(requestHeader))
                .thenReturn(CompletableFuture.completedFuture(Optional.empty()));
         final CompletionStage<Result> eventualResult = filterConstraints.composite("testConstraint")
-                                                                        .apply(context,
-                                                                               requestHeader,
+                                                                        .apply(requestHeader,
                                                                                handler,
                                                                                rh ->
                                                                                {
@@ -1494,7 +1441,7 @@ public class FilterConstraintsTest
         ((CompletableFuture) eventualResult).get();
         Assert.assertFalse(flag[0]);
         Mockito.verify(handler,
-                       Mockito.times(1)).onAuthFailure(Mockito.any(Http.Context.class),
+                       Mockito.times(1)).onAuthFailure(Mockito.any(Http.RequestHeader.class),
                                                        Mockito.eq(Optional.empty()));
     }
 
@@ -1502,12 +1449,11 @@ public class FilterConstraintsTest
     public void testComposite_byName_withContent_fail() throws Exception
     {
         final boolean[] flag = {false};
-        Mockito.when(handler.getSubject(context))
+        Mockito.when(handler.getSubject(requestHeader))
                .thenReturn(CompletableFuture.completedFuture(Optional.empty()));
         final CompletionStage<Result> eventualResult = filterConstraints.composite("testConstraint",
                                                                                    Optional.of("json"))
-                                                                        .apply(context,
-                                                                               requestHeader,
+                                                                        .apply(requestHeader,
                                                                                handler,
                                                                                rh ->
                                                                                {
@@ -1517,7 +1463,7 @@ public class FilterConstraintsTest
         ((CompletableFuture) eventualResult).get();
         Assert.assertFalse(flag[0]);
         Mockito.verify(handler,
-                       Mockito.times(1)).onAuthFailure(Mockito.any(Http.Context.class),
+                       Mockito.times(1)).onAuthFailure(Mockito.any(Http.RequestHeader.class),
                                                        Mockito.eq(Optional.of("json")));
     }
 
@@ -1525,12 +1471,11 @@ public class FilterConstraintsTest
     public void testComposite_byConstraint_pass() throws Exception
     {
         final boolean[] flag = {false};
-        Mockito.when(handler.getSubject(context))
+        Mockito.when(handler.getSubject(requestHeader))
                .thenReturn(CompletableFuture.completedFuture(Optional.of(Mockito.mock(Subject.class))));
         final CompletionStage<Result> eventualResult = filterConstraints.composite(new SubjectPresentConstraint(Optional.empty(),
                                                                                                                 constraintLogic))
-                                                                        .apply(context,
-                                                                               requestHeader,
+                                                                        .apply(requestHeader,
                                                                                handler,
                                                                                rh ->
                                                                                {
@@ -1545,13 +1490,12 @@ public class FilterConstraintsTest
     public void testComposite_byConstraint_withContent_pass() throws Exception
     {
         final boolean[] flag = {false};
-        Mockito.when(handler.getSubject(context))
+        Mockito.when(handler.getSubject(requestHeader))
                .thenReturn(CompletableFuture.completedFuture(Optional.of(Mockito.mock(Subject.class))));
         final CompletionStage<Result> eventualResult = filterConstraints.composite(new SubjectPresentConstraint(Optional.empty(),
                                                                                                                 constraintLogic),
                                                                                    Optional.of("json"))
-                                                                        .apply(context,
-                                                                               requestHeader,
+                                                                        .apply(requestHeader,
                                                                                handler,
                                                                                rh ->
                                                                                {
@@ -1566,14 +1510,13 @@ public class FilterConstraintsTest
     public void testComposite_byConstraint_fail() throws Exception
     {
         final boolean[] flag = {false};
-        Mockito.when(handler.getSubject(context))
+        Mockito.when(handler.getSubject(requestHeader))
                .thenReturn(CompletableFuture.completedFuture(Optional.empty()));
         Mockito.when(handler.getPermissionsForRole("foo"))
                .then(invocation -> Collections.singletonList(new TestPermission("bar")));
         final CompletionStage<Result> eventualResult = filterConstraints.composite(new SubjectPresentConstraint(Optional.empty(),
                                                                                                                 constraintLogic))
-                                                                        .apply(context,
-                                                                               requestHeader,
+                                                                        .apply(requestHeader,
                                                                                handler,
                                                                                rh ->
                                                                                {
@@ -1583,7 +1526,7 @@ public class FilterConstraintsTest
         ((CompletableFuture) eventualResult).get();
         Assert.assertFalse(flag[0]);
         Mockito.verify(handler,
-                       Mockito.times(1)).onAuthFailure(Mockito.any(Http.Context.class),
+                       Mockito.times(1)).onAuthFailure(Mockito.any(Http.RequestHeader.class),
                                                        Mockito.eq(Optional.empty()));
     }
 
@@ -1591,15 +1534,14 @@ public class FilterConstraintsTest
     public void testComposite_byConstraint_withContent_fail() throws Exception
     {
         final boolean[] flag = {false};
-        Mockito.when(handler.getSubject(context))
+        Mockito.when(handler.getSubject(requestHeader))
                .thenReturn(CompletableFuture.completedFuture(Optional.empty()));
         Mockito.when(handler.getPermissionsForRole("foo"))
                .then(invocation -> Collections.singletonList(new TestPermission("bar")));
         final CompletionStage<Result> eventualResult = filterConstraints.composite(new SubjectPresentConstraint(Optional.empty(),
                                                                                                                 constraintLogic),
                                                                                    Optional.of("json"))
-                                                                        .apply(context,
-                                                                               requestHeader,
+                                                                        .apply(requestHeader,
                                                                                handler,
                                                                                rh ->
                                                                                {
@@ -1609,7 +1551,7 @@ public class FilterConstraintsTest
         ((CompletableFuture) eventualResult).get();
         Assert.assertFalse(flag[0]);
         Mockito.verify(handler,
-                       Mockito.times(1)).onAuthFailure(Mockito.any(Http.Context.class),
+                       Mockito.times(1)).onAuthFailure(Mockito.any(Http.RequestHeader.class),
                                                        Mockito.eq(Optional.of("json")));
     }
 
@@ -1619,13 +1561,12 @@ public class FilterConstraintsTest
         final boolean[] flag = {false};
         final TestSubject subject = new TestSubject.Builder().permission(new TestPermission("bar"))
                                                              .build();
-        Mockito.when(handler.getSubject(context))
+        Mockito.when(handler.getSubject(requestHeader))
                .thenReturn(CompletableFuture.completedFuture(Optional.of(subject)));
         Mockito.when(handler.getPermissionsForRole("foo"))
                .then(invocation -> CompletableFuture.completedFuture(Collections.singletonList(new TestPermission("bar"))));
         final CompletionStage<Result> eventualResult = filterConstraints.roleBasedPermissions("foo")
-                                                                        .apply(context,
-                                                                               requestHeader,
+                                                                        .apply(requestHeader,
                                                                                handler,
                                                                                rh ->
                                                                                {
@@ -1642,14 +1583,13 @@ public class FilterConstraintsTest
         final boolean[] flag = {false};
         final TestSubject subject = new TestSubject.Builder().permission(new TestPermission("bar"))
                                                              .build();
-        Mockito.when(handler.getSubject(context))
+        Mockito.when(handler.getSubject(requestHeader))
                .thenReturn(CompletableFuture.completedFuture(Optional.of(subject)));
         Mockito.when(handler.getPermissionsForRole("foo"))
                .then(invocation -> CompletableFuture.completedFuture(Collections.singletonList(new TestPermission("bar"))));
         final CompletionStage<Result> eventualResult = filterConstraints.roleBasedPermissions("foo",
                                                                                               Optional.of("json"))
-                                                                        .apply(context,
-                                                                               requestHeader,
+                                                                        .apply(requestHeader,
                                                                                handler,
                                                                                rh ->
                                                                                {
@@ -1666,14 +1606,13 @@ public class FilterConstraintsTest
         final boolean[] flag = {false};
         final TestSubject subject = new TestSubject.Builder().permission(new TestPermission("hurdy"))
                                                              .build();
-        Mockito.when(handler.getSubject(context))
+        Mockito.when(handler.getSubject(requestHeader))
                .thenReturn(CompletableFuture.completedFuture(Optional.of(subject)));
         Mockito.when(handler.getPermissionsForRole("foo"))
                .then(invocation -> CompletableFuture.completedFuture(Collections.singletonList(new TestPermission("bar"))));
 
         final CompletionStage<Result> eventualResult = filterConstraints.roleBasedPermissions("foo")
-                                                                        .apply(context,
-                                                                               requestHeader,
+                                                                        .apply(requestHeader,
                                                                                handler,
                                                                                rh ->
                                                                                {
@@ -1683,7 +1622,7 @@ public class FilterConstraintsTest
         ((CompletableFuture) eventualResult).get();
         Assert.assertFalse(flag[0]);
         Mockito.verify(handler,
-                       Mockito.times(1)).onAuthFailure(Mockito.any(Http.Context.class),
+                       Mockito.times(1)).onAuthFailure(Mockito.any(Http.RequestHeader.class),
                                                        Mockito.eq(Optional.empty()));
     }
 
@@ -1693,15 +1632,14 @@ public class FilterConstraintsTest
         final boolean[] flag = {false};
         final TestSubject subject = new TestSubject.Builder().permission(new TestPermission("hurdy"))
                                                              .build();
-        Mockito.when(handler.getSubject(context))
+        Mockito.when(handler.getSubject(requestHeader))
                .thenReturn(CompletableFuture.completedFuture(Optional.of(subject)));
         Mockito.when(handler.getPermissionsForRole("foo"))
                .then(invocation -> CompletableFuture.completedFuture(Collections.singletonList(new TestPermission("bar"))));
 
         final CompletionStage<Result> eventualResult = filterConstraints.roleBasedPermissions("foo",
                                                                                               Optional.of("json"))
-                                                                        .apply(context,
-                                                                               requestHeader,
+                                                                        .apply(requestHeader,
                                                                                handler,
                                                                                rh ->
                                                                                {
@@ -1711,7 +1649,7 @@ public class FilterConstraintsTest
         ((CompletableFuture) eventualResult).get();
         Assert.assertFalse(flag[0]);
         Mockito.verify(handler,
-                       Mockito.times(1)).onAuthFailure(Mockito.any(Http.Context.class),
+                       Mockito.times(1)).onAuthFailure(Mockito.any(Http.RequestHeader.class),
                                                        Mockito.eq(Optional.of("json")));
     }
 }

--- a/code/test/be/objectify/deadbolt/java/testsupport/TestCookies.java
+++ b/code/test/be/objectify/deadbolt/java/testsupport/TestCookies.java
@@ -18,6 +18,7 @@ package be.objectify.deadbolt.java.testsupport;
 import play.mvc.Http;
 
 import java.util.ArrayList;
+import java.util.Optional;
 
 /**
  * @author Steve Chaloner (steve@objectify.be)
@@ -25,8 +26,8 @@ import java.util.ArrayList;
 public class TestCookies extends ArrayList<Http.Cookie> implements Http.Cookies
 {
     @Override
-    public Http.Cookie get(final String name)
+    public Optional<Http.Cookie> getCookie(final String name)
     {
-        return null;
+        return Optional.empty();
     }
 }

--- a/code/test/be/objectify/deadbolt/java/views/di/dynamicTest/DynamicOrTest.java
+++ b/code/test/be/objectify/deadbolt/java/views/di/dynamicTest/DynamicOrTest.java
@@ -47,13 +47,12 @@ public class DynamicOrTest extends AbstractFakeApplicationTest
         final DeadboltHandler deadboltHandler = new NoPreAuthDeadboltHandler()
         {
             @Override
-            public CompletionStage<Optional<DynamicResourceHandler>> getDynamicResourceHandler(final Http.Context context)
+            public CompletionStage<Optional<DynamicResourceHandler>> getDynamicResourceHandler(final Http.RequestHeader requestHeader)
             {
                 return CompletableFuture.supplyAsync(() -> Optional.of(new TestDynamicResourceHandler((name, meta) -> true)));
             }
         };
-        final Content html = dynamicOrContent().render(context(),
-                                                       "foo",
+        final Content html = dynamicOrContent().render("foo",
                                                        Optional.of("bar"),
                                                        deadboltHandler);
         final String content = Helpers.contentAsString(html);
@@ -69,13 +68,12 @@ public class DynamicOrTest extends AbstractFakeApplicationTest
         final DeadboltHandler deadboltHandler = new NoPreAuthDeadboltHandler()
         {
             @Override
-            public CompletionStage<Optional<DynamicResourceHandler>> getDynamicResourceHandler(final Http.Context context)
+            public CompletionStage<Optional<DynamicResourceHandler>> getDynamicResourceHandler(final Http.RequestHeader requestHeader)
             {
                 return CompletableFuture.supplyAsync(() -> Optional.of(new TestDynamicResourceHandler((name, meta) -> "foo".equals(name))));
             }
         };
-        final Content html = dynamicOrContent().render(context(),
-                                                       "foo",
+        final Content html = dynamicOrContent().render("foo",
                                                        Optional.of("bar"),
                                                        deadboltHandler);
         final String content = Helpers.contentAsString(html);
@@ -91,13 +89,12 @@ public class DynamicOrTest extends AbstractFakeApplicationTest
         final DeadboltHandler deadboltHandler = new NoPreAuthDeadboltHandler()
         {
             @Override
-            public CompletionStage<Optional<DynamicResourceHandler>> getDynamicResourceHandler(final Http.Context context)
+            public CompletionStage<Optional<DynamicResourceHandler>> getDynamicResourceHandler(final Http.RequestHeader requestHeader)
             {
                 return CompletableFuture.supplyAsync(() -> Optional.of(new TestDynamicResourceHandler((name, meta) -> meta.map("bar"::equals).orElse(false))));
             }
         };
-        final Content html = dynamicOrContent().render(context(),
-                                                       "foo",
+        final Content html = dynamicOrContent().render("foo",
                                                        Optional.of("bar"),
                                                        deadboltHandler);
         final String content = Helpers.contentAsString(html);
@@ -113,13 +110,12 @@ public class DynamicOrTest extends AbstractFakeApplicationTest
         final DeadboltHandler deadboltHandler = new NoPreAuthDeadboltHandler()
         {
             @Override
-            public CompletionStage<Optional<DynamicResourceHandler>> getDynamicResourceHandler(final Http.Context context)
+            public CompletionStage<Optional<DynamicResourceHandler>> getDynamicResourceHandler(final Http.RequestHeader requestHeader)
             {
                 return CompletableFuture.supplyAsync(() -> Optional.of(new TestDynamicResourceHandler((name, meta) -> false)));
             }
         };
-        final Content html = dynamicOrContent().render(context(),
-                                                       "foo",
+        final Content html = dynamicOrContent().render("foo",
                                                        Optional.of("bar"),
                                                        deadboltHandler);
         final String content = Helpers.contentAsString(html);
@@ -154,7 +150,7 @@ public class DynamicOrTest extends AbstractFakeApplicationTest
         public CompletionStage<Boolean> isAllowed(final String name,
                                                   final Optional<String> meta,
                                                   final DeadboltHandler deadboltHandler,
-                                                  final Http.Context ctx)
+                                                  final Http.RequestHeader requestHeader)
         {
             return CompletableFuture.completedFuture(test.apply(name,
                                                                 meta));

--- a/code/test/be/objectify/deadbolt/java/views/di/dynamicTest/DynamicOrTest.java
+++ b/code/test/be/objectify/deadbolt/java/views/di/dynamicTest/DynamicOrTest.java
@@ -54,7 +54,7 @@ public class DynamicOrTest extends AbstractFakeApplicationTest
         };
         final Content html = dynamicOrContent().render("foo",
                                                        Optional.of("bar"),
-                                                       deadboltHandler);
+                                                       deadboltHandler, new Http.RequestBuilder().build());
         final String content = Helpers.contentAsString(html);
         Assert.assertTrue(content.contains("This is before the constraint."));
         Assert.assertTrue(content.contains("This is protected by the constraint."));
@@ -75,7 +75,7 @@ public class DynamicOrTest extends AbstractFakeApplicationTest
         };
         final Content html = dynamicOrContent().render("foo",
                                                        Optional.of("bar"),
-                                                       deadboltHandler);
+                                                       deadboltHandler, new Http.RequestBuilder().build());
         final String content = Helpers.contentAsString(html);
         Assert.assertTrue(content.contains("This is before the constraint."));
         Assert.assertTrue(content.contains("This is protected by the constraint."));
@@ -96,7 +96,7 @@ public class DynamicOrTest extends AbstractFakeApplicationTest
         };
         final Content html = dynamicOrContent().render("foo",
                                                        Optional.of("bar"),
-                                                       deadboltHandler);
+                                                       deadboltHandler, new Http.RequestBuilder().build());
         final String content = Helpers.contentAsString(html);
         Assert.assertTrue(content.contains("This is before the constraint."));
         Assert.assertTrue(content.contains("This is protected by the constraint."));
@@ -117,7 +117,7 @@ public class DynamicOrTest extends AbstractFakeApplicationTest
         };
         final Content html = dynamicOrContent().render("foo",
                                                        Optional.of("bar"),
-                                                       deadboltHandler);
+                                                       deadboltHandler, new Http.RequestBuilder().build());
         final String content = Helpers.contentAsString(html);
         Assert.assertTrue(content.contains("This is before the constraint."));
         Assert.assertFalse(content.contains("This is protected by the constraint."));

--- a/code/test/be/objectify/deadbolt/java/views/di/dynamicTest/DynamicTest.java
+++ b/code/test/be/objectify/deadbolt/java/views/di/dynamicTest/DynamicTest.java
@@ -63,7 +63,7 @@ public class DynamicTest extends AbstractFakeApplicationTest
         };
         final Content html = dynamicContent().render("foo",
                                                      Optional.of("bar"),
-                                                     deadboltHandler);
+                                                     deadboltHandler, new Http.RequestBuilder().build());
         final String content = Helpers.contentAsString(html);
         Assert.assertTrue(content.contains("This is before the constraint."));
         Assert.assertTrue(content.contains("This is protected by the constraint."));
@@ -93,7 +93,7 @@ public class DynamicTest extends AbstractFakeApplicationTest
         };
         final Content html = dynamicContent().render("foo",
                                                      Optional.of("bar"),
-                                                     deadboltHandler);
+                                                     deadboltHandler, new Http.RequestBuilder().build());
         final String content = Helpers.contentAsString(html);
         Assert.assertTrue(content.contains("This is before the constraint."));
         Assert.assertTrue(content.contains("This is protected by the constraint."));
@@ -123,7 +123,7 @@ public class DynamicTest extends AbstractFakeApplicationTest
         };
         final Content html = dynamicContent().render("foo",
                                                      Optional.of("bar"),
-                                                     deadboltHandler);
+                                                     deadboltHandler, new Http.RequestBuilder().build());
         final String content = Helpers.contentAsString(html);
         Assert.assertTrue(content.contains("This is before the constraint."));
         Assert.assertTrue(content.contains("This is protected by the constraint."));
@@ -153,7 +153,7 @@ public class DynamicTest extends AbstractFakeApplicationTest
         };
         final Content html = dynamicContent().render("foo",
                                                      Optional.of("bar"),
-                                                     deadboltHandler);
+                                                     deadboltHandler, new Http.RequestBuilder().build());
         final String content = Helpers.contentAsString(html);
         Assert.assertTrue(content.contains("This is before the constraint."));
         Assert.assertFalse(content.contains("This is protected by the constraint."));

--- a/code/test/be/objectify/deadbolt/java/views/di/dynamicTest/DynamicTest.java
+++ b/code/test/be/objectify/deadbolt/java/views/di/dynamicTest/DynamicTest.java
@@ -46,7 +46,7 @@ public class DynamicTest extends AbstractFakeApplicationTest
         final DeadboltHandler deadboltHandler = new NoPreAuthDeadboltHandler()
         {
             @Override
-            public CompletionStage<Optional<DynamicResourceHandler>> getDynamicResourceHandler(final Http.Context context)
+            public CompletionStage<Optional<DynamicResourceHandler>> getDynamicResourceHandler(final Http.RequestHeader requestHeader)
             {
                 return CompletableFuture.supplyAsync(() -> Optional.of(new AbstractDynamicResourceHandler()
                 {
@@ -54,15 +54,14 @@ public class DynamicTest extends AbstractFakeApplicationTest
                     public CompletionStage<Boolean> isAllowed(final String name,
                                                               final Optional<String> meta,
                                                               final DeadboltHandler deadboltHandler,
-                                                              final Http.Context ctx)
+                                                              final Http.RequestHeader rh)
                     {
                         return CompletableFuture.completedFuture(true);
                     }
                 }));
             }
         };
-        final Content html = dynamicContent().render(context(),
-                                                     "foo",
+        final Content html = dynamicContent().render("foo",
                                                      Optional.of("bar"),
                                                      deadboltHandler);
         final String content = Helpers.contentAsString(html);
@@ -77,7 +76,7 @@ public class DynamicTest extends AbstractFakeApplicationTest
         final DeadboltHandler deadboltHandler = new NoPreAuthDeadboltHandler()
         {
             @Override
-            public CompletionStage<Optional<DynamicResourceHandler>> getDynamicResourceHandler(final Http.Context context)
+            public CompletionStage<Optional<DynamicResourceHandler>> getDynamicResourceHandler(final Http.RequestHeader requestHeader)
             {
                 return CompletableFuture.supplyAsync(() -> Optional.of(new AbstractDynamicResourceHandler()
                 {
@@ -85,15 +84,14 @@ public class DynamicTest extends AbstractFakeApplicationTest
                     public CompletionStage<Boolean> isAllowed(final String name,
                                                               final Optional<String> meta,
                                                               final DeadboltHandler deadboltHandler,
-                                                              final Http.Context ctx)
+                                                              final Http.RequestHeader rh)
                     {
                         return CompletableFuture.completedFuture("foo".equals(name));
                     }
                 }));
             }
         };
-        final Content html = dynamicContent().render(context(),
-                                                     "foo",
+        final Content html = dynamicContent().render("foo",
                                                      Optional.of("bar"),
                                                      deadboltHandler);
         final String content = Helpers.contentAsString(html);
@@ -108,7 +106,7 @@ public class DynamicTest extends AbstractFakeApplicationTest
         final DeadboltHandler deadboltHandler = new NoPreAuthDeadboltHandler()
         {
             @Override
-            public CompletionStage<Optional<DynamicResourceHandler>> getDynamicResourceHandler(final Http.Context context)
+            public CompletionStage<Optional<DynamicResourceHandler>> getDynamicResourceHandler(final Http.RequestHeader requestHeader)
             {
                 return CompletableFuture.supplyAsync(() -> Optional.of(new AbstractDynamicResourceHandler()
                 {
@@ -116,15 +114,14 @@ public class DynamicTest extends AbstractFakeApplicationTest
                     public CompletionStage<Boolean> isAllowed(final String name,
                                                               final Optional<String> meta,
                                                               final DeadboltHandler deadboltHandler,
-                                                              final Http.Context ctx)
+                                                              final Http.RequestHeader rh)
                     {
                         return CompletableFuture.completedFuture(meta.map("bar"::equals).orElse(false));
                     }
                 }));
             }
         };
-        final Content html = dynamicContent().render(context(),
-                                                     "foo",
+        final Content html = dynamicContent().render("foo",
                                                      Optional.of("bar"),
                                                      deadboltHandler);
         final String content = Helpers.contentAsString(html);
@@ -139,7 +136,7 @@ public class DynamicTest extends AbstractFakeApplicationTest
         final DeadboltHandler deadboltHandler = new NoPreAuthDeadboltHandler()
         {
             @Override
-            public CompletionStage<Optional<DynamicResourceHandler>> getDynamicResourceHandler(final Http.Context context)
+            public CompletionStage<Optional<DynamicResourceHandler>> getDynamicResourceHandler(final Http.RequestHeader requestHeader)
             {
                 return CompletableFuture.supplyAsync(() -> Optional.of(new AbstractDynamicResourceHandler()
                 {
@@ -147,15 +144,14 @@ public class DynamicTest extends AbstractFakeApplicationTest
                     public CompletionStage<Boolean> isAllowed(final String name,
                                                               final Optional<String> meta,
                                                               final DeadboltHandler deadboltHandler,
-                                                              final Http.Context ctx)
+                                                              final Http.RequestHeader rh)
                     {
                         return CompletableFuture.completedFuture(false);
                     }
                 }));
             }
         };
-        final Content html = dynamicContent().render(context(),
-                                                     "foo",
+        final Content html = dynamicContent().render("foo",
                                                      Optional.of("bar"),
                                                      deadboltHandler);
         final String content = Helpers.contentAsString(html);

--- a/code/test/be/objectify/deadbolt/java/views/di/dynamicTest/dynamicContent.scala.html
+++ b/code/test/be/objectify/deadbolt/java/views/di/dynamicTest/dynamicContent.scala.html
@@ -1,9 +1,9 @@
 @this(dynamic: be.objectify.deadbolt.java.views.html.di.dynamic)
-@(ctx: Http.Context, name: String, meta: Optional[String] = Optional.empty(), deadboltHandler: be.objectify.deadbolt.java.DeadboltHandler)
+@(name: String, meta: Optional[String] = Optional.empty(), deadboltHandler: be.objectify.deadbolt.java.DeadboltHandler)
 
 This is before the constraint.
 
-@dynamic(context = ctx, name = name, meta = meta, handler = deadboltHandler) {
+@dynamic(name = name, meta = meta, handler = deadboltHandler) {
     This is protected by the constraint.
 }
 

--- a/code/test/be/objectify/deadbolt/java/views/di/dynamicTest/dynamicContent.scala.html
+++ b/code/test/be/objectify/deadbolt/java/views/di/dynamicTest/dynamicContent.scala.html
@@ -1,5 +1,5 @@
 @this(dynamic: be.objectify.deadbolt.java.views.html.di.dynamic)
-@(name: String, meta: Optional[String] = Optional.empty(), deadboltHandler: be.objectify.deadbolt.java.DeadboltHandler)
+@(name: String, meta: Optional[String] = Optional.empty(), deadboltHandler: be.objectify.deadbolt.java.DeadboltHandler)(implicit request: play.mvc.Http.Request)
 
 This is before the constraint.
 

--- a/code/test/be/objectify/deadbolt/java/views/di/dynamicTest/dynamicOrContent.scala.html
+++ b/code/test/be/objectify/deadbolt/java/views/di/dynamicTest/dynamicOrContent.scala.html
@@ -1,9 +1,9 @@
 @this(dynamicOr: be.objectify.deadbolt.java.views.html.di.dynamicOr)
-@(ctx: Http.Context, name: String, meta: Optional[String] = Optional.empty(), deadboltHandler: be.objectify.deadbolt.java.DeadboltHandler)
+@(name: String, meta: Optional[String] = Optional.empty(), deadboltHandler: be.objectify.deadbolt.java.DeadboltHandler)
 
 This is before the constraint.
 
-@dynamicOr(ctx, name, meta, handler = deadboltHandler) {
+@dynamicOr(name, meta, handler = deadboltHandler) {
     This is protected by the constraint.
 } {
     This is default content in case the constraint denies access to the protected content.

--- a/code/test/be/objectify/deadbolt/java/views/di/dynamicTest/dynamicOrContent.scala.html
+++ b/code/test/be/objectify/deadbolt/java/views/di/dynamicTest/dynamicOrContent.scala.html
@@ -1,5 +1,5 @@
 @this(dynamicOr: be.objectify.deadbolt.java.views.html.di.dynamicOr)
-@(name: String, meta: Optional[String] = Optional.empty(), deadboltHandler: be.objectify.deadbolt.java.DeadboltHandler)
+@(name: String, meta: Optional[String] = Optional.empty(), deadboltHandler: be.objectify.deadbolt.java.DeadboltHandler)(implicit request: play.mvc.Http.Request)
 
 This is before the constraint.
 

--- a/code/test/be/objectify/deadbolt/java/views/di/patternTest/PatternOrTest.java
+++ b/code/test/be/objectify/deadbolt/java/views/di/patternTest/PatternOrTest.java
@@ -50,15 +50,14 @@ public class PatternOrTest extends AbstractFakeApplicationTest
         final DeadboltHandler deadboltHandler = new NoPreAuthDeadboltHandler()
         {
             @Override
-            public CompletionStage<Optional<? extends Subject>> getSubject(final Http.Context context)
+            public CompletionStage<Optional<? extends Subject>> getSubject(final Http.RequestHeader requestHeader)
             {
                 return CompletableFuture.supplyAsync(() -> Optional.of(new TestSubject.Builder().permission(new TestPermission("killer.undead.zombie"))
                                                                                                 .build()));
             }
 
         };
-        final Content html = patternOrContent(deadboltHandler).render(context(),
-                                                                      "killer.undead.zombie",
+        final Content html = patternOrContent(deadboltHandler).render("killer.undead.zombie",
                                                                       PatternType.EQUALITY,
                                                                       deadboltHandler);
         final String content = Helpers.contentAsString(html);
@@ -74,15 +73,14 @@ public class PatternOrTest extends AbstractFakeApplicationTest
         final DeadboltHandler deadboltHandler = new NoPreAuthDeadboltHandler()
         {
             @Override
-            public CompletionStage<Optional<? extends Subject>> getSubject(final Http.Context context)
+            public CompletionStage<Optional<? extends Subject>> getSubject(final Http.RequestHeader requestHeader)
             {
                 return CompletableFuture.supplyAsync(() -> Optional.of(new TestSubject.Builder().permission(new TestPermission("killer.undead.vampire"))
                                                                                                 .build()));
             }
 
         };
-        final Content html = patternOrContent(deadboltHandler).render(context(),
-                                                                      "killer.undead.zombie",
+        final Content html = patternOrContent(deadboltHandler).render("killer.undead.zombie",
                                                                       PatternType.EQUALITY,
                                                                       deadboltHandler);
         final String content = Helpers.contentAsString(html);
@@ -98,14 +96,13 @@ public class PatternOrTest extends AbstractFakeApplicationTest
         final DeadboltHandler deadboltHandler = new NoPreAuthDeadboltHandler()
         {
             @Override
-            public CompletionStage<Optional<? extends Subject>> getSubject(final Http.Context context)
+            public CompletionStage<Optional<? extends Subject>> getSubject(final Http.RequestHeader requestHeader)
             {
                 return CompletableFuture.supplyAsync(() -> Optional.of(new TestSubject.Builder().build()));
             }
 
         };
-        final Content html = patternOrContent(deadboltHandler).render(context(),
-                                                                      "killer.undead.zombie",
+        final Content html = patternOrContent(deadboltHandler).render("killer.undead.zombie",
                                                                       PatternType.EQUALITY,
                                                                       deadboltHandler);
         final String content = Helpers.contentAsString(html);
@@ -118,8 +115,7 @@ public class PatternOrTest extends AbstractFakeApplicationTest
     @Test
     public void testEquality_noSubject()
     {
-        final Content html = patternOrContent(null).render(context(),
-                                                           "killer.undead.zombie",
+        final Content html = patternOrContent(null).render("killer.undead.zombie",
                                                            PatternType.EQUALITY,
                                                            new NoPreAuthDeadboltHandler()
                                                            {
@@ -137,15 +133,14 @@ public class PatternOrTest extends AbstractFakeApplicationTest
         final DeadboltHandler deadboltHandler = new NoPreAuthDeadboltHandler()
         {
             @Override
-            public CompletionStage<Optional<? extends Subject>> getSubject(final Http.Context context)
+            public CompletionStage<Optional<? extends Subject>> getSubject(final Http.RequestHeader requestHeader)
             {
                 return CompletableFuture.supplyAsync(() -> Optional.of(new TestSubject.Builder().permission(new TestPermission("killer.undead.zombie"))
                                                                                                 .build()));
             }
 
         };
-        final Content html = patternOrContent(deadboltHandler).render(context(),
-                                                                      "killer.undead.*",
+        final Content html = patternOrContent(deadboltHandler).render("killer.undead.*",
                                                                       PatternType.REGEX,
                                                                       deadboltHandler);
         final String content = Helpers.contentAsString(html);
@@ -161,15 +156,14 @@ public class PatternOrTest extends AbstractFakeApplicationTest
         final DeadboltHandler deadboltHandler = new NoPreAuthDeadboltHandler()
         {
             @Override
-            public CompletionStage<Optional<? extends Subject>> getSubject(final Http.Context context)
+            public CompletionStage<Optional<? extends Subject>> getSubject(final Http.RequestHeader requestHeader)
             {
                 return CompletableFuture.supplyAsync(() -> Optional.of(new TestSubject.Builder().permission(new TestPermission("killer.undead.zombie"))
                                                                                                 .build()));
             }
 
         };
-        final Content html = patternOrContent(deadboltHandler).render(context(),
-                                                                      "killer.*",
+        final Content html = patternOrContent(deadboltHandler).render("killer.*",
                                                                       PatternType.REGEX,
                                                                       deadboltHandler);
         final String content = Helpers.contentAsString(html);
@@ -185,15 +179,14 @@ public class PatternOrTest extends AbstractFakeApplicationTest
         final DeadboltHandler deadboltHandler = new NoPreAuthDeadboltHandler()
         {
             @Override
-            public CompletionStage<Optional<? extends Subject>> getSubject(final Http.Context context)
+            public CompletionStage<Optional<? extends Subject>> getSubject(final Http.RequestHeader requestHeader)
             {
                 return CompletableFuture.supplyAsync(() -> Optional.of(new TestSubject.Builder().permission(new TestPermission("killer.undead.vampire"))
                                                                                                 .build()));
             }
 
         };
-        final Content html = patternOrContent(deadboltHandler).render(context(),
-                                                                      "killer.pixies.*",
+        final Content html = patternOrContent(deadboltHandler).render("killer.pixies.*",
                                                                       PatternType.REGEX,
                                                                       deadboltHandler);
         final String content = Helpers.contentAsString(html);
@@ -209,14 +202,13 @@ public class PatternOrTest extends AbstractFakeApplicationTest
         final DeadboltHandler deadboltHandler = new NoPreAuthDeadboltHandler()
         {
             @Override
-            public CompletionStage<Optional<? extends Subject>> getSubject(final Http.Context context)
+            public CompletionStage<Optional<? extends Subject>> getSubject(final Http.RequestHeader requestHeader)
             {
                 return CompletableFuture.supplyAsync(() -> Optional.of(new TestSubject.Builder().build()));
             }
 
         };
-        final Content html = patternOrContent(deadboltHandler).render(context(),
-                                                                      "killer.undead.zombie",
+        final Content html = patternOrContent(deadboltHandler).render("killer.undead.zombie",
                                                                       PatternType.REGEX,
                                                                       deadboltHandler);
         final String content = Helpers.contentAsString(html);
@@ -229,8 +221,7 @@ public class PatternOrTest extends AbstractFakeApplicationTest
     @Test
     public void testRegex_noSubject()
     {
-        final Content html = patternOrContent(null).render(context(),
-                                                                      "killer.undead.zombie",
+        final Content html = patternOrContent(null).render("killer.undead.zombie",
                                                                       PatternType.REGEX,
                                                                       new NoPreAuthDeadboltHandler()
                                                                       {
@@ -248,7 +239,7 @@ public class PatternOrTest extends AbstractFakeApplicationTest
         final DeadboltHandler deadboltHandler = new NoPreAuthDeadboltHandler()
         {
             @Override
-            public CompletionStage<Optional<DynamicResourceHandler>> getDynamicResourceHandler(final Http.Context context)
+            public CompletionStage<Optional<DynamicResourceHandler>> getDynamicResourceHandler(final Http.RequestHeader requestHeader)
             {
                 return CompletableFuture.supplyAsync(() -> Optional.of(new AbstractDynamicResourceHandler()
                 {
@@ -256,15 +247,14 @@ public class PatternOrTest extends AbstractFakeApplicationTest
                     public CompletionStage<Boolean> checkPermission(final String permissionValue,
                                                                     final Optional<String> meta,
                                                                     final DeadboltHandler deadboltHandler,
-                                                                    final Http.Context ctx)
+                                                                    final Http.RequestHeader rh)
                     {
                         return CompletableFuture.completedFuture("killer.undead.zombie".equals(permissionValue));
                     }
                 }));
             }
         };
-        final Content html = patternOrContent(deadboltHandler).render(context(),
-                                                                      "killer.undead.zombie",
+        final Content html = patternOrContent(deadboltHandler).render("killer.undead.zombie",
                                                                       PatternType.CUSTOM,
                                                                       deadboltHandler);
         final String content = Helpers.contentAsString(html);
@@ -280,7 +270,7 @@ public class PatternOrTest extends AbstractFakeApplicationTest
         final DeadboltHandler deadboltHandler = new NoPreAuthDeadboltHandler()
         {
             @Override
-            public CompletionStage<Optional<DynamicResourceHandler>> getDynamicResourceHandler(final Http.Context context)
+            public CompletionStage<Optional<DynamicResourceHandler>> getDynamicResourceHandler(final Http.RequestHeader requestHeader)
             {
                 return CompletableFuture.supplyAsync(() -> Optional.of(new AbstractDynamicResourceHandler()
                 {
@@ -288,15 +278,14 @@ public class PatternOrTest extends AbstractFakeApplicationTest
                     public CompletionStage<Boolean> checkPermission(final String permissionValue,
                                                                     final Optional<String> meta,
                                                                     final DeadboltHandler deadboltHandler,
-                                                                    final Http.Context ctx)
+                                                                    final Http.RequestHeader rh)
                     {
                         return CompletableFuture.completedFuture(true);
                     }
                 }));
             }
         };
-        final Content html = patternOrContent(deadboltHandler).render(context(),
-                                                                      "killer.undead.zombie",
+        final Content html = patternOrContent(deadboltHandler).render("killer.undead.zombie",
                                                                       PatternType.CUSTOM,
                                                                       deadboltHandler);
         final String content = Helpers.contentAsString(html);
@@ -312,7 +301,7 @@ public class PatternOrTest extends AbstractFakeApplicationTest
         final DeadboltHandler deadboltHandler = new NoPreAuthDeadboltHandler()
         {
             @Override
-            public CompletionStage<Optional<DynamicResourceHandler>> getDynamicResourceHandler(final Http.Context context)
+            public CompletionStage<Optional<DynamicResourceHandler>> getDynamicResourceHandler(final Http.RequestHeader requestHeader)
             {
                 return CompletableFuture.supplyAsync(() -> Optional.of(new AbstractDynamicResourceHandler()
                 {
@@ -320,15 +309,14 @@ public class PatternOrTest extends AbstractFakeApplicationTest
                     public CompletionStage<Boolean> checkPermission(final String permissionValue,
                                                                     final Optional<String> meta,
                                                                     final DeadboltHandler deadboltHandler,
-                                                                    final Http.Context ctx)
+                                                                    final Http.RequestHeader rh)
                     {
                         return CompletableFuture.completedFuture(false);
                     }
                 }));
             }
         };
-        final Content html = patternOrContent(deadboltHandler).render(context(),
-                                                                      "killer.undead.zombie",
+        final Content html = patternOrContent(deadboltHandler).render("killer.undead.zombie",
                                                                       PatternType.CUSTOM,
                                                                       deadboltHandler);
         final String content = Helpers.contentAsString(html);

--- a/code/test/be/objectify/deadbolt/java/views/di/patternTest/PatternOrTest.java
+++ b/code/test/be/objectify/deadbolt/java/views/di/patternTest/PatternOrTest.java
@@ -59,7 +59,7 @@ public class PatternOrTest extends AbstractFakeApplicationTest
         };
         final Content html = patternOrContent(deadboltHandler).render("killer.undead.zombie",
                                                                       PatternType.EQUALITY,
-                                                                      deadboltHandler);
+                                                                      deadboltHandler, new Http.RequestBuilder().build());
         final String content = Helpers.contentAsString(html);
         Assert.assertTrue(content.contains("This is before the constraint."));
         Assert.assertTrue(content.contains("This is protected by the constraint."));
@@ -82,7 +82,7 @@ public class PatternOrTest extends AbstractFakeApplicationTest
         };
         final Content html = patternOrContent(deadboltHandler).render("killer.undead.zombie",
                                                                       PatternType.EQUALITY,
-                                                                      deadboltHandler);
+                                                                      deadboltHandler, new Http.RequestBuilder().build());
         final String content = Helpers.contentAsString(html);
         Assert.assertTrue(content.contains("This is before the constraint."));
         Assert.assertFalse(content.contains("This is protected by the constraint."));
@@ -104,7 +104,7 @@ public class PatternOrTest extends AbstractFakeApplicationTest
         };
         final Content html = patternOrContent(deadboltHandler).render("killer.undead.zombie",
                                                                       PatternType.EQUALITY,
-                                                                      deadboltHandler);
+                                                                      deadboltHandler, new Http.RequestBuilder().build());
         final String content = Helpers.contentAsString(html);
         Assert.assertTrue(content.contains("This is before the constraint."));
         Assert.assertFalse(content.contains("This is protected by the constraint."));
@@ -119,7 +119,8 @@ public class PatternOrTest extends AbstractFakeApplicationTest
                                                            PatternType.EQUALITY,
                                                            new NoPreAuthDeadboltHandler()
                                                            {
-                                                           });
+                                                           },
+                                                           new Http.RequestBuilder().build());
         final String content = Helpers.contentAsString(html);
         Assert.assertTrue(content.contains("This is before the constraint."));
         Assert.assertFalse(content.contains("This is protected by the constraint."));
@@ -142,7 +143,7 @@ public class PatternOrTest extends AbstractFakeApplicationTest
         };
         final Content html = patternOrContent(deadboltHandler).render("killer.undead.*",
                                                                       PatternType.REGEX,
-                                                                      deadboltHandler);
+                                                                      deadboltHandler, new Http.RequestBuilder().build());
         final String content = Helpers.contentAsString(html);
         Assert.assertTrue(content.contains("This is before the constraint."));
         Assert.assertTrue(content.contains("This is protected by the constraint."));
@@ -165,7 +166,7 @@ public class PatternOrTest extends AbstractFakeApplicationTest
         };
         final Content html = patternOrContent(deadboltHandler).render("killer.*",
                                                                       PatternType.REGEX,
-                                                                      deadboltHandler);
+                                                                      deadboltHandler, new Http.RequestBuilder().build());
         final String content = Helpers.contentAsString(html);
         Assert.assertTrue(content.contains("This is before the constraint."));
         Assert.assertTrue(content.contains("This is protected by the constraint."));
@@ -188,7 +189,7 @@ public class PatternOrTest extends AbstractFakeApplicationTest
         };
         final Content html = patternOrContent(deadboltHandler).render("killer.pixies.*",
                                                                       PatternType.REGEX,
-                                                                      deadboltHandler);
+                                                                      deadboltHandler, new Http.RequestBuilder().build());
         final String content = Helpers.contentAsString(html);
         Assert.assertTrue(content.contains("This is before the constraint."));
         Assert.assertFalse(content.contains("This is protected by the constraint."));
@@ -210,7 +211,7 @@ public class PatternOrTest extends AbstractFakeApplicationTest
         };
         final Content html = patternOrContent(deadboltHandler).render("killer.undead.zombie",
                                                                       PatternType.REGEX,
-                                                                      deadboltHandler);
+                                                                      deadboltHandler, new Http.RequestBuilder().build());
         final String content = Helpers.contentAsString(html);
         Assert.assertTrue(content.contains("This is before the constraint."));
         Assert.assertFalse(content.contains("This is protected by the constraint."));
@@ -225,7 +226,8 @@ public class PatternOrTest extends AbstractFakeApplicationTest
                                                                       PatternType.REGEX,
                                                                       new NoPreAuthDeadboltHandler()
                                                                       {
-                                                                      });
+                                                                      },
+                                                                      new Http.RequestBuilder().build());
         final String content = Helpers.contentAsString(html);
         Assert.assertTrue(content.contains("This is before the constraint."));
         Assert.assertFalse(content.contains("This is protected by the constraint."));
@@ -256,7 +258,7 @@ public class PatternOrTest extends AbstractFakeApplicationTest
         };
         final Content html = patternOrContent(deadboltHandler).render("killer.undead.zombie",
                                                                       PatternType.CUSTOM,
-                                                                      deadboltHandler);
+                                                                      deadboltHandler, new Http.RequestBuilder().build());
         final String content = Helpers.contentAsString(html);
         Assert.assertTrue(content.contains("This is before the constraint."));
         Assert.assertTrue(content.contains("This is protected by the constraint."));
@@ -287,7 +289,7 @@ public class PatternOrTest extends AbstractFakeApplicationTest
         };
         final Content html = patternOrContent(deadboltHandler).render("killer.undead.zombie",
                                                                       PatternType.CUSTOM,
-                                                                      deadboltHandler);
+                                                                      deadboltHandler, new Http.RequestBuilder().build());
         final String content = Helpers.contentAsString(html);
         Assert.assertTrue(content.contains("This is before the constraint."));
         Assert.assertTrue(content.contains("This is protected by the constraint."));
@@ -318,7 +320,7 @@ public class PatternOrTest extends AbstractFakeApplicationTest
         };
         final Content html = patternOrContent(deadboltHandler).render("killer.undead.zombie",
                                                                       PatternType.CUSTOM,
-                                                                      deadboltHandler);
+                                                                      deadboltHandler, new Http.RequestBuilder().build());
         final String content = Helpers.contentAsString(html);
         Assert.assertTrue(content.contains("This is before the constraint."));
         Assert.assertFalse(content.contains("This is protected by the constraint."));

--- a/code/test/be/objectify/deadbolt/java/views/di/patternTest/PatternTest.java
+++ b/code/test/be/objectify/deadbolt/java/views/di/patternTest/PatternTest.java
@@ -59,7 +59,7 @@ public class PatternTest extends AbstractFakeApplicationTest
         };
         final Content html = patternContent().render("killer.undead.zombie",
                                                      PatternType.EQUALITY,
-                                                     deadboltHandler);
+                                                     deadboltHandler, new Http.RequestBuilder().build());
         final String content = Helpers.contentAsString(html);
         Assert.assertTrue(content.contains("This is before the constraint."));
         Assert.assertTrue(content.contains("This is protected by the constraint."));
@@ -81,7 +81,7 @@ public class PatternTest extends AbstractFakeApplicationTest
         };
         final Content html = patternContent().render("killer.undead.zombie",
                                                      PatternType.EQUALITY,
-                                                     deadboltHandler);
+                                                     deadboltHandler, new Http.RequestBuilder().build());
         final String content = Helpers.contentAsString(html);
         Assert.assertTrue(content.contains("This is before the constraint."));
         Assert.assertFalse(content.contains("This is protected by the constraint."));
@@ -102,7 +102,7 @@ public class PatternTest extends AbstractFakeApplicationTest
         };
         final Content html = patternContent().render("killer.undead.zombie",
                                                      PatternType.EQUALITY,
-                                                     deadboltHandler);
+                                                     deadboltHandler, new Http.RequestBuilder().build());
         final String content = Helpers.contentAsString(html);
         Assert.assertTrue(content.contains("This is before the constraint."));
         Assert.assertFalse(content.contains("This is protected by the constraint."));
@@ -116,7 +116,8 @@ public class PatternTest extends AbstractFakeApplicationTest
                                                      PatternType.EQUALITY,
                                                      new NoPreAuthDeadboltHandler()
                                                      {
-                                                     });
+                                                     },
+                                                     new Http.RequestBuilder().build());
         final String content = Helpers.contentAsString(html);
         Assert.assertTrue(content.contains("This is before the constraint."));
         Assert.assertFalse(content.contains("This is protected by the constraint."));
@@ -138,7 +139,7 @@ public class PatternTest extends AbstractFakeApplicationTest
         };
         final Content html = patternContent().render("killer.undead.*",
                                                      PatternType.REGEX,
-                                                     deadboltHandler);
+                                                     deadboltHandler, new Http.RequestBuilder().build());
         final String content = Helpers.contentAsString(html);
         Assert.assertTrue(content.contains("This is before the constraint."));
         Assert.assertTrue(content.contains("This is protected by the constraint."));
@@ -160,7 +161,7 @@ public class PatternTest extends AbstractFakeApplicationTest
         };
         final Content html = patternContent().render("killer.*",
                                                      PatternType.REGEX,
-                                                     deadboltHandler);
+                                                     deadboltHandler, new Http.RequestBuilder().build());
         final String content = Helpers.contentAsString(html);
         Assert.assertTrue(content.contains("This is before the constraint."));
         Assert.assertTrue(content.contains("This is protected by the constraint."));
@@ -182,7 +183,7 @@ public class PatternTest extends AbstractFakeApplicationTest
         };
         final Content html = patternContent().render("killer.pixies.*",
                                                      PatternType.REGEX,
-                                                     deadboltHandler);
+                                                     deadboltHandler, new Http.RequestBuilder().build());
         final String content = Helpers.contentAsString(html);
         Assert.assertTrue(content.contains("This is before the constraint."));
         Assert.assertFalse(content.contains("This is protected by the constraint."));
@@ -203,7 +204,7 @@ public class PatternTest extends AbstractFakeApplicationTest
         };
         final Content html = patternContent().render("killer.undead.zombie",
                                                      PatternType.REGEX,
-                                                     deadboltHandler);
+                                                     deadboltHandler, new Http.RequestBuilder().build());
         final String content = Helpers.contentAsString(html);
         Assert.assertTrue(content.contains("This is before the constraint."));
         Assert.assertFalse(content.contains("This is protected by the constraint."));
@@ -217,7 +218,8 @@ public class PatternTest extends AbstractFakeApplicationTest
                                                      PatternType.REGEX,
                                                      new NoPreAuthDeadboltHandler()
                                                      {
-                                                     });
+                                                     },
+                                                     new Http.RequestBuilder().build());
         final String content = Helpers.contentAsString(html);
         Assert.assertTrue(content.contains("This is before the constraint."));
         Assert.assertFalse(content.contains("This is protected by the constraint."));
@@ -247,7 +249,7 @@ public class PatternTest extends AbstractFakeApplicationTest
         };
         final Content html = patternContent().render("killer.undead.zombie",
                                                      PatternType.CUSTOM,
-                                                     deadboltHandler);
+                                                     deadboltHandler, new Http.RequestBuilder().build());
         final String content = Helpers.contentAsString(html);
         Assert.assertTrue(content.contains("This is before the constraint."));
         Assert.assertTrue(content.contains("This is protected by the constraint."));
@@ -277,7 +279,7 @@ public class PatternTest extends AbstractFakeApplicationTest
         };
         final Content html = patternContent().render("killer.undead.zombie",
                                                      PatternType.CUSTOM,
-                                                     deadboltHandler);
+                                                     deadboltHandler, new Http.RequestBuilder().build());
         final String content = Helpers.contentAsString(html);
         Assert.assertTrue(content.contains("This is before the constraint."));
         Assert.assertTrue(content.contains("This is protected by the constraint."));
@@ -307,7 +309,7 @@ public class PatternTest extends AbstractFakeApplicationTest
         };
         final Content html = patternContent().render("killer.undead.zombie",
                                                      PatternType.CUSTOM,
-                                                     deadboltHandler);
+                                                     deadboltHandler, new Http.RequestBuilder().build());
         final String content = Helpers.contentAsString(html);
         Assert.assertTrue(content.contains("This is before the constraint."));
         Assert.assertFalse(content.contains("This is protected by the constraint."));

--- a/code/test/be/objectify/deadbolt/java/views/di/patternTest/PatternTest.java
+++ b/code/test/be/objectify/deadbolt/java/views/di/patternTest/PatternTest.java
@@ -50,15 +50,14 @@ public class PatternTest extends AbstractFakeApplicationTest
         final DeadboltHandler deadboltHandler = new NoPreAuthDeadboltHandler()
         {
             @Override
-            public CompletionStage<Optional<? extends Subject>> getSubject(final Http.Context context)
+            public CompletionStage<Optional<? extends Subject>> getSubject(final Http.RequestHeader requestHeader)
             {
                 return CompletableFuture.supplyAsync(() -> Optional.of(new TestSubject.Builder().permission(new TestPermission("killer.undead.zombie"))
                                                                                                 .build()));
             }
 
         };
-        final Content html = patternContent().render(context(),
-                                                     "killer.undead.zombie",
+        final Content html = patternContent().render("killer.undead.zombie",
                                                      PatternType.EQUALITY,
                                                      deadboltHandler);
         final String content = Helpers.contentAsString(html);
@@ -73,15 +72,14 @@ public class PatternTest extends AbstractFakeApplicationTest
         final DeadboltHandler deadboltHandler = new NoPreAuthDeadboltHandler()
         {
             @Override
-            public CompletionStage<Optional<? extends Subject>> getSubject(final Http.Context context)
+            public CompletionStage<Optional<? extends Subject>> getSubject(final Http.RequestHeader requestHeader)
             {
                 return CompletableFuture.supplyAsync(() -> Optional.of(new TestSubject.Builder().permission(new TestPermission("killer.undead.vampire"))
                                                                                                 .build()));
             }
 
         };
-        final Content html = patternContent().render(context(),
-                                                     "killer.undead.zombie",
+        final Content html = patternContent().render("killer.undead.zombie",
                                                      PatternType.EQUALITY,
                                                      deadboltHandler);
         final String content = Helpers.contentAsString(html);
@@ -96,14 +94,13 @@ public class PatternTest extends AbstractFakeApplicationTest
         final DeadboltHandler deadboltHandler = new NoPreAuthDeadboltHandler()
         {
             @Override
-            public CompletionStage<Optional<? extends Subject>> getSubject(final Http.Context context)
+            public CompletionStage<Optional<? extends Subject>> getSubject(final Http.RequestHeader requestHeader)
             {
                 return CompletableFuture.supplyAsync(() -> Optional.of(new TestSubject.Builder().build()));
             }
 
         };
-        final Content html = patternContent().render(context(),
-                                                     "killer.undead.zombie",
+        final Content html = patternContent().render("killer.undead.zombie",
                                                      PatternType.EQUALITY,
                                                      deadboltHandler);
         final String content = Helpers.contentAsString(html);
@@ -115,8 +112,7 @@ public class PatternTest extends AbstractFakeApplicationTest
     @Test
     public void testEquality_noSubject()
     {
-        final Content html = patternContent().render(context(),
-                                                     "killer.undead.zombie",
+        final Content html = patternContent().render("killer.undead.zombie",
                                                      PatternType.EQUALITY,
                                                      new NoPreAuthDeadboltHandler()
                                                      {
@@ -133,15 +129,14 @@ public class PatternTest extends AbstractFakeApplicationTest
         final DeadboltHandler deadboltHandler = new NoPreAuthDeadboltHandler()
         {
             @Override
-            public CompletionStage<Optional<? extends Subject>> getSubject(final Http.Context context)
+            public CompletionStage<Optional<? extends Subject>> getSubject(final Http.RequestHeader requestHeader)
             {
                 return CompletableFuture.supplyAsync(() -> Optional.of(new TestSubject.Builder().permission(new TestPermission("killer.undead.zombie"))
                                                                                                 .build()));
             }
 
         };
-        final Content html = patternContent().render(context(),
-                                                     "killer.undead.*",
+        final Content html = patternContent().render("killer.undead.*",
                                                      PatternType.REGEX,
                                                      deadboltHandler);
         final String content = Helpers.contentAsString(html);
@@ -156,15 +151,14 @@ public class PatternTest extends AbstractFakeApplicationTest
         final DeadboltHandler deadboltHandler = new NoPreAuthDeadboltHandler()
         {
             @Override
-            public CompletionStage<Optional<? extends Subject>> getSubject(final Http.Context context)
+            public CompletionStage<Optional<? extends Subject>> getSubject(final Http.RequestHeader requestHeader)
             {
                 return CompletableFuture.supplyAsync(() -> Optional.of(new TestSubject.Builder().permission(new TestPermission("killer.undead.zombie"))
                                                                                                 .build()));
             }
 
         };
-        final Content html = patternContent().render(context(),
-                                                     "killer.*",
+        final Content html = patternContent().render("killer.*",
                                                      PatternType.REGEX,
                                                      deadboltHandler);
         final String content = Helpers.contentAsString(html);
@@ -179,15 +173,14 @@ public class PatternTest extends AbstractFakeApplicationTest
         final DeadboltHandler deadboltHandler = new NoPreAuthDeadboltHandler()
         {
             @Override
-            public CompletionStage<Optional<? extends Subject>> getSubject(final Http.Context context)
+            public CompletionStage<Optional<? extends Subject>> getSubject(final Http.RequestHeader requestHeader)
             {
                 return CompletableFuture.supplyAsync(() -> Optional.of(new TestSubject.Builder().permission(new TestPermission("killer.undead.vampire"))
                                                                                                 .build()));
             }
 
         };
-        final Content html = patternContent().render(context(),
-                                                     "killer.pixies.*",
+        final Content html = patternContent().render("killer.pixies.*",
                                                      PatternType.REGEX,
                                                      deadboltHandler);
         final String content = Helpers.contentAsString(html);
@@ -202,14 +195,13 @@ public class PatternTest extends AbstractFakeApplicationTest
         final DeadboltHandler deadboltHandler = new NoPreAuthDeadboltHandler()
         {
             @Override
-            public CompletionStage<Optional<? extends Subject>> getSubject(final Http.Context context)
+            public CompletionStage<Optional<? extends Subject>> getSubject(final Http.RequestHeader requestHeader)
             {
                 return CompletableFuture.supplyAsync(() -> Optional.of(new TestSubject.Builder().build()));
             }
 
         };
-        final Content html = patternContent().render(context(),
-                                                     "killer.undead.zombie",
+        final Content html = patternContent().render("killer.undead.zombie",
                                                      PatternType.REGEX,
                                                      deadboltHandler);
         final String content = Helpers.contentAsString(html);
@@ -221,8 +213,7 @@ public class PatternTest extends AbstractFakeApplicationTest
     @Test
     public void testRegex_noSubject()
     {
-        final Content html = patternContent().render(context(),
-                                                     "killer.undead.zombie",
+        final Content html = patternContent().render("killer.undead.zombie",
                                                      PatternType.REGEX,
                                                      new NoPreAuthDeadboltHandler()
                                                      {
@@ -239,7 +230,7 @@ public class PatternTest extends AbstractFakeApplicationTest
         final DeadboltHandler deadboltHandler = new NoPreAuthDeadboltHandler()
         {
             @Override
-            public CompletionStage<Optional<DynamicResourceHandler>> getDynamicResourceHandler(final Http.Context context)
+            public CompletionStage<Optional<DynamicResourceHandler>> getDynamicResourceHandler(final Http.RequestHeader requestHeader)
             {
                 return CompletableFuture.supplyAsync(() -> Optional.of(new AbstractDynamicResourceHandler()
                 {
@@ -247,15 +238,14 @@ public class PatternTest extends AbstractFakeApplicationTest
                     public CompletionStage<Boolean> checkPermission(final String permissionValue,
                                                                     final Optional<String> meta,
                                                                     final DeadboltHandler deadboltHandler,
-                                                                    final Http.Context ctx)
+                                                                    final Http.RequestHeader rh)
                     {
                         return CompletableFuture.completedFuture("killer.undead.zombie".equals(permissionValue));
                     }
                 }));
             }
         };
-        final Content html = patternContent().render(context(),
-                                                     "killer.undead.zombie",
+        final Content html = patternContent().render("killer.undead.zombie",
                                                      PatternType.CUSTOM,
                                                      deadboltHandler);
         final String content = Helpers.contentAsString(html);
@@ -270,7 +260,7 @@ public class PatternTest extends AbstractFakeApplicationTest
         final DeadboltHandler deadboltHandler = new NoPreAuthDeadboltHandler()
         {
             @Override
-            public CompletionStage<Optional<DynamicResourceHandler>> getDynamicResourceHandler(final Http.Context context)
+            public CompletionStage<Optional<DynamicResourceHandler>> getDynamicResourceHandler(final Http.RequestHeader requestHeader)
             {
                 return CompletableFuture.supplyAsync(() -> Optional.of(new AbstractDynamicResourceHandler()
                 {
@@ -278,15 +268,14 @@ public class PatternTest extends AbstractFakeApplicationTest
                     public CompletionStage<Boolean> checkPermission(final String permissionValue,
                                                                     final Optional<String> meta,
                                                                     final DeadboltHandler deadboltHandler,
-                                                                    final Http.Context ctx)
+                                                                    final Http.RequestHeader rh)
                     {
                         return CompletableFuture.completedFuture(true);
                     }
                 }));
             }
         };
-        final Content html = patternContent().render(context(),
-                                                     "killer.undead.zombie",
+        final Content html = patternContent().render("killer.undead.zombie",
                                                      PatternType.CUSTOM,
                                                      deadboltHandler);
         final String content = Helpers.contentAsString(html);
@@ -301,7 +290,7 @@ public class PatternTest extends AbstractFakeApplicationTest
         final DeadboltHandler deadboltHandler = new NoPreAuthDeadboltHandler()
         {
             @Override
-            public CompletionStage<Optional<DynamicResourceHandler>> getDynamicResourceHandler(final Http.Context context)
+            public CompletionStage<Optional<DynamicResourceHandler>> getDynamicResourceHandler(final Http.RequestHeader requestHeader)
             {
                 return CompletableFuture.supplyAsync(() -> Optional.of(new AbstractDynamicResourceHandler()
                 {
@@ -309,15 +298,14 @@ public class PatternTest extends AbstractFakeApplicationTest
                     public CompletionStage<Boolean> checkPermission(final String permissionValue,
                                                                     final Optional<String> meta,
                                                                     final DeadboltHandler deadboltHandler,
-                                                                    final Http.Context ctx)
+                                                                    final Http.RequestHeader rh)
                     {
                         return CompletableFuture.completedFuture(false);
                     }
                 }));
             }
         };
-        final Content html = patternContent().render(context(),
-                                                     "killer.undead.zombie",
+        final Content html = patternContent().render("killer.undead.zombie",
                                                      PatternType.CUSTOM,
                                                      deadboltHandler);
         final String content = Helpers.contentAsString(html);

--- a/code/test/be/objectify/deadbolt/java/views/di/patternTest/patternContent.scala.html
+++ b/code/test/be/objectify/deadbolt/java/views/di/patternTest/patternContent.scala.html
@@ -1,9 +1,9 @@
 @this(pattern: be.objectify.deadbolt.java.views.html.di.pattern)
-@(ctx: Http.Context, value: String, patternType: be.objectify.deadbolt.java.models.PatternType, deadboltHandler: be.objectify.deadbolt.java.DeadboltHandler)
+@(value: String, patternType: be.objectify.deadbolt.java.models.PatternType, deadboltHandler: be.objectify.deadbolt.java.DeadboltHandler)
 
 This is before the constraint.
 
-@pattern(context = ctx, value = value, patternType = patternType, handler = deadboltHandler) {
+@pattern(value = value, patternType = patternType, handler = deadboltHandler) {
     This is protected by the constraint.
 }
 

--- a/code/test/be/objectify/deadbolt/java/views/di/patternTest/patternContent.scala.html
+++ b/code/test/be/objectify/deadbolt/java/views/di/patternTest/patternContent.scala.html
@@ -1,5 +1,5 @@
 @this(pattern: be.objectify.deadbolt.java.views.html.di.pattern)
-@(value: String, patternType: be.objectify.deadbolt.java.models.PatternType, deadboltHandler: be.objectify.deadbolt.java.DeadboltHandler)
+@(value: String, patternType: be.objectify.deadbolt.java.models.PatternType, deadboltHandler: be.objectify.deadbolt.java.DeadboltHandler)(implicit request: play.mvc.Http.Request)
 
 This is before the constraint.
 

--- a/code/test/be/objectify/deadbolt/java/views/di/patternTest/patternOrContent.scala.html
+++ b/code/test/be/objectify/deadbolt/java/views/di/patternTest/patternOrContent.scala.html
@@ -1,9 +1,9 @@
 @this(patternOr: be.objectify.deadbolt.java.views.html.di.patternOr)
-@(ctx: Http.Context, value: String, patternType: be.objectify.deadbolt.java.models.PatternType, deadboltHandler: be.objectify.deadbolt.java.DeadboltHandler)
+@(value: String, patternType: be.objectify.deadbolt.java.models.PatternType, deadboltHandler: be.objectify.deadbolt.java.DeadboltHandler)
 
 This is before the constraint.
 
-@patternOr(context = ctx, value = value, patternType = patternType, handler = deadboltHandler) {
+@patternOr(value = value, patternType = patternType, handler = deadboltHandler) {
     This is protected by the constraint.
 } {
     This is default content in case the constraint denies access to the protected content.

--- a/code/test/be/objectify/deadbolt/java/views/di/patternTest/patternOrContent.scala.html
+++ b/code/test/be/objectify/deadbolt/java/views/di/patternTest/patternOrContent.scala.html
@@ -1,5 +1,5 @@
 @this(patternOr: be.objectify.deadbolt.java.views.html.di.patternOr)
-@(value: String, patternType: be.objectify.deadbolt.java.models.PatternType, deadboltHandler: be.objectify.deadbolt.java.DeadboltHandler)
+@(value: String, patternType: be.objectify.deadbolt.java.models.PatternType, deadboltHandler: be.objectify.deadbolt.java.DeadboltHandler)(implicit request: play.mvc.Http.Request)
 
 This is before the constraint.
 

--- a/code/test/be/objectify/deadbolt/java/views/di/rbpTest/RoleBasedPermissionsOrTest.java
+++ b/code/test/be/objectify/deadbolt/java/views/di/rbpTest/RoleBasedPermissionsOrTest.java
@@ -50,7 +50,7 @@ public class RoleBasedPermissionsOrTest extends AbstractFakeApplicationTest
         final DeadboltHandler deadboltHandler = new NoPreAuthDeadboltHandler()
         {
             @Override
-            public CompletionStage<Optional<? extends Subject>> getSubject(final Http.Context context)
+            public CompletionStage<Optional<? extends Subject>> getSubject(final Http.RequestHeader requestHeader)
             {
                 return CompletableFuture.supplyAsync(() -> Optional.of(new TestSubject.Builder().permission(new TestPermission("bar"))
                                                                                                 .build()));
@@ -62,8 +62,7 @@ public class RoleBasedPermissionsOrTest extends AbstractFakeApplicationTest
                 return CompletableFuture.completedFuture(Collections.emptyList());
             }
         };
-        final Content html = roleBasedPermissionsOrContent().render(context(),
-                                                                    "foo",
+        final Content html = roleBasedPermissionsOrContent().render("foo",
                                                                     deadboltHandler);
         final String content = Helpers.contentAsString(html);
         Assert.assertTrue(content.contains("This is before the constraint."));
@@ -78,7 +77,7 @@ public class RoleBasedPermissionsOrTest extends AbstractFakeApplicationTest
         final DeadboltHandler deadboltHandler = new NoPreAuthDeadboltHandler()
         {
             @Override
-            public CompletionStage<Optional<? extends Subject>> getSubject(final Http.Context context)
+            public CompletionStage<Optional<? extends Subject>> getSubject(final Http.RequestHeader requestHeader)
             {
                 return CompletableFuture.supplyAsync(() -> Optional.of(new TestSubject.Builder().permission(new TestPermission("bar"))
                                                                                                 .build()));
@@ -90,8 +89,7 @@ public class RoleBasedPermissionsOrTest extends AbstractFakeApplicationTest
                 return CompletableFuture.completedFuture(Collections.singletonList(new TestPermission("bar")));
             }
         };
-        final Content html = roleBasedPermissionsOrContent().render(context(),
-                                                                    "foo",
+        final Content html = roleBasedPermissionsOrContent().render("foo",
                                                                     deadboltHandler);
         final String content = Helpers.contentAsString(html);
         Assert.assertTrue(content.contains("This is before the constraint."));
@@ -106,7 +104,7 @@ public class RoleBasedPermissionsOrTest extends AbstractFakeApplicationTest
         final DeadboltHandler deadboltHandler = new NoPreAuthDeadboltHandler()
         {
             @Override
-            public CompletionStage<Optional<? extends Subject>> getSubject(final Http.Context context)
+            public CompletionStage<Optional<? extends Subject>> getSubject(final Http.RequestHeader requestHeader)
             {
                 return CompletableFuture.supplyAsync(() -> Optional.of(new TestSubject.Builder().permission(new TestPermission("bar"))
                                                                                                 .build()));
@@ -118,8 +116,7 @@ public class RoleBasedPermissionsOrTest extends AbstractFakeApplicationTest
                 return CompletableFuture.completedFuture(Collections.singletonList(new TestPermission("hurdy")));
             }
         };
-        final Content html = roleBasedPermissionsOrContent().render(context(),
-                                                                    "foo",
+        final Content html = roleBasedPermissionsOrContent().render("foo",
                                                                     deadboltHandler);
         final String content = Helpers.contentAsString(html);
         Assert.assertTrue(content.contains("This is before the constraint."));
@@ -134,7 +131,7 @@ public class RoleBasedPermissionsOrTest extends AbstractFakeApplicationTest
         final DeadboltHandler deadboltHandler = new NoPreAuthDeadboltHandler()
         {
             @Override
-            public CompletionStage<Optional<? extends Subject>> getSubject(final Http.Context context)
+            public CompletionStage<Optional<? extends Subject>> getSubject(final Http.RequestHeader requestHeader)
             {
                 return CompletableFuture.completedFuture(Optional.empty());
             }
@@ -145,8 +142,7 @@ public class RoleBasedPermissionsOrTest extends AbstractFakeApplicationTest
                 return CompletableFuture.completedFuture(Collections.singletonList(new TestPermission("hurdy")));
             }
         };
-        final Content html = roleBasedPermissionsOrContent().render(context(),
-                                                                    "foo",
+        final Content html = roleBasedPermissionsOrContent().render("foo",
                                                                     deadboltHandler);
         final String content = Helpers.contentAsString(html);
         Assert.assertTrue(content.contains("This is before the constraint."));

--- a/code/test/be/objectify/deadbolt/java/views/di/rbpTest/RoleBasedPermissionsOrTest.java
+++ b/code/test/be/objectify/deadbolt/java/views/di/rbpTest/RoleBasedPermissionsOrTest.java
@@ -63,7 +63,7 @@ public class RoleBasedPermissionsOrTest extends AbstractFakeApplicationTest
             }
         };
         final Content html = roleBasedPermissionsOrContent().render("foo",
-                                                                    deadboltHandler);
+                                                                    deadboltHandler, new Http.RequestBuilder().build());
         final String content = Helpers.contentAsString(html);
         Assert.assertTrue(content.contains("This is before the constraint."));
         Assert.assertFalse(content.contains("This is protected by the constraint."));
@@ -90,7 +90,7 @@ public class RoleBasedPermissionsOrTest extends AbstractFakeApplicationTest
             }
         };
         final Content html = roleBasedPermissionsOrContent().render("foo",
-                                                                    deadboltHandler);
+                                                                    deadboltHandler, new Http.RequestBuilder().build());
         final String content = Helpers.contentAsString(html);
         Assert.assertTrue(content.contains("This is before the constraint."));
         Assert.assertTrue(content.contains("This is protected by the constraint."));
@@ -117,7 +117,7 @@ public class RoleBasedPermissionsOrTest extends AbstractFakeApplicationTest
             }
         };
         final Content html = roleBasedPermissionsOrContent().render("foo",
-                                                                    deadboltHandler);
+                                                                    deadboltHandler, new Http.RequestBuilder().build());
         final String content = Helpers.contentAsString(html);
         Assert.assertTrue(content.contains("This is before the constraint."));
         Assert.assertFalse(content.contains("This is protected by the constraint."));
@@ -143,7 +143,7 @@ public class RoleBasedPermissionsOrTest extends AbstractFakeApplicationTest
             }
         };
         final Content html = roleBasedPermissionsOrContent().render("foo",
-                                                                    deadboltHandler);
+                                                                    deadboltHandler, new Http.RequestBuilder().build());
         final String content = Helpers.contentAsString(html);
         Assert.assertTrue(content.contains("This is before the constraint."));
         Assert.assertFalse(content.contains("This is protected by the constraint."));

--- a/code/test/be/objectify/deadbolt/java/views/di/rbpTest/RoleBasedPermissionsTest.java
+++ b/code/test/be/objectify/deadbolt/java/views/di/rbpTest/RoleBasedPermissionsTest.java
@@ -63,7 +63,7 @@ public class RoleBasedPermissionsTest extends AbstractFakeApplicationTest
             }
         };
         final Content html = roleBasedPermissionsContent().render("foo",
-                                                                  deadboltHandler);
+                                                                  deadboltHandler, new Http.RequestBuilder().build());
         final String content = Helpers.contentAsString(html);
         Assert.assertTrue(content.contains("This is before the constraint."));
         Assert.assertFalse(content.contains("This is protected by the constraint."));
@@ -89,7 +89,7 @@ public class RoleBasedPermissionsTest extends AbstractFakeApplicationTest
             }
         };
         final Content html = roleBasedPermissionsContent().render("foo",
-                                                                  deadboltHandler);
+                                                                  deadboltHandler, new Http.RequestBuilder().build());
         final String content = Helpers.contentAsString(html);
         Assert.assertTrue(content.contains("This is before the constraint."));
         Assert.assertTrue(content.contains("This is protected by the constraint."));
@@ -115,7 +115,7 @@ public class RoleBasedPermissionsTest extends AbstractFakeApplicationTest
             }
         };
         final Content html = roleBasedPermissionsContent().render("foo",
-                                                                  deadboltHandler);
+                                                                  deadboltHandler, new Http.RequestBuilder().build());
         final String content = Helpers.contentAsString(html);
         Assert.assertTrue(content.contains("This is before the constraint."));
         Assert.assertFalse(content.contains("This is protected by the constraint."));
@@ -140,7 +140,7 @@ public class RoleBasedPermissionsTest extends AbstractFakeApplicationTest
             }
         };
         final Content html = roleBasedPermissionsContent().render("foo",
-                                                                  deadboltHandler);
+                                                                  deadboltHandler, new Http.RequestBuilder().build());
         final String content = Helpers.contentAsString(html);
         Assert.assertTrue(content.contains("This is before the constraint."));
         Assert.assertFalse(content.contains("This is protected by the constraint."));

--- a/code/test/be/objectify/deadbolt/java/views/di/rbpTest/RoleBasedPermissionsTest.java
+++ b/code/test/be/objectify/deadbolt/java/views/di/rbpTest/RoleBasedPermissionsTest.java
@@ -50,7 +50,7 @@ public class RoleBasedPermissionsTest extends AbstractFakeApplicationTest
         final DeadboltHandler deadboltHandler = new NoPreAuthDeadboltHandler()
         {
             @Override
-            public CompletionStage<Optional<? extends Subject>> getSubject(final Http.Context context)
+            public CompletionStage<Optional<? extends Subject>> getSubject(final Http.RequestHeader requestHeader)
             {
                 return CompletableFuture.supplyAsync(() -> Optional.of(new TestSubject.Builder().permission(new TestPermission("bar"))
                                                                                                 .build()));
@@ -62,8 +62,7 @@ public class RoleBasedPermissionsTest extends AbstractFakeApplicationTest
                 return CompletableFuture.completedFuture(Collections.emptyList());
             }
         };
-        final Content html = roleBasedPermissionsContent().render(context(),
-                                                                  "foo",
+        final Content html = roleBasedPermissionsContent().render("foo",
                                                                   deadboltHandler);
         final String content = Helpers.contentAsString(html);
         Assert.assertTrue(content.contains("This is before the constraint."));
@@ -77,7 +76,7 @@ public class RoleBasedPermissionsTest extends AbstractFakeApplicationTest
         final DeadboltHandler deadboltHandler = new NoPreAuthDeadboltHandler()
         {
             @Override
-            public CompletionStage<Optional<? extends Subject>> getSubject(final Http.Context context)
+            public CompletionStage<Optional<? extends Subject>> getSubject(final Http.RequestHeader requestHeader)
             {
                 return CompletableFuture.supplyAsync(() -> Optional.of(new TestSubject.Builder().permission(new TestPermission("bar"))
                                                                                                 .build()));
@@ -89,8 +88,7 @@ public class RoleBasedPermissionsTest extends AbstractFakeApplicationTest
                 return CompletableFuture.completedFuture(Collections.singletonList(new TestPermission("bar")));
             }
         };
-        final Content html = roleBasedPermissionsContent().render(context(),
-                                                                  "foo",
+        final Content html = roleBasedPermissionsContent().render("foo",
                                                                   deadboltHandler);
         final String content = Helpers.contentAsString(html);
         Assert.assertTrue(content.contains("This is before the constraint."));
@@ -104,7 +102,7 @@ public class RoleBasedPermissionsTest extends AbstractFakeApplicationTest
         final DeadboltHandler deadboltHandler = new NoPreAuthDeadboltHandler()
         {
             @Override
-            public CompletionStage<Optional<? extends Subject>> getSubject(final Http.Context context)
+            public CompletionStage<Optional<? extends Subject>> getSubject(final Http.RequestHeader requestHeader)
             {
                 return CompletableFuture.supplyAsync(() -> Optional.of(new TestSubject.Builder().permission(new TestPermission("bar"))
                                                                                                 .build()));
@@ -116,8 +114,7 @@ public class RoleBasedPermissionsTest extends AbstractFakeApplicationTest
                 return CompletableFuture.completedFuture(Collections.singletonList(new TestPermission("hurdy")));
             }
         };
-        final Content html = roleBasedPermissionsContent().render(context(),
-                                                                  "foo",
+        final Content html = roleBasedPermissionsContent().render("foo",
                                                                   deadboltHandler);
         final String content = Helpers.contentAsString(html);
         Assert.assertTrue(content.contains("This is before the constraint."));
@@ -131,7 +128,7 @@ public class RoleBasedPermissionsTest extends AbstractFakeApplicationTest
         final DeadboltHandler deadboltHandler = new NoPreAuthDeadboltHandler()
         {
             @Override
-            public CompletionStage<Optional<? extends Subject>> getSubject(final Http.Context context)
+            public CompletionStage<Optional<? extends Subject>> getSubject(final Http.RequestHeader requestHeader)
             {
                 return CompletableFuture.completedFuture(Optional.empty());
             }
@@ -142,8 +139,7 @@ public class RoleBasedPermissionsTest extends AbstractFakeApplicationTest
                 return CompletableFuture.completedFuture(Collections.singletonList(new TestPermission("hurdy")));
             }
         };
-        final Content html = roleBasedPermissionsContent().render(context(),
-                                                                  "foo",
+        final Content html = roleBasedPermissionsContent().render("foo",
                                                                   deadboltHandler);
         final String content = Helpers.contentAsString(html);
         Assert.assertTrue(content.contains("This is before the constraint."));

--- a/code/test/be/objectify/deadbolt/java/views/di/rbpTest/roleBasedPermissionsContent.scala.html
+++ b/code/test/be/objectify/deadbolt/java/views/di/rbpTest/roleBasedPermissionsContent.scala.html
@@ -1,9 +1,9 @@
 @this(rbp: be.objectify.deadbolt.java.views.html.di.roleBasedPermissions)
-@(ctx: Http.Context, roleName: String, deadboltHandler: be.objectify.deadbolt.java.DeadboltHandler)
+@(roleName: String, deadboltHandler: be.objectify.deadbolt.java.DeadboltHandler)
 
 This is before the constraint.
 
-@rbp(context = ctx, roleName = roleName, handler = deadboltHandler) {
+@rbp(roleName = roleName, handler = deadboltHandler) {
     This is protected by the constraint.
 }
 

--- a/code/test/be/objectify/deadbolt/java/views/di/rbpTest/roleBasedPermissionsContent.scala.html
+++ b/code/test/be/objectify/deadbolt/java/views/di/rbpTest/roleBasedPermissionsContent.scala.html
@@ -1,5 +1,5 @@
 @this(rbp: be.objectify.deadbolt.java.views.html.di.roleBasedPermissions)
-@(roleName: String, deadboltHandler: be.objectify.deadbolt.java.DeadboltHandler)
+@(roleName: String, deadboltHandler: be.objectify.deadbolt.java.DeadboltHandler)(implicit request: play.mvc.Http.Request)
 
 This is before the constraint.
 

--- a/code/test/be/objectify/deadbolt/java/views/di/rbpTest/roleBasedPermissionsOrContent.scala.html
+++ b/code/test/be/objectify/deadbolt/java/views/di/rbpTest/roleBasedPermissionsOrContent.scala.html
@@ -1,5 +1,5 @@
 @this(rbp: be.objectify.deadbolt.java.views.html.di.roleBasedPermissionsOr)
-@(roleName: String, deadboltHandler: be.objectify.deadbolt.java.DeadboltHandler)
+@(roleName: String, deadboltHandler: be.objectify.deadbolt.java.DeadboltHandler)(implicit request: play.mvc.Http.Request)
 
 This is before the constraint.
 

--- a/code/test/be/objectify/deadbolt/java/views/di/rbpTest/roleBasedPermissionsOrContent.scala.html
+++ b/code/test/be/objectify/deadbolt/java/views/di/rbpTest/roleBasedPermissionsOrContent.scala.html
@@ -1,9 +1,9 @@
 @this(rbp: be.objectify.deadbolt.java.views.html.di.roleBasedPermissionsOr)
-@(ctx: Http.Context, roleName: String, deadboltHandler: be.objectify.deadbolt.java.DeadboltHandler)
+@(roleName: String, deadboltHandler: be.objectify.deadbolt.java.DeadboltHandler)
 
 This is before the constraint.
 
-@rbp(context = ctx, roleName = roleName, handler = deadboltHandler) {
+@rbp(roleName = roleName, handler = deadboltHandler) {
     This is protected by the constraint.
 } {
     This is default content in case the constraint denies access to the protected content.

--- a/code/test/be/objectify/deadbolt/java/views/di/restrictTest/RestrictOrTest.java
+++ b/code/test/be/objectify/deadbolt/java/views/di/restrictTest/RestrictOrTest.java
@@ -50,14 +50,13 @@ public class RestrictOrTest extends AbstractFakeApplicationTest
         final DeadboltHandler deadboltHandler = new NoPreAuthDeadboltHandler()
         {
             @Override
-            public CompletionStage<Optional<? extends Subject>> getSubject(final Http.Context context)
+            public CompletionStage<Optional<? extends Subject>> getSubject(final Http.RequestHeader requestHeader)
             {
                 return CompletableFuture.supplyAsync(() -> Optional.of(new TestSubject.Builder().role(new TestRole("foo"))
                                                                                                 .build()));
             }
         };
-        final Content html = restrictOrContent().render(context(),
-                                                        Collections.singletonList(new String[]{"foo"}),
+        final Content html = restrictOrContent().render(Collections.singletonList(new String[]{"foo"}),
                                                         deadboltHandler);
         final String content = Helpers.contentAsString(html);
         Assert.assertTrue(content.contains("This is before the constraint."));
@@ -72,14 +71,13 @@ public class RestrictOrTest extends AbstractFakeApplicationTest
         final DeadboltHandler deadboltHandler = new NoPreAuthDeadboltHandler()
         {
             @Override
-            public CompletionStage<Optional<? extends Subject>> getSubject(final Http.Context context)
+            public CompletionStage<Optional<? extends Subject>> getSubject(final Http.RequestHeader requestHeader)
             {
                 return CompletableFuture.supplyAsync(() -> Optional.of(new TestSubject.Builder().role(new TestRole("bar"))
                                                                                                 .build()));
             }
         };
-        final Content html = restrictOrContent().render(context(),
-                                                        Collections.singletonList(new String[]{"foo"}),
+        final Content html = restrictOrContent().render(Collections.singletonList(new String[]{"foo"}),
                                                         deadboltHandler);
         final String content = Helpers.contentAsString(html);
         Assert.assertTrue(content.contains("This is before the constraint."));
@@ -94,13 +92,12 @@ public class RestrictOrTest extends AbstractFakeApplicationTest
         final DeadboltHandler deadboltHandler = new NoPreAuthDeadboltHandler()
         {
             @Override
-            public CompletionStage<Optional<? extends Subject>> getSubject(final Http.Context context)
+            public CompletionStage<Optional<? extends Subject>> getSubject(final Http.RequestHeader requestHeader)
             {
                 return CompletableFuture.supplyAsync(() -> Optional.of(new TestSubject.Builder().build()));
             }
         };
-        final Content html = restrictOrContent().render(context(),
-                                                        Collections.singletonList(new String[]{"foo"}),
+        final Content html = restrictOrContent().render(Collections.singletonList(new String[]{"foo"}),
                                                         deadboltHandler);
         final String content = Helpers.contentAsString(html);
         Assert.assertTrue(content.contains("This is before the constraint."));
@@ -115,13 +112,12 @@ public class RestrictOrTest extends AbstractFakeApplicationTest
         final DeadboltHandler deadboltHandler = new NoPreAuthDeadboltHandler()
         {
             @Override
-            public CompletionStage<Optional<? extends Subject>> getSubject(final Http.Context context)
+            public CompletionStage<Optional<? extends Subject>> getSubject(final Http.RequestHeader requestHeader)
             {
                 return CompletableFuture.supplyAsync(Optional::empty);
             }
         };
-        final Content html = restrictOrContent().render(context(),
-                                                        Collections.singletonList(new String[]{"foo"}),
+        final Content html = restrictOrContent().render(Collections.singletonList(new String[]{"foo"}),
                                                         deadboltHandler);
         final String content = Helpers.contentAsString(html);
         Assert.assertTrue(content.contains("This is before the constraint."));
@@ -136,14 +132,13 @@ public class RestrictOrTest extends AbstractFakeApplicationTest
         final DeadboltHandler deadboltHandler = new NoPreAuthDeadboltHandler()
         {
             @Override
-            public CompletionStage<Optional<? extends Subject>> getSubject(final Http.Context context)
+            public CompletionStage<Optional<? extends Subject>> getSubject(final Http.RequestHeader requestHeader)
             {
                 return CompletableFuture.supplyAsync(() -> Optional.of(new TestSubject.Builder().role(new TestRole("foo"))
                                                                                                 .build()));
             }
         };
-        final Content html = restrictOrContent().render(context(),
-                                                        Arrays.asList(new String[]{"foo"},
+        final Content html = restrictOrContent().render(Arrays.asList(new String[]{"foo"},
                                                                       new String[]{"bar"}),
                                                         deadboltHandler);
         final String content = Helpers.contentAsString(html);
@@ -159,14 +154,13 @@ public class RestrictOrTest extends AbstractFakeApplicationTest
         final DeadboltHandler deadboltHandler = new NoPreAuthDeadboltHandler()
         {
             @Override
-            public CompletionStage<Optional<? extends Subject>> getSubject(final Http.Context context)
+            public CompletionStage<Optional<? extends Subject>> getSubject(final Http.RequestHeader requestHeader)
             {
                 return CompletableFuture.supplyAsync(() -> Optional.of(new TestSubject.Builder().role(new TestRole("bar"))
                                                                                                 .build()));
             }
         };
-        final Content html = restrictOrContent().render(context(),
-                                                        Arrays.asList(new String[]{"foo"},
+        final Content html = restrictOrContent().render(Arrays.asList(new String[]{"foo"},
                                                                       new String[]{"bar"}),
                                                         deadboltHandler);
         final String content = Helpers.contentAsString(html);
@@ -182,15 +176,14 @@ public class RestrictOrTest extends AbstractFakeApplicationTest
         final DeadboltHandler deadboltHandler = new NoPreAuthDeadboltHandler()
         {
             @Override
-            public CompletionStage<Optional<? extends Subject>> getSubject(final Http.Context context)
+            public CompletionStage<Optional<? extends Subject>> getSubject(final Http.RequestHeader requestHeader)
             {
                 return CompletableFuture.supplyAsync(() -> Optional.of(new TestSubject.Builder().role(new TestRole("foo"))
                                                                                                 .role(new TestRole("bar"))
                                                                                                 .build()));
             }
         };
-        final Content html = restrictOrContent().render(context(),
-                                                        Arrays.asList(new String[]{"foo"},
+        final Content html = restrictOrContent().render(Arrays.asList(new String[]{"foo"},
                                                                       new String[]{"bar"}),
                                                         deadboltHandler);
         final String content = Helpers.contentAsString(html);
@@ -206,13 +199,12 @@ public class RestrictOrTest extends AbstractFakeApplicationTest
         final DeadboltHandler deadboltHandler = new NoPreAuthDeadboltHandler()
         {
             @Override
-            public CompletionStage<Optional<? extends Subject>> getSubject(final Http.Context context)
+            public CompletionStage<Optional<? extends Subject>> getSubject(final Http.RequestHeader requestHeader)
             {
                 return CompletableFuture.supplyAsync(() -> Optional.of(new TestSubject.Builder().build()));
             }
         };
-        final Content html = restrictOrContent().render(context(),
-                                                        Arrays.asList(new String[]{"foo"},
+        final Content html = restrictOrContent().render(Arrays.asList(new String[]{"foo"},
                                                                       new String[]{"bar"}),
                                                         deadboltHandler);
         final String content = Helpers.contentAsString(html);
@@ -228,13 +220,12 @@ public class RestrictOrTest extends AbstractFakeApplicationTest
         final DeadboltHandler deadboltHandler = new NoPreAuthDeadboltHandler()
         {
             @Override
-            public CompletionStage<Optional<? extends Subject>> getSubject(final Http.Context context)
+            public CompletionStage<Optional<? extends Subject>> getSubject(final Http.RequestHeader requestHeader)
             {
                 return CompletableFuture.supplyAsync(Optional::empty);
             }
         };
-        final Content html = restrictOrContent().render(context(),
-                                                        Collections.singletonList(new String[]{"foo"}),
+        final Content html = restrictOrContent().render(Collections.singletonList(new String[]{"foo"}),
                                                         deadboltHandler);
         final String content = Helpers.contentAsString(html);
         Assert.assertTrue(content.contains("This is before the constraint."));
@@ -249,14 +240,13 @@ public class RestrictOrTest extends AbstractFakeApplicationTest
         final DeadboltHandler deadboltHandler = new NoPreAuthDeadboltHandler()
         {
             @Override
-            public CompletionStage<Optional<? extends Subject>> getSubject(final Http.Context context)
+            public CompletionStage<Optional<? extends Subject>> getSubject(final Http.RequestHeader requestHeader)
             {
                 return CompletableFuture.supplyAsync(() -> Optional.of(new TestSubject.Builder().role(new TestRole("foo"))
                                                                                                 .build()));
             }
         };
-        final Content html = restrictOrContent().render(context(),
-                                                        Collections.singletonList(new String[]{"foo", "bar"}),
+        final Content html = restrictOrContent().render(Collections.singletonList(new String[]{"foo", "bar"}),
                                                         deadboltHandler);
         final String content = Helpers.contentAsString(html);
         Assert.assertTrue(content.contains("This is before the constraint."));
@@ -271,14 +261,13 @@ public class RestrictOrTest extends AbstractFakeApplicationTest
         final DeadboltHandler deadboltHandler = new NoPreAuthDeadboltHandler()
         {
             @Override
-            public CompletionStage<Optional<? extends Subject>> getSubject(final Http.Context context)
+            public CompletionStage<Optional<? extends Subject>> getSubject(final Http.RequestHeader requestHeader)
             {
                 return CompletableFuture.supplyAsync(() -> Optional.of(new TestSubject.Builder().role(new TestRole("bar"))
                                                                                                 .build()));
             }
         };
-        final Content html = restrictOrContent().render(context(),
-                                                        Collections.singletonList(new String[]{"foo", "bar"}),
+        final Content html = restrictOrContent().render(Collections.singletonList(new String[]{"foo", "bar"}),
                                                         deadboltHandler);
         final String content = Helpers.contentAsString(html);
         Assert.assertTrue(content.contains("This is before the constraint."));
@@ -293,15 +282,14 @@ public class RestrictOrTest extends AbstractFakeApplicationTest
         final DeadboltHandler deadboltHandler = new NoPreAuthDeadboltHandler()
         {
             @Override
-            public CompletionStage<Optional<? extends Subject>> getSubject(final Http.Context context)
+            public CompletionStage<Optional<? extends Subject>> getSubject(final Http.RequestHeader requestHeader)
             {
                 return CompletableFuture.supplyAsync(() -> Optional.of(new TestSubject.Builder().role(new TestRole("foo"))
                                                                                                 .role(new TestRole("bar"))
                                                                                                 .build()));
             }
         };
-        final Content html = restrictOrContent().render(context(),
-                                                        Collections.singletonList(new String[]{"foo", "bar"}),
+        final Content html = restrictOrContent().render(Collections.singletonList(new String[]{"foo", "bar"}),
                                                         deadboltHandler);
         final String content = Helpers.contentAsString(html);
         Assert.assertTrue(content.contains("This is before the constraint."));
@@ -316,13 +304,12 @@ public class RestrictOrTest extends AbstractFakeApplicationTest
         final DeadboltHandler deadboltHandler = new NoPreAuthDeadboltHandler()
         {
             @Override
-            public CompletionStage<Optional<? extends Subject>> getSubject(final Http.Context context)
+            public CompletionStage<Optional<? extends Subject>> getSubject(final Http.RequestHeader requestHeader)
             {
                 return CompletableFuture.supplyAsync(() -> Optional.of(new TestSubject.Builder().build()));
             }
         };
-        final Content html = restrictOrContent().render(context(),
-                                                        Collections.singletonList(new String[]{"foo", "bar"}),
+        final Content html = restrictOrContent().render(Collections.singletonList(new String[]{"foo", "bar"}),
                                                         deadboltHandler);
         final String content = Helpers.contentAsString(html);
         Assert.assertTrue(content.contains("This is before the constraint."));
@@ -337,13 +324,12 @@ public class RestrictOrTest extends AbstractFakeApplicationTest
         final DeadboltHandler deadboltHandler = new NoPreAuthDeadboltHandler()
         {
             @Override
-            public CompletionStage<Optional<? extends Subject>> getSubject(final Http.Context context)
+            public CompletionStage<Optional<? extends Subject>> getSubject(final Http.RequestHeader requestHeader)
             {
                 return CompletableFuture.supplyAsync(Optional::empty);
             }
         };
-        final Content html = restrictOrContent().render(context(),
-                                                        Collections.singletonList(new String[]{"foo", "bar"}),
+        final Content html = restrictOrContent().render(Collections.singletonList(new String[]{"foo", "bar"}),
                                                         deadboltHandler);
         final String content = Helpers.contentAsString(html);
         Assert.assertTrue(content.contains("This is before the constraint."));
@@ -358,14 +344,13 @@ public class RestrictOrTest extends AbstractFakeApplicationTest
         final DeadboltHandler deadboltHandler = new NoPreAuthDeadboltHandler()
         {
             @Override
-            public CompletionStage<Optional<? extends Subject>> getSubject(final Http.Context context)
+            public CompletionStage<Optional<? extends Subject>> getSubject(final Http.RequestHeader requestHeader)
             {
                 return CompletableFuture.supplyAsync(() -> Optional.of(new TestSubject.Builder().role(new TestRole("foo"))
                                                                                                 .build()));
             }
         };
-        final Content html = restrictOrContent().render(context(),
-                                                        Collections.singletonList(new String[]{"!foo"}),
+        final Content html = restrictOrContent().render(Collections.singletonList(new String[]{"!foo"}),
                                                         deadboltHandler);
         final String content = Helpers.contentAsString(html);
         Assert.assertTrue(content.contains("This is before the constraint."));
@@ -380,14 +365,13 @@ public class RestrictOrTest extends AbstractFakeApplicationTest
         final DeadboltHandler deadboltHandler = new NoPreAuthDeadboltHandler()
         {
             @Override
-            public CompletionStage<Optional<? extends Subject>> getSubject(final Http.Context context)
+            public CompletionStage<Optional<? extends Subject>> getSubject(final Http.RequestHeader requestHeader)
             {
                 return CompletableFuture.supplyAsync(() -> Optional.of(new TestSubject.Builder().role(new TestRole("bar"))
                                                                                                 .build()));
             }
         };
-        final Content html = restrictOrContent().render(context(),
-                                                        Collections.singletonList(new String[]{"!foo"}),
+        final Content html = restrictOrContent().render(Collections.singletonList(new String[]{"!foo"}),
                                                         deadboltHandler);
         final String content = Helpers.contentAsString(html);
         Assert.assertTrue(content.contains("This is before the constraint."));
@@ -402,15 +386,14 @@ public class RestrictOrTest extends AbstractFakeApplicationTest
         final DeadboltHandler deadboltHandler = new NoPreAuthDeadboltHandler()
         {
             @Override
-            public CompletionStage<Optional<? extends Subject>> getSubject(final Http.Context context)
+            public CompletionStage<Optional<? extends Subject>> getSubject(final Http.RequestHeader requestHeader)
             {
                 return CompletableFuture.supplyAsync(() -> Optional.of(new TestSubject.Builder().role(new TestRole("foo"))
                                                                                                 .role(new TestRole("bar"))
                                                                                                 .build()));
             }
         };
-        final Content html = restrictOrContent().render(context(),
-                                                        Collections.singletonList(new String[]{"!foo"}),
+        final Content html = restrictOrContent().render(Collections.singletonList(new String[]{"!foo"}),
                                                         deadboltHandler);
         final String content = Helpers.contentAsString(html);
         Assert.assertTrue(content.contains("This is before the constraint."));
@@ -425,13 +408,12 @@ public class RestrictOrTest extends AbstractFakeApplicationTest
         final DeadboltHandler deadboltHandler = new NoPreAuthDeadboltHandler()
         {
             @Override
-            public CompletionStage<Optional<? extends Subject>> getSubject(final Http.Context context)
+            public CompletionStage<Optional<? extends Subject>> getSubject(final Http.RequestHeader requestHeader)
             {
                 return CompletableFuture.supplyAsync(() -> Optional.of(new TestSubject.Builder().build()));
             }
         };
-        final Content html = restrictOrContent().render(context(),
-                                                        Collections.singletonList(new String[]{"!foo"}),
+        final Content html = restrictOrContent().render(Collections.singletonList(new String[]{"!foo"}),
                                                         deadboltHandler);
         final String content = Helpers.contentAsString(html);
         Assert.assertTrue(content.contains("This is before the constraint."));
@@ -446,13 +428,12 @@ public class RestrictOrTest extends AbstractFakeApplicationTest
         final DeadboltHandler deadboltHandler = new NoPreAuthDeadboltHandler()
         {
             @Override
-            public CompletionStage<Optional<? extends Subject>> getSubject(final Http.Context context)
+            public CompletionStage<Optional<? extends Subject>> getSubject(final Http.RequestHeader requestHeader)
             {
                 return CompletableFuture.supplyAsync(Optional::empty);
             }
         };
-        final Content html = restrictOrContent().render(context(),
-                                                        Collections.singletonList(new String[]{"!foo"}),
+        final Content html = restrictOrContent().render(Collections.singletonList(new String[]{"!foo"}),
                                                         deadboltHandler);
         final String content = Helpers.contentAsString(html);
         Assert.assertTrue(content.contains("This is before the constraint."));
@@ -467,14 +448,13 @@ public class RestrictOrTest extends AbstractFakeApplicationTest
         final DeadboltHandler deadboltHandler = new NoPreAuthDeadboltHandler()
         {
             @Override
-            public CompletionStage<Optional<? extends Subject>> getSubject(final Http.Context context)
+            public CompletionStage<Optional<? extends Subject>> getSubject(final Http.RequestHeader requestHeader)
             {
                 return CompletableFuture.supplyAsync(() -> Optional.of(new TestSubject.Builder().role(new TestRole("foo"))
                                                                                                 .build()));
             }
         };
-        final Content html = restrictOrContent().render(context(),
-                                                        Arrays.asList(new String[]{"!foo"},
+        final Content html = restrictOrContent().render(Arrays.asList(new String[]{"!foo"},
                                                                       new String[]{"bar"}),
                                                         deadboltHandler);
         final String content = Helpers.contentAsString(html);
@@ -490,14 +470,13 @@ public class RestrictOrTest extends AbstractFakeApplicationTest
         final DeadboltHandler deadboltHandler = new NoPreAuthDeadboltHandler()
         {
             @Override
-            public CompletionStage<Optional<? extends Subject>> getSubject(final Http.Context context)
+            public CompletionStage<Optional<? extends Subject>> getSubject(final Http.RequestHeader requestHeader)
             {
                 return CompletableFuture.supplyAsync(() -> Optional.of(new TestSubject.Builder().role(new TestRole("bar"))
                                                                                                 .build()));
             }
         };
-        final Content html = restrictOrContent().render(context(),
-                                                        Arrays.asList(new String[]{"!foo"},
+        final Content html = restrictOrContent().render(Arrays.asList(new String[]{"!foo"},
                                                                       new String[]{"bar"}),
                                                         deadboltHandler);
         final String content = Helpers.contentAsString(html);
@@ -513,15 +492,14 @@ public class RestrictOrTest extends AbstractFakeApplicationTest
         final DeadboltHandler deadboltHandler = new NoPreAuthDeadboltHandler()
         {
             @Override
-            public CompletionStage<Optional<? extends Subject>> getSubject(final Http.Context context)
+            public CompletionStage<Optional<? extends Subject>> getSubject(final Http.RequestHeader requestHeader)
             {
                 return CompletableFuture.supplyAsync(() -> Optional.of(new TestSubject.Builder().role(new TestRole("foo"))
                                                                                                 .role(new TestRole("bar"))
                                                                                                 .build()));
             }
         };
-        final Content html = restrictOrContent().render(context(),
-                                                        Arrays.asList(new String[]{"!foo"},
+        final Content html = restrictOrContent().render(Arrays.asList(new String[]{"!foo"},
                                                                       new String[]{"bar"}),
                                                         deadboltHandler);
         final String content = Helpers.contentAsString(html);
@@ -537,13 +515,12 @@ public class RestrictOrTest extends AbstractFakeApplicationTest
         final DeadboltHandler deadboltHandler = new NoPreAuthDeadboltHandler()
         {
             @Override
-            public CompletionStage<Optional<? extends Subject>> getSubject(final Http.Context context)
+            public CompletionStage<Optional<? extends Subject>> getSubject(final Http.RequestHeader requestHeader)
             {
                 return CompletableFuture.supplyAsync(() -> Optional.of(new TestSubject.Builder().build()));
             }
         };
-        final Content html = restrictOrContent().render(context(),
-                                                        Arrays.asList(new String[]{"!foo"},
+        final Content html = restrictOrContent().render(Arrays.asList(new String[]{"!foo"},
                                                                       new String[]{"bar"}),
                                                         deadboltHandler);
         final String content = Helpers.contentAsString(html);
@@ -559,13 +536,12 @@ public class RestrictOrTest extends AbstractFakeApplicationTest
         final DeadboltHandler deadboltHandler = new NoPreAuthDeadboltHandler()
         {
             @Override
-            public CompletionStage<Optional<? extends Subject>> getSubject(final Http.Context context)
+            public CompletionStage<Optional<? extends Subject>> getSubject(final Http.RequestHeader requestHeader)
             {
                 return CompletableFuture.supplyAsync(Optional::empty);
             }
         };
-        final Content html = restrictOrContent().render(context(),
-                                                        Collections.singletonList(new String[]{"!foo"}),
+        final Content html = restrictOrContent().render(Collections.singletonList(new String[]{"!foo"}),
                                                         deadboltHandler);
         final String content = Helpers.contentAsString(html);
         Assert.assertTrue(content.contains("This is before the constraint."));
@@ -580,14 +556,13 @@ public class RestrictOrTest extends AbstractFakeApplicationTest
         final DeadboltHandler deadboltHandler = new NoPreAuthDeadboltHandler()
         {
             @Override
-            public CompletionStage<Optional<? extends Subject>> getSubject(final Http.Context context)
+            public CompletionStage<Optional<? extends Subject>> getSubject(final Http.RequestHeader requestHeader)
             {
                 return CompletableFuture.supplyAsync(() -> Optional.of(new TestSubject.Builder().role(new TestRole("foo"))
                                                                                                 .build()));
             }
         };
-        final Content html = restrictOrContent().render(context(),
-                                                        Collections.singletonList(new String[]{"!foo", "bar"}),
+        final Content html = restrictOrContent().render(Collections.singletonList(new String[]{"!foo", "bar"}),
                                                         deadboltHandler);
         final String content = Helpers.contentAsString(html);
         Assert.assertTrue(content.contains("This is before the constraint."));
@@ -602,14 +577,13 @@ public class RestrictOrTest extends AbstractFakeApplicationTest
         final DeadboltHandler deadboltHandler = new NoPreAuthDeadboltHandler()
         {
             @Override
-            public CompletionStage<Optional<? extends Subject>> getSubject(final Http.Context context)
+            public CompletionStage<Optional<? extends Subject>> getSubject(final Http.RequestHeader requestHeader)
             {
                 return CompletableFuture.supplyAsync(() -> Optional.of(new TestSubject.Builder().role(new TestRole("bar"))
                                                                                                 .build()));
             }
         };
-        final Content html = restrictOrContent().render(context(),
-                                                        Collections.singletonList(new String[]{"!foo", "bar"}),
+        final Content html = restrictOrContent().render(Collections.singletonList(new String[]{"!foo", "bar"}),
                                                         deadboltHandler);
         final String content = Helpers.contentAsString(html);
         Assert.assertTrue(content.contains("This is before the constraint."));
@@ -624,15 +598,14 @@ public class RestrictOrTest extends AbstractFakeApplicationTest
         final DeadboltHandler deadboltHandler = new NoPreAuthDeadboltHandler()
         {
             @Override
-            public CompletionStage<Optional<? extends Subject>> getSubject(final Http.Context context)
+            public CompletionStage<Optional<? extends Subject>> getSubject(final Http.RequestHeader requestHeader)
             {
                 return CompletableFuture.supplyAsync(() -> Optional.of(new TestSubject.Builder().role(new TestRole("foo"))
                                                                                                 .role(new TestRole("bar"))
                                                                                                 .build()));
             }
         };
-        final Content html = restrictOrContent().render(context(),
-                                                        Collections.singletonList(new String[]{"!foo", "bar"}),
+        final Content html = restrictOrContent().render(Collections.singletonList(new String[]{"!foo", "bar"}),
                                                         deadboltHandler);
         final String content = Helpers.contentAsString(html);
         Assert.assertTrue(content.contains("This is before the constraint."));
@@ -647,13 +620,12 @@ public class RestrictOrTest extends AbstractFakeApplicationTest
         final DeadboltHandler deadboltHandler = new NoPreAuthDeadboltHandler()
         {
             @Override
-            public CompletionStage<Optional<? extends Subject>> getSubject(final Http.Context context)
+            public CompletionStage<Optional<? extends Subject>> getSubject(final Http.RequestHeader requestHeader)
             {
                 return CompletableFuture.supplyAsync(() -> Optional.of(new TestSubject.Builder().build()));
             }
         };
-        final Content html = restrictOrContent().render(context(),
-                                                        Collections.singletonList(new String[]{"!foo", "bar"}),
+        final Content html = restrictOrContent().render(Collections.singletonList(new String[]{"!foo", "bar"}),
                                                         deadboltHandler);
         final String content = Helpers.contentAsString(html);
         Assert.assertTrue(content.contains("This is before the constraint."));
@@ -668,13 +640,12 @@ public class RestrictOrTest extends AbstractFakeApplicationTest
         final DeadboltHandler deadboltHandler = new NoPreAuthDeadboltHandler()
         {
             @Override
-            public CompletionStage<Optional<? extends Subject>> getSubject(final Http.Context context)
+            public CompletionStage<Optional<? extends Subject>> getSubject(final Http.RequestHeader requestHeader)
             {
                 return CompletableFuture.supplyAsync(Optional::empty);
             }
         };
-        final Content html = restrictOrContent().render(context(),
-                                                        Collections.singletonList(new String[]{"!foo", "bar"}),
+        final Content html = restrictOrContent().render(Collections.singletonList(new String[]{"!foo", "bar"}),
                                                         deadboltHandler);
         final String content = Helpers.contentAsString(html);
         Assert.assertTrue(content.contains("This is before the constraint."));

--- a/code/test/be/objectify/deadbolt/java/views/di/restrictTest/RestrictOrTest.java
+++ b/code/test/be/objectify/deadbolt/java/views/di/restrictTest/RestrictOrTest.java
@@ -57,7 +57,7 @@ public class RestrictOrTest extends AbstractFakeApplicationTest
             }
         };
         final Content html = restrictOrContent().render(Collections.singletonList(new String[]{"foo"}),
-                                                        deadboltHandler);
+                                                        deadboltHandler, new Http.RequestBuilder().build());
         final String content = Helpers.contentAsString(html);
         Assert.assertTrue(content.contains("This is before the constraint."));
         Assert.assertTrue(content.contains("This is protected by the constraint."));
@@ -78,7 +78,7 @@ public class RestrictOrTest extends AbstractFakeApplicationTest
             }
         };
         final Content html = restrictOrContent().render(Collections.singletonList(new String[]{"foo"}),
-                                                        deadboltHandler);
+                                                        deadboltHandler, new Http.RequestBuilder().build());
         final String content = Helpers.contentAsString(html);
         Assert.assertTrue(content.contains("This is before the constraint."));
         Assert.assertFalse(content.contains("This is protected by the constraint."));
@@ -98,7 +98,7 @@ public class RestrictOrTest extends AbstractFakeApplicationTest
             }
         };
         final Content html = restrictOrContent().render(Collections.singletonList(new String[]{"foo"}),
-                                                        deadboltHandler);
+                                                        deadboltHandler, new Http.RequestBuilder().build());
         final String content = Helpers.contentAsString(html);
         Assert.assertTrue(content.contains("This is before the constraint."));
         Assert.assertFalse(content.contains("This is protected by the constraint."));
@@ -118,7 +118,7 @@ public class RestrictOrTest extends AbstractFakeApplicationTest
             }
         };
         final Content html = restrictOrContent().render(Collections.singletonList(new String[]{"foo"}),
-                                                        deadboltHandler);
+                                                        deadboltHandler, new Http.RequestBuilder().build());
         final String content = Helpers.contentAsString(html);
         Assert.assertTrue(content.contains("This is before the constraint."));
         Assert.assertFalse(content.contains("This is protected by the constraint."));
@@ -140,7 +140,7 @@ public class RestrictOrTest extends AbstractFakeApplicationTest
         };
         final Content html = restrictOrContent().render(Arrays.asList(new String[]{"foo"},
                                                                       new String[]{"bar"}),
-                                                        deadboltHandler);
+                                                        deadboltHandler, new Http.RequestBuilder().build());
         final String content = Helpers.contentAsString(html);
         Assert.assertTrue(content.contains("This is before the constraint."));
         Assert.assertTrue(content.contains("This is protected by the constraint."));
@@ -162,7 +162,7 @@ public class RestrictOrTest extends AbstractFakeApplicationTest
         };
         final Content html = restrictOrContent().render(Arrays.asList(new String[]{"foo"},
                                                                       new String[]{"bar"}),
-                                                        deadboltHandler);
+                                                        deadboltHandler, new Http.RequestBuilder().build());
         final String content = Helpers.contentAsString(html);
         Assert.assertTrue(content.contains("This is before the constraint."));
         Assert.assertTrue(content.contains("This is protected by the constraint."));
@@ -185,7 +185,7 @@ public class RestrictOrTest extends AbstractFakeApplicationTest
         };
         final Content html = restrictOrContent().render(Arrays.asList(new String[]{"foo"},
                                                                       new String[]{"bar"}),
-                                                        deadboltHandler);
+                                                        deadboltHandler, new Http.RequestBuilder().build());
         final String content = Helpers.contentAsString(html);
         Assert.assertTrue(content.contains("This is before the constraint."));
         Assert.assertTrue(content.contains("This is protected by the constraint."));
@@ -206,7 +206,7 @@ public class RestrictOrTest extends AbstractFakeApplicationTest
         };
         final Content html = restrictOrContent().render(Arrays.asList(new String[]{"foo"},
                                                                       new String[]{"bar"}),
-                                                        deadboltHandler);
+                                                        deadboltHandler, new Http.RequestBuilder().build());
         final String content = Helpers.contentAsString(html);
         Assert.assertTrue(content.contains("This is before the constraint."));
         Assert.assertFalse(content.contains("This is protected by the constraint."));
@@ -226,7 +226,7 @@ public class RestrictOrTest extends AbstractFakeApplicationTest
             }
         };
         final Content html = restrictOrContent().render(Collections.singletonList(new String[]{"foo"}),
-                                                        deadboltHandler);
+                                                        deadboltHandler, new Http.RequestBuilder().build());
         final String content = Helpers.contentAsString(html);
         Assert.assertTrue(content.contains("This is before the constraint."));
         Assert.assertFalse(content.contains("This is protected by the constraint."));
@@ -247,7 +247,7 @@ public class RestrictOrTest extends AbstractFakeApplicationTest
             }
         };
         final Content html = restrictOrContent().render(Collections.singletonList(new String[]{"foo", "bar"}),
-                                                        deadboltHandler);
+                                                        deadboltHandler, new Http.RequestBuilder().build());
         final String content = Helpers.contentAsString(html);
         Assert.assertTrue(content.contains("This is before the constraint."));
         Assert.assertFalse(content.contains("This is protected by the constraint."));
@@ -268,7 +268,7 @@ public class RestrictOrTest extends AbstractFakeApplicationTest
             }
         };
         final Content html = restrictOrContent().render(Collections.singletonList(new String[]{"foo", "bar"}),
-                                                        deadboltHandler);
+                                                        deadboltHandler, new Http.RequestBuilder().build());
         final String content = Helpers.contentAsString(html);
         Assert.assertTrue(content.contains("This is before the constraint."));
         Assert.assertFalse(content.contains("This is protected by the constraint."));
@@ -290,7 +290,7 @@ public class RestrictOrTest extends AbstractFakeApplicationTest
             }
         };
         final Content html = restrictOrContent().render(Collections.singletonList(new String[]{"foo", "bar"}),
-                                                        deadboltHandler);
+                                                        deadboltHandler, new Http.RequestBuilder().build());
         final String content = Helpers.contentAsString(html);
         Assert.assertTrue(content.contains("This is before the constraint."));
         Assert.assertTrue(content.contains("This is protected by the constraint."));
@@ -310,7 +310,7 @@ public class RestrictOrTest extends AbstractFakeApplicationTest
             }
         };
         final Content html = restrictOrContent().render(Collections.singletonList(new String[]{"foo", "bar"}),
-                                                        deadboltHandler);
+                                                        deadboltHandler, new Http.RequestBuilder().build());
         final String content = Helpers.contentAsString(html);
         Assert.assertTrue(content.contains("This is before the constraint."));
         Assert.assertFalse(content.contains("This is protected by the constraint."));
@@ -330,7 +330,7 @@ public class RestrictOrTest extends AbstractFakeApplicationTest
             }
         };
         final Content html = restrictOrContent().render(Collections.singletonList(new String[]{"foo", "bar"}),
-                                                        deadboltHandler);
+                                                        deadboltHandler, new Http.RequestBuilder().build());
         final String content = Helpers.contentAsString(html);
         Assert.assertTrue(content.contains("This is before the constraint."));
         Assert.assertFalse(content.contains("This is protected by the constraint."));
@@ -351,7 +351,7 @@ public class RestrictOrTest extends AbstractFakeApplicationTest
             }
         };
         final Content html = restrictOrContent().render(Collections.singletonList(new String[]{"!foo"}),
-                                                        deadboltHandler);
+                                                        deadboltHandler, new Http.RequestBuilder().build());
         final String content = Helpers.contentAsString(html);
         Assert.assertTrue(content.contains("This is before the constraint."));
         Assert.assertFalse(content.contains("This is protected by the constraint."));
@@ -372,7 +372,7 @@ public class RestrictOrTest extends AbstractFakeApplicationTest
             }
         };
         final Content html = restrictOrContent().render(Collections.singletonList(new String[]{"!foo"}),
-                                                        deadboltHandler);
+                                                        deadboltHandler, new Http.RequestBuilder().build());
         final String content = Helpers.contentAsString(html);
         Assert.assertTrue(content.contains("This is before the constraint."));
         Assert.assertTrue(content.contains("This is protected by the constraint."));
@@ -394,7 +394,7 @@ public class RestrictOrTest extends AbstractFakeApplicationTest
             }
         };
         final Content html = restrictOrContent().render(Collections.singletonList(new String[]{"!foo"}),
-                                                        deadboltHandler);
+                                                        deadboltHandler, new Http.RequestBuilder().build());
         final String content = Helpers.contentAsString(html);
         Assert.assertTrue(content.contains("This is before the constraint."));
         Assert.assertFalse(content.contains("This is protected by the constraint."));
@@ -414,7 +414,7 @@ public class RestrictOrTest extends AbstractFakeApplicationTest
             }
         };
         final Content html = restrictOrContent().render(Collections.singletonList(new String[]{"!foo"}),
-                                                        deadboltHandler);
+                                                        deadboltHandler, new Http.RequestBuilder().build());
         final String content = Helpers.contentAsString(html);
         Assert.assertTrue(content.contains("This is before the constraint."));
         Assert.assertTrue(content.contains("This is protected by the constraint."));
@@ -434,7 +434,7 @@ public class RestrictOrTest extends AbstractFakeApplicationTest
             }
         };
         final Content html = restrictOrContent().render(Collections.singletonList(new String[]{"!foo"}),
-                                                        deadboltHandler);
+                                                        deadboltHandler, new Http.RequestBuilder().build());
         final String content = Helpers.contentAsString(html);
         Assert.assertTrue(content.contains("This is before the constraint."));
         Assert.assertFalse(content.contains("This is protected by the constraint."));
@@ -456,7 +456,7 @@ public class RestrictOrTest extends AbstractFakeApplicationTest
         };
         final Content html = restrictOrContent().render(Arrays.asList(new String[]{"!foo"},
                                                                       new String[]{"bar"}),
-                                                        deadboltHandler);
+                                                        deadboltHandler, new Http.RequestBuilder().build());
         final String content = Helpers.contentAsString(html);
         Assert.assertTrue(content.contains("This is before the constraint."));
         Assert.assertFalse(content.contains("This is protected by the constraint."));
@@ -478,7 +478,7 @@ public class RestrictOrTest extends AbstractFakeApplicationTest
         };
         final Content html = restrictOrContent().render(Arrays.asList(new String[]{"!foo"},
                                                                       new String[]{"bar"}),
-                                                        deadboltHandler);
+                                                        deadboltHandler, new Http.RequestBuilder().build());
         final String content = Helpers.contentAsString(html);
         Assert.assertTrue(content.contains("This is before the constraint."));
         Assert.assertTrue(content.contains("This is protected by the constraint."));
@@ -501,7 +501,7 @@ public class RestrictOrTest extends AbstractFakeApplicationTest
         };
         final Content html = restrictOrContent().render(Arrays.asList(new String[]{"!foo"},
                                                                       new String[]{"bar"}),
-                                                        deadboltHandler);
+                                                        deadboltHandler, new Http.RequestBuilder().build());
         final String content = Helpers.contentAsString(html);
         Assert.assertTrue(content.contains("This is before the constraint."));
         Assert.assertTrue(content.contains("This is protected by the constraint."));
@@ -522,7 +522,7 @@ public class RestrictOrTest extends AbstractFakeApplicationTest
         };
         final Content html = restrictOrContent().render(Arrays.asList(new String[]{"!foo"},
                                                                       new String[]{"bar"}),
-                                                        deadboltHandler);
+                                                        deadboltHandler, new Http.RequestBuilder().build());
         final String content = Helpers.contentAsString(html);
         Assert.assertTrue(content.contains("This is before the constraint."));
         Assert.assertTrue(content.contains("This is protected by the constraint."));
@@ -542,7 +542,7 @@ public class RestrictOrTest extends AbstractFakeApplicationTest
             }
         };
         final Content html = restrictOrContent().render(Collections.singletonList(new String[]{"!foo"}),
-                                                        deadboltHandler);
+                                                        deadboltHandler, new Http.RequestBuilder().build());
         final String content = Helpers.contentAsString(html);
         Assert.assertTrue(content.contains("This is before the constraint."));
         Assert.assertFalse(content.contains("This is protected by the constraint."));
@@ -563,7 +563,7 @@ public class RestrictOrTest extends AbstractFakeApplicationTest
             }
         };
         final Content html = restrictOrContent().render(Collections.singletonList(new String[]{"!foo", "bar"}),
-                                                        deadboltHandler);
+                                                        deadboltHandler, new Http.RequestBuilder().build());
         final String content = Helpers.contentAsString(html);
         Assert.assertTrue(content.contains("This is before the constraint."));
         Assert.assertFalse(content.contains("This is protected by the constraint."));
@@ -584,7 +584,7 @@ public class RestrictOrTest extends AbstractFakeApplicationTest
             }
         };
         final Content html = restrictOrContent().render(Collections.singletonList(new String[]{"!foo", "bar"}),
-                                                        deadboltHandler);
+                                                        deadboltHandler, new Http.RequestBuilder().build());
         final String content = Helpers.contentAsString(html);
         Assert.assertTrue(content.contains("This is before the constraint."));
         Assert.assertTrue(content.contains("This is protected by the constraint."));
@@ -606,7 +606,7 @@ public class RestrictOrTest extends AbstractFakeApplicationTest
             }
         };
         final Content html = restrictOrContent().render(Collections.singletonList(new String[]{"!foo", "bar"}),
-                                                        deadboltHandler);
+                                                        deadboltHandler, new Http.RequestBuilder().build());
         final String content = Helpers.contentAsString(html);
         Assert.assertTrue(content.contains("This is before the constraint."));
         Assert.assertFalse(content.contains("This is protected by the constraint."));
@@ -626,7 +626,7 @@ public class RestrictOrTest extends AbstractFakeApplicationTest
             }
         };
         final Content html = restrictOrContent().render(Collections.singletonList(new String[]{"!foo", "bar"}),
-                                                        deadboltHandler);
+                                                        deadboltHandler, new Http.RequestBuilder().build());
         final String content = Helpers.contentAsString(html);
         Assert.assertTrue(content.contains("This is before the constraint."));
         Assert.assertFalse(content.contains("This is protected by the constraint."));
@@ -646,7 +646,7 @@ public class RestrictOrTest extends AbstractFakeApplicationTest
             }
         };
         final Content html = restrictOrContent().render(Collections.singletonList(new String[]{"!foo", "bar"}),
-                                                        deadboltHandler);
+                                                        deadboltHandler, new Http.RequestBuilder().build());
         final String content = Helpers.contentAsString(html);
         Assert.assertTrue(content.contains("This is before the constraint."));
         Assert.assertFalse(content.contains("This is protected by the constraint."));

--- a/code/test/be/objectify/deadbolt/java/views/di/restrictTest/RestrictTest.java
+++ b/code/test/be/objectify/deadbolt/java/views/di/restrictTest/RestrictTest.java
@@ -27,6 +27,7 @@ import org.junit.Assert;
 import org.junit.Test;
 import play.test.Helpers;
 import play.twirl.api.Content;
+import play.mvc.Http;
 
 import java.util.Arrays;
 import java.util.Collections;
@@ -44,7 +45,7 @@ public class RestrictTest extends AbstractFakeApplicationTest
     public void testSingleRole_present()
     {
         final Content html = restrictContent().render(Collections.singletonList(new String[]{"foo"}),
-                                                      handlers.apply("foo"));
+                                                      handlers.apply("foo"), new Http.RequestBuilder().build());
         final String content = Helpers.contentAsString(html);
         Assert.assertTrue(content.contains("This is before the constraint."));
         Assert.assertTrue(content.contains("This is protected by the constraint."));
@@ -55,7 +56,7 @@ public class RestrictTest extends AbstractFakeApplicationTest
     public void testSingleRole_notPresent()
     {
         final Content html = restrictContent().render(Collections.singletonList(new String[]{"foo"}),
-                                                      handlers.apply("bar"));
+                                                      handlers.apply("bar"), new Http.RequestBuilder().build());
         final String content = Helpers.contentAsString(html);
         Assert.assertTrue(content.contains("This is before the constraint."));
         Assert.assertFalse(content.contains("This is protected by the constraint."));
@@ -66,7 +67,7 @@ public class RestrictTest extends AbstractFakeApplicationTest
     public void testSingleRole_noRolesPresent()
     {
         final Content html = restrictContent().render(Collections.singletonList(new String[]{"foo"}),
-                                                      handlers.apply("noRoles"));
+                                                      handlers.apply("noRoles"), new Http.RequestBuilder().build());
         final String content = Helpers.contentAsString(html);
         Assert.assertTrue(content.contains("This is before the constraint."));
         Assert.assertFalse(content.contains("This is protected by the constraint."));
@@ -77,7 +78,7 @@ public class RestrictTest extends AbstractFakeApplicationTest
     public void testSingleRole_noSubject()
     {
         final Content html = restrictContent().render(Collections.singletonList(new String[]{"foo"}),
-                                                      handlers.apply("noSubject"));
+                                                      handlers.apply("noSubject"), new Http.RequestBuilder().build());
         final String content = Helpers.contentAsString(html);
         Assert.assertTrue(content.contains("This is before the constraint."));
         Assert.assertFalse(content.contains("This is protected by the constraint."));
@@ -89,7 +90,7 @@ public class RestrictTest extends AbstractFakeApplicationTest
     {
         final Content html = restrictContent().render(Arrays.asList(new String[]{"foo"},
                                                                     new String[]{"bar"}),
-                                                      handlers.apply("foo"));
+                                                      handlers.apply("foo"), new Http.RequestBuilder().build());
         final String content = Helpers.contentAsString(html);
         Assert.assertTrue(content.contains("This is before the constraint."));
         Assert.assertTrue(content.contains("This is protected by the constraint."));
@@ -101,7 +102,7 @@ public class RestrictTest extends AbstractFakeApplicationTest
     {
         final Content html = restrictContent().render(Arrays.asList(new String[]{"foo"},
                                                                     new String[]{"bar"}),
-                                                      handlers.apply("bar"));
+                                                      handlers.apply("bar"), new Http.RequestBuilder().build());
         final String content = Helpers.contentAsString(html);
         Assert.assertTrue(content.contains("This is before the constraint."));
         Assert.assertTrue(content.contains("This is protected by the constraint."));
@@ -113,7 +114,7 @@ public class RestrictTest extends AbstractFakeApplicationTest
     {
         final Content html = restrictContent().render(Arrays.asList(new String[]{"foo"},
                                                                     new String[]{"bar"}),
-                                                      handlers.apply("fooBar"));
+                                                      handlers.apply("fooBar"), new Http.RequestBuilder().build());
         final String content = Helpers.contentAsString(html);
         Assert.assertTrue(content.contains("This is before the constraint."));
         Assert.assertTrue(content.contains("This is protected by the constraint."));
@@ -125,7 +126,7 @@ public class RestrictTest extends AbstractFakeApplicationTest
     {
         final Content html = restrictContent().render(Arrays.asList(new String[]{"foo"},
                                                                     new String[]{"bar"}),
-                                                      handlers.apply("noRoles"));
+                                                      handlers.apply("noRoles"), new Http.RequestBuilder().build());
         final String content = Helpers.contentAsString(html);
         Assert.assertTrue(content.contains("This is before the constraint."));
         Assert.assertFalse(content.contains("This is protected by the constraint."));
@@ -136,7 +137,7 @@ public class RestrictTest extends AbstractFakeApplicationTest
     public void testOr_noSubject()
     {
         final Content html = restrictContent().render(Collections.singletonList(new String[]{"foo"}),
-                                                      handlers.apply("noSubject"));
+                                                      handlers.apply("noSubject"), new Http.RequestBuilder().build());
         final String content = Helpers.contentAsString(html);
         Assert.assertTrue(content.contains("This is before the constraint."));
         Assert.assertFalse(content.contains("This is protected by the constraint."));
@@ -147,7 +148,7 @@ public class RestrictTest extends AbstractFakeApplicationTest
     public void testAnd_fooPresent()
     {
         final Content html = restrictContent().render(Collections.singletonList(new String[]{"foo", "bar"}),
-                                                      handlers.apply("foo"));
+                                                      handlers.apply("foo"), new Http.RequestBuilder().build());
         final String content = Helpers.contentAsString(html);
         Assert.assertTrue(content.contains("This is before the constraint."));
         Assert.assertFalse(content.contains("This is protected by the constraint."));
@@ -158,7 +159,7 @@ public class RestrictTest extends AbstractFakeApplicationTest
     public void testAnd_barPresent()
     {
         final Content html = restrictContent().render(Collections.singletonList(new String[]{"foo", "bar"}),
-                                                      handlers.apply("bar"));
+                                                      handlers.apply("bar"), new Http.RequestBuilder().build());
         final String content = Helpers.contentAsString(html);
         Assert.assertTrue(content.contains("This is before the constraint."));
         Assert.assertFalse(content.contains("This is protected by the constraint."));
@@ -169,7 +170,7 @@ public class RestrictTest extends AbstractFakeApplicationTest
     public void testAnd_bothPresent()
     {
         final Content html = restrictContent().render(Collections.singletonList(new String[]{"foo", "bar"}),
-                                                      handlers.apply("fooBar"));
+                                                      handlers.apply("fooBar"), new Http.RequestBuilder().build());
         final String content = Helpers.contentAsString(html);
         Assert.assertTrue(content.contains("This is before the constraint."));
         Assert.assertTrue(content.contains("This is protected by the constraint."));
@@ -180,7 +181,7 @@ public class RestrictTest extends AbstractFakeApplicationTest
     public void testAnd_neitherPresent()
     {
         final Content html = restrictContent().render(Collections.singletonList(new String[]{"foo", "bar"}),
-                                                      handlers.apply("noRoles"));
+                                                      handlers.apply("noRoles"), new Http.RequestBuilder().build());
         final String content = Helpers.contentAsString(html);
         Assert.assertTrue(content.contains("This is before the constraint."));
         Assert.assertFalse(content.contains("This is protected by the constraint."));
@@ -191,7 +192,7 @@ public class RestrictTest extends AbstractFakeApplicationTest
     public void testAnd_noSubject()
     {
         final Content html = restrictContent().render(Collections.singletonList(new String[]{"foo", "bar"}),
-                                                      handlers.apply("noSubject"));
+                                                      handlers.apply("noSubject"), new Http.RequestBuilder().build());
         final String content = Helpers.contentAsString(html);
         Assert.assertTrue(content.contains("This is before the constraint."));
         Assert.assertFalse(content.contains("This is protected by the constraint."));
@@ -202,7 +203,7 @@ public class RestrictTest extends AbstractFakeApplicationTest
     public void testNegatedRole_subjectHasRole()
     {
         final Content html = restrictContent().render(Collections.singletonList(new String[]{"!foo"}),
-                                                      handlers.apply("foo"));
+                                                      handlers.apply("foo"), new Http.RequestBuilder().build());
         final String content = Helpers.contentAsString(html);
         Assert.assertTrue(content.contains("This is before the constraint."));
         Assert.assertFalse(content.contains("This is protected by the constraint."));
@@ -213,7 +214,7 @@ public class RestrictTest extends AbstractFakeApplicationTest
     public void testNegatedRole_subjectDoesNotHaveRole()
     {
         final Content html = restrictContent().render(Collections.singletonList(new String[]{"!foo"}),
-                                                      handlers.apply("bar"));
+                                                      handlers.apply("bar"), new Http.RequestBuilder().build());
         final String content = Helpers.contentAsString(html);
         Assert.assertTrue(content.contains("This is before the constraint."));
         Assert.assertTrue(content.contains("This is protected by the constraint."));
@@ -224,7 +225,7 @@ public class RestrictTest extends AbstractFakeApplicationTest
     public void testNegatedRole_subjectHasMultipleRole()
     {
         final Content html = restrictContent().render(Collections.singletonList(new String[]{"!foo"}),
-                                                      handlers.apply("fooBar"));
+                                                      handlers.apply("fooBar"), new Http.RequestBuilder().build());
         final String content = Helpers.contentAsString(html);
         Assert.assertTrue(content.contains("This is before the constraint."));
         Assert.assertFalse(content.contains("This is protected by the constraint."));
@@ -235,7 +236,7 @@ public class RestrictTest extends AbstractFakeApplicationTest
     public void testNegatedRole_noRolesPresent()
     {
         final Content html = restrictContent().render(Collections.singletonList(new String[]{"!foo"}),
-                                                      handlers.apply("noRoles"));
+                                                      handlers.apply("noRoles"), new Http.RequestBuilder().build());
         final String content = Helpers.contentAsString(html);
         Assert.assertTrue(content.contains("This is before the constraint."));
         Assert.assertTrue(content.contains("This is protected by the constraint."));
@@ -246,7 +247,7 @@ public class RestrictTest extends AbstractFakeApplicationTest
     public void testNegatedRole_noSubject()
     {
         final Content html = restrictContent().render(Collections.singletonList(new String[]{"!foo"}),
-                                                      handlers.apply("noSubject"));
+                                                      handlers.apply("noSubject"), new Http.RequestBuilder().build());
         final String content = Helpers.contentAsString(html);
         Assert.assertTrue(content.contains("This is before the constraint."));
         Assert.assertFalse(content.contains("This is protected by the constraint."));
@@ -258,7 +259,7 @@ public class RestrictTest extends AbstractFakeApplicationTest
     {
         final Content html = restrictContent().render(Arrays.asList(new String[]{"!foo"},
                                                                     new String[]{"bar"}),
-                                                      handlers.apply("foo"));
+                                                      handlers.apply("foo"), new Http.RequestBuilder().build());
         final String content = Helpers.contentAsString(html);
         Assert.assertTrue(content.contains("This is before the constraint."));
         Assert.assertFalse(content.contains("This is protected by the constraint."));
@@ -270,7 +271,7 @@ public class RestrictTest extends AbstractFakeApplicationTest
     {
         final Content html = restrictContent().render(Arrays.asList(new String[]{"!foo"},
                                                                     new String[]{"bar"}),
-                                                      handlers.apply("bar"));
+                                                      handlers.apply("bar"), new Http.RequestBuilder().build());
         final String content = Helpers.contentAsString(html);
         Assert.assertTrue(content.contains("This is before the constraint."));
         Assert.assertTrue(content.contains("This is protected by the constraint."));
@@ -282,7 +283,7 @@ public class RestrictTest extends AbstractFakeApplicationTest
     {
         final Content html = restrictContent().render(Arrays.asList(new String[]{"!foo"},
                                                                     new String[]{"bar"}),
-                                                      handlers.apply("fooBar"));
+                                                      handlers.apply("fooBar"), new Http.RequestBuilder().build());
         final String content = Helpers.contentAsString(html);
         Assert.assertTrue(content.contains("This is before the constraint."));
         Assert.assertTrue(content.contains("This is protected by the constraint."));
@@ -294,7 +295,7 @@ public class RestrictTest extends AbstractFakeApplicationTest
     {
         final Content html = restrictContent().render(Arrays.asList(new String[]{"!foo"},
                                                                     new String[]{"bar"}),
-                                                      handlers.apply("noRoles"));
+                                                      handlers.apply("noRoles"), new Http.RequestBuilder().build());
         final String content = Helpers.contentAsString(html);
         Assert.assertTrue(content.contains("This is before the constraint."));
         Assert.assertTrue(content.contains("This is protected by the constraint."));
@@ -305,7 +306,7 @@ public class RestrictTest extends AbstractFakeApplicationTest
     public void testOr_oneSideNegated_noSubject()
     {
         final Content html = restrictContent().render(Collections.singletonList(new String[]{"!foo"}),
-                                                      handlers.apply("noSubject"));
+                                                      handlers.apply("noSubject"), new Http.RequestBuilder().build());
         final String content = Helpers.contentAsString(html);
         Assert.assertTrue(content.contains("This is before the constraint."));
         Assert.assertFalse(content.contains("This is protected by the constraint."));
@@ -316,7 +317,7 @@ public class RestrictTest extends AbstractFakeApplicationTest
     public void testAnd_oneSideNegated_fooPresent()
     {
         final Content html = restrictContent().render(Collections.singletonList(new String[]{"!foo", "bar"}),
-                                                      handlers.apply("foo"));
+                                                      handlers.apply("foo"), new Http.RequestBuilder().build());
         final String content = Helpers.contentAsString(html);
         Assert.assertTrue(content.contains("This is before the constraint."));
         Assert.assertFalse(content.contains("This is protected by the constraint."));
@@ -327,7 +328,7 @@ public class RestrictTest extends AbstractFakeApplicationTest
     public void testAnd_oneSideNegated_barPresent()
     {
         final Content html = restrictContent().render(Collections.singletonList(new String[]{"!foo", "bar"}),
-                                                      handlers.apply("bar"));
+                                                      handlers.apply("bar"), new Http.RequestBuilder().build());
         final String content = Helpers.contentAsString(html);
         Assert.assertTrue(content.contains("This is before the constraint."));
         Assert.assertTrue(content.contains("This is protected by the constraint."));
@@ -338,7 +339,7 @@ public class RestrictTest extends AbstractFakeApplicationTest
     public void testAnd_oneSideNegated_bothPresent()
     {
         final Content html = restrictContent().render(Collections.singletonList(new String[]{"!foo", "bar"}),
-                                                      handlers.apply("fooBar"));
+                                                      handlers.apply("fooBar"), new Http.RequestBuilder().build());
         final String content = Helpers.contentAsString(html);
         Assert.assertTrue(content.contains("This is before the constraint."));
         Assert.assertFalse(content.contains("This is protected by the constraint."));
@@ -349,7 +350,7 @@ public class RestrictTest extends AbstractFakeApplicationTest
     public void testAnd_oneSideNegated_neitherPresent()
     {
         final Content html = restrictContent().render(Collections.singletonList(new String[]{"!foo", "bar"}),
-                                                      handlers.apply("noRoles"));
+                                                      handlers.apply("noRoles"), new Http.RequestBuilder().build());
         final String content = Helpers.contentAsString(html);
         Assert.assertTrue(content.contains("This is before the constraint."));
         Assert.assertFalse(content.contains("This is protected by the constraint."));
@@ -360,7 +361,7 @@ public class RestrictTest extends AbstractFakeApplicationTest
     public void testAnd_oneSideNegated_noSubject()
     {
         final Content html = restrictContent().render(Collections.singletonList(new String[]{"!foo", "bar"}),
-                                                      handlers.apply("noSubject"));
+                                                      handlers.apply("noSubject"), new Http.RequestBuilder().build());
         final String content = Helpers.contentAsString(html);
         Assert.assertTrue(content.contains("This is before the constraint."));
         Assert.assertFalse(content.contains("This is protected by the constraint."));

--- a/code/test/be/objectify/deadbolt/java/views/di/restrictTest/RestrictTest.java
+++ b/code/test/be/objectify/deadbolt/java/views/di/restrictTest/RestrictTest.java
@@ -43,8 +43,7 @@ public class RestrictTest extends AbstractFakeApplicationTest
     @Test
     public void testSingleRole_present()
     {
-        final Content html = restrictContent().render(context(),
-                                                      Collections.singletonList(new String[]{"foo"}),
+        final Content html = restrictContent().render(Collections.singletonList(new String[]{"foo"}),
                                                       handlers.apply("foo"));
         final String content = Helpers.contentAsString(html);
         Assert.assertTrue(content.contains("This is before the constraint."));
@@ -55,8 +54,7 @@ public class RestrictTest extends AbstractFakeApplicationTest
     @Test
     public void testSingleRole_notPresent()
     {
-        final Content html = restrictContent().render(context(),
-                                                      Collections.singletonList(new String[]{"foo"}),
+        final Content html = restrictContent().render(Collections.singletonList(new String[]{"foo"}),
                                                       handlers.apply("bar"));
         final String content = Helpers.contentAsString(html);
         Assert.assertTrue(content.contains("This is before the constraint."));
@@ -67,8 +65,7 @@ public class RestrictTest extends AbstractFakeApplicationTest
     @Test
     public void testSingleRole_noRolesPresent()
     {
-        final Content html = restrictContent().render(context(),
-                                                      Collections.singletonList(new String[]{"foo"}),
+        final Content html = restrictContent().render(Collections.singletonList(new String[]{"foo"}),
                                                       handlers.apply("noRoles"));
         final String content = Helpers.contentAsString(html);
         Assert.assertTrue(content.contains("This is before the constraint."));
@@ -79,8 +76,7 @@ public class RestrictTest extends AbstractFakeApplicationTest
     @Test
     public void testSingleRole_noSubject()
     {
-        final Content html = restrictContent().render(context(),
-                                                      Collections.singletonList(new String[]{"foo"}),
+        final Content html = restrictContent().render(Collections.singletonList(new String[]{"foo"}),
                                                       handlers.apply("noSubject"));
         final String content = Helpers.contentAsString(html);
         Assert.assertTrue(content.contains("This is before the constraint."));
@@ -91,8 +87,7 @@ public class RestrictTest extends AbstractFakeApplicationTest
     @Test
     public void testOr_fooPresent()
     {
-        final Content html = restrictContent().render(context(),
-                                                      Arrays.asList(new String[]{"foo"},
+        final Content html = restrictContent().render(Arrays.asList(new String[]{"foo"},
                                                                     new String[]{"bar"}),
                                                       handlers.apply("foo"));
         final String content = Helpers.contentAsString(html);
@@ -104,8 +99,7 @@ public class RestrictTest extends AbstractFakeApplicationTest
     @Test
     public void testOr_barPresent()
     {
-        final Content html = restrictContent().render(context(),
-                                                      Arrays.asList(new String[]{"foo"},
+        final Content html = restrictContent().render(Arrays.asList(new String[]{"foo"},
                                                                     new String[]{"bar"}),
                                                       handlers.apply("bar"));
         final String content = Helpers.contentAsString(html);
@@ -117,8 +111,7 @@ public class RestrictTest extends AbstractFakeApplicationTest
     @Test
     public void testOr_bothPresent()
     {
-        final Content html = restrictContent().render(context(),
-                                                      Arrays.asList(new String[]{"foo"},
+        final Content html = restrictContent().render(Arrays.asList(new String[]{"foo"},
                                                                     new String[]{"bar"}),
                                                       handlers.apply("fooBar"));
         final String content = Helpers.contentAsString(html);
@@ -130,8 +123,7 @@ public class RestrictTest extends AbstractFakeApplicationTest
     @Test
     public void testOr_neitherPresent()
     {
-        final Content html = restrictContent().render(context(),
-                                                      Arrays.asList(new String[]{"foo"},
+        final Content html = restrictContent().render(Arrays.asList(new String[]{"foo"},
                                                                     new String[]{"bar"}),
                                                       handlers.apply("noRoles"));
         final String content = Helpers.contentAsString(html);
@@ -143,8 +135,7 @@ public class RestrictTest extends AbstractFakeApplicationTest
     @Test
     public void testOr_noSubject()
     {
-        final Content html = restrictContent().render(context(),
-                                                      Collections.singletonList(new String[]{"foo"}),
+        final Content html = restrictContent().render(Collections.singletonList(new String[]{"foo"}),
                                                       handlers.apply("noSubject"));
         final String content = Helpers.contentAsString(html);
         Assert.assertTrue(content.contains("This is before the constraint."));
@@ -155,8 +146,7 @@ public class RestrictTest extends AbstractFakeApplicationTest
     @Test
     public void testAnd_fooPresent()
     {
-        final Content html = restrictContent().render(context(),
-                                                      Collections.singletonList(new String[]{"foo", "bar"}),
+        final Content html = restrictContent().render(Collections.singletonList(new String[]{"foo", "bar"}),
                                                       handlers.apply("foo"));
         final String content = Helpers.contentAsString(html);
         Assert.assertTrue(content.contains("This is before the constraint."));
@@ -167,8 +157,7 @@ public class RestrictTest extends AbstractFakeApplicationTest
     @Test
     public void testAnd_barPresent()
     {
-        final Content html = restrictContent().render(context(),
-                                                      Collections.singletonList(new String[]{"foo", "bar"}),
+        final Content html = restrictContent().render(Collections.singletonList(new String[]{"foo", "bar"}),
                                                       handlers.apply("bar"));
         final String content = Helpers.contentAsString(html);
         Assert.assertTrue(content.contains("This is before the constraint."));
@@ -179,8 +168,7 @@ public class RestrictTest extends AbstractFakeApplicationTest
     @Test
     public void testAnd_bothPresent()
     {
-        final Content html = restrictContent().render(context(),
-                                                      Collections.singletonList(new String[]{"foo", "bar"}),
+        final Content html = restrictContent().render(Collections.singletonList(new String[]{"foo", "bar"}),
                                                       handlers.apply("fooBar"));
         final String content = Helpers.contentAsString(html);
         Assert.assertTrue(content.contains("This is before the constraint."));
@@ -191,8 +179,7 @@ public class RestrictTest extends AbstractFakeApplicationTest
     @Test
     public void testAnd_neitherPresent()
     {
-        final Content html = restrictContent().render(context(),
-                                                      Collections.singletonList(new String[]{"foo", "bar"}),
+        final Content html = restrictContent().render(Collections.singletonList(new String[]{"foo", "bar"}),
                                                       handlers.apply("noRoles"));
         final String content = Helpers.contentAsString(html);
         Assert.assertTrue(content.contains("This is before the constraint."));
@@ -203,8 +190,7 @@ public class RestrictTest extends AbstractFakeApplicationTest
     @Test
     public void testAnd_noSubject()
     {
-        final Content html = restrictContent().render(context(),
-                                                      Collections.singletonList(new String[]{"foo", "bar"}),
+        final Content html = restrictContent().render(Collections.singletonList(new String[]{"foo", "bar"}),
                                                       handlers.apply("noSubject"));
         final String content = Helpers.contentAsString(html);
         Assert.assertTrue(content.contains("This is before the constraint."));
@@ -215,8 +201,7 @@ public class RestrictTest extends AbstractFakeApplicationTest
     @Test
     public void testNegatedRole_subjectHasRole()
     {
-        final Content html = restrictContent().render(context(),
-                                                      Collections.singletonList(new String[]{"!foo"}),
+        final Content html = restrictContent().render(Collections.singletonList(new String[]{"!foo"}),
                                                       handlers.apply("foo"));
         final String content = Helpers.contentAsString(html);
         Assert.assertTrue(content.contains("This is before the constraint."));
@@ -227,8 +212,7 @@ public class RestrictTest extends AbstractFakeApplicationTest
     @Test
     public void testNegatedRole_subjectDoesNotHaveRole()
     {
-        final Content html = restrictContent().render(context(),
-                                                      Collections.singletonList(new String[]{"!foo"}),
+        final Content html = restrictContent().render(Collections.singletonList(new String[]{"!foo"}),
                                                       handlers.apply("bar"));
         final String content = Helpers.contentAsString(html);
         Assert.assertTrue(content.contains("This is before the constraint."));
@@ -239,8 +223,7 @@ public class RestrictTest extends AbstractFakeApplicationTest
     @Test
     public void testNegatedRole_subjectHasMultipleRole()
     {
-        final Content html = restrictContent().render(context(),
-                                                      Collections.singletonList(new String[]{"!foo"}),
+        final Content html = restrictContent().render(Collections.singletonList(new String[]{"!foo"}),
                                                       handlers.apply("fooBar"));
         final String content = Helpers.contentAsString(html);
         Assert.assertTrue(content.contains("This is before the constraint."));
@@ -251,8 +234,7 @@ public class RestrictTest extends AbstractFakeApplicationTest
     @Test
     public void testNegatedRole_noRolesPresent()
     {
-        final Content html = restrictContent().render(context(),
-                                                      Collections.singletonList(new String[]{"!foo"}),
+        final Content html = restrictContent().render(Collections.singletonList(new String[]{"!foo"}),
                                                       handlers.apply("noRoles"));
         final String content = Helpers.contentAsString(html);
         Assert.assertTrue(content.contains("This is before the constraint."));
@@ -263,8 +245,7 @@ public class RestrictTest extends AbstractFakeApplicationTest
     @Test
     public void testNegatedRole_noSubject()
     {
-        final Content html = restrictContent().render(context(),
-                                                      Collections.singletonList(new String[]{"!foo"}),
+        final Content html = restrictContent().render(Collections.singletonList(new String[]{"!foo"}),
                                                       handlers.apply("noSubject"));
         final String content = Helpers.contentAsString(html);
         Assert.assertTrue(content.contains("This is before the constraint."));
@@ -275,8 +256,7 @@ public class RestrictTest extends AbstractFakeApplicationTest
     @Test
     public void testOr_oneSideNegated_fooPresent()
     {
-        final Content html = restrictContent().render(context(),
-                                                      Arrays.asList(new String[]{"!foo"},
+        final Content html = restrictContent().render(Arrays.asList(new String[]{"!foo"},
                                                                     new String[]{"bar"}),
                                                       handlers.apply("foo"));
         final String content = Helpers.contentAsString(html);
@@ -288,8 +268,7 @@ public class RestrictTest extends AbstractFakeApplicationTest
     @Test
     public void testOr_oneSideNegated_barPresent()
     {
-        final Content html = restrictContent().render(context(),
-                                                      Arrays.asList(new String[]{"!foo"},
+        final Content html = restrictContent().render(Arrays.asList(new String[]{"!foo"},
                                                                     new String[]{"bar"}),
                                                       handlers.apply("bar"));
         final String content = Helpers.contentAsString(html);
@@ -301,8 +280,7 @@ public class RestrictTest extends AbstractFakeApplicationTest
     @Test
     public void testOr_oneSideNegated_bothPresent()
     {
-        final Content html = restrictContent().render(context(),
-                                                      Arrays.asList(new String[]{"!foo"},
+        final Content html = restrictContent().render(Arrays.asList(new String[]{"!foo"},
                                                                     new String[]{"bar"}),
                                                       handlers.apply("fooBar"));
         final String content = Helpers.contentAsString(html);
@@ -314,8 +292,7 @@ public class RestrictTest extends AbstractFakeApplicationTest
     @Test
     public void testOr_oneSideNegated_neitherPresent()
     {
-        final Content html = restrictContent().render(context(),
-                                                      Arrays.asList(new String[]{"!foo"},
+        final Content html = restrictContent().render(Arrays.asList(new String[]{"!foo"},
                                                                     new String[]{"bar"}),
                                                       handlers.apply("noRoles"));
         final String content = Helpers.contentAsString(html);
@@ -327,8 +304,7 @@ public class RestrictTest extends AbstractFakeApplicationTest
     @Test
     public void testOr_oneSideNegated_noSubject()
     {
-        final Content html = restrictContent().render(context(),
-                                                      Collections.singletonList(new String[]{"!foo"}),
+        final Content html = restrictContent().render(Collections.singletonList(new String[]{"!foo"}),
                                                       handlers.apply("noSubject"));
         final String content = Helpers.contentAsString(html);
         Assert.assertTrue(content.contains("This is before the constraint."));
@@ -339,8 +315,7 @@ public class RestrictTest extends AbstractFakeApplicationTest
     @Test
     public void testAnd_oneSideNegated_fooPresent()
     {
-        final Content html = restrictContent().render(context(),
-                                                      Collections.singletonList(new String[]{"!foo", "bar"}),
+        final Content html = restrictContent().render(Collections.singletonList(new String[]{"!foo", "bar"}),
                                                       handlers.apply("foo"));
         final String content = Helpers.contentAsString(html);
         Assert.assertTrue(content.contains("This is before the constraint."));
@@ -351,8 +326,7 @@ public class RestrictTest extends AbstractFakeApplicationTest
     @Test
     public void testAnd_oneSideNegated_barPresent()
     {
-        final Content html = restrictContent().render(context(),
-                                                      Collections.singletonList(new String[]{"!foo", "bar"}),
+        final Content html = restrictContent().render(Collections.singletonList(new String[]{"!foo", "bar"}),
                                                       handlers.apply("bar"));
         final String content = Helpers.contentAsString(html);
         Assert.assertTrue(content.contains("This is before the constraint."));
@@ -363,8 +337,7 @@ public class RestrictTest extends AbstractFakeApplicationTest
     @Test
     public void testAnd_oneSideNegated_bothPresent()
     {
-        final Content html = restrictContent().render(context(),
-                                                      Collections.singletonList(new String[]{"!foo", "bar"}),
+        final Content html = restrictContent().render(Collections.singletonList(new String[]{"!foo", "bar"}),
                                                       handlers.apply("fooBar"));
         final String content = Helpers.contentAsString(html);
         Assert.assertTrue(content.contains("This is before the constraint."));
@@ -375,8 +348,7 @@ public class RestrictTest extends AbstractFakeApplicationTest
     @Test
     public void testAnd_oneSideNegated_neitherPresent()
     {
-        final Content html = restrictContent().render(context(),
-                                                      Collections.singletonList(new String[]{"!foo", "bar"}),
+        final Content html = restrictContent().render(Collections.singletonList(new String[]{"!foo", "bar"}),
                                                       handlers.apply("noRoles"));
         final String content = Helpers.contentAsString(html);
         Assert.assertTrue(content.contains("This is before the constraint."));
@@ -387,8 +359,7 @@ public class RestrictTest extends AbstractFakeApplicationTest
     @Test
     public void testAnd_oneSideNegated_noSubject()
     {
-        final Content html = restrictContent().render(context(),
-                                                      Collections.singletonList(new String[]{"!foo", "bar"}),
+        final Content html = restrictContent().render(Collections.singletonList(new String[]{"!foo", "bar"}),
                                                       handlers.apply("noSubject"));
         final String content = Helpers.contentAsString(html);
         Assert.assertTrue(content.contains("This is before the constraint."));

--- a/code/test/be/objectify/deadbolt/java/views/di/restrictTest/restrictContent.scala.html
+++ b/code/test/be/objectify/deadbolt/java/views/di/restrictTest/restrictContent.scala.html
@@ -1,5 +1,5 @@
 @this(restrict: be.objectify.deadbolt.java.views.html.di.restrict)
-@(roles: List[Array[String]], deadboltHandler: be.objectify.deadbolt.java.DeadboltHandler)
+@(roles: List[Array[String]], deadboltHandler: be.objectify.deadbolt.java.DeadboltHandler)(implicit request: play.mvc.Http.Request)
 
 This is before the constraint.
 

--- a/code/test/be/objectify/deadbolt/java/views/di/restrictTest/restrictContent.scala.html
+++ b/code/test/be/objectify/deadbolt/java/views/di/restrictTest/restrictContent.scala.html
@@ -1,9 +1,9 @@
 @this(restrict: be.objectify.deadbolt.java.views.html.di.restrict)
-@(ctx: Http.Context, roles: List[Array[String]], deadboltHandler: be.objectify.deadbolt.java.DeadboltHandler)
+@(roles: List[Array[String]], deadboltHandler: be.objectify.deadbolt.java.DeadboltHandler)
 
 This is before the constraint.
 
-@restrict(context = ctx, roles = roles, handler = deadboltHandler) {
+@restrict(roles = roles, handler = deadboltHandler) {
     This is protected by the constraint.
 }
 

--- a/code/test/be/objectify/deadbolt/java/views/di/restrictTest/restrictOrContent.scala.html
+++ b/code/test/be/objectify/deadbolt/java/views/di/restrictTest/restrictOrContent.scala.html
@@ -1,9 +1,9 @@
 @this(restrictOr: be.objectify.deadbolt.java.views.html.di.restrictOr)
-@(ctx: Http.Context, roles: List[Array[String]], deadboltHandler: be.objectify.deadbolt.java.DeadboltHandler)
+@(roles: List[Array[String]], deadboltHandler: be.objectify.deadbolt.java.DeadboltHandler)
 
 This is before the constraint.
 
-@restrictOr(context = ctx, roles = roles, handler = deadboltHandler) {
+@restrictOr(roles = roles, handler = deadboltHandler) {
     This is protected by the constraint.
 } {
     This is default content in case the constraint denies access to the protected content.

--- a/code/test/be/objectify/deadbolt/java/views/di/restrictTest/restrictOrContent.scala.html
+++ b/code/test/be/objectify/deadbolt/java/views/di/restrictTest/restrictOrContent.scala.html
@@ -1,5 +1,5 @@
 @this(restrictOr: be.objectify.deadbolt.java.views.html.di.restrictOr)
-@(roles: List[Array[String]], deadboltHandler: be.objectify.deadbolt.java.DeadboltHandler)
+@(roles: List[Array[String]], deadboltHandler: be.objectify.deadbolt.java.DeadboltHandler)(implicit request: play.mvc.Http.Request)
 
 This is before the constraint.
 

--- a/code/test/be/objectify/deadbolt/java/views/di/subject/SubjectNotPresentOrTest.java
+++ b/code/test/be/objectify/deadbolt/java/views/di/subject/SubjectNotPresentOrTest.java
@@ -26,6 +26,7 @@ import org.junit.Assert;
 import org.junit.Test;
 import play.test.Helpers;
 import play.twirl.api.Content;
+import play.mvc.Http;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -40,7 +41,7 @@ public class SubjectNotPresentOrTest extends AbstractFakeApplicationTest
     @Test
     public void testWithSubjectPresent()
     {
-        final Content html = subjectNotPresentOrContent().render(handlers.apply("present"));
+        final Content html = subjectNotPresentOrContent().render(handlers.apply("present"), new Http.RequestBuilder().build());
         final String content = Helpers.contentAsString(html);
         Assert.assertTrue(content.contains("This is before the constraint."));
         Assert.assertFalse(content.contains("This is protected by the constraint."));
@@ -51,7 +52,7 @@ public class SubjectNotPresentOrTest extends AbstractFakeApplicationTest
     @Test
     public void testWithNoSubjectPresent()
     {
-        final Content html = subjectNotPresentOrContent().render(handlers.apply("notPresent"));
+        final Content html = subjectNotPresentOrContent().render(handlers.apply("notPresent"), new Http.RequestBuilder().build());
         final String content = Helpers.contentAsString(html);
         Assert.assertTrue(content.contains("This is before the constraint."));
         Assert.assertTrue(content.contains("This is protected by the constraint."));

--- a/code/test/be/objectify/deadbolt/java/views/di/subject/SubjectNotPresentOrTest.java
+++ b/code/test/be/objectify/deadbolt/java/views/di/subject/SubjectNotPresentOrTest.java
@@ -40,7 +40,7 @@ public class SubjectNotPresentOrTest extends AbstractFakeApplicationTest
     @Test
     public void testWithSubjectPresent()
     {
-        final Content html = subjectNotPresentOrContent().render(context(), handlers.apply("present"));
+        final Content html = subjectNotPresentOrContent().render(handlers.apply("present"));
         final String content = Helpers.contentAsString(html);
         Assert.assertTrue(content.contains("This is before the constraint."));
         Assert.assertFalse(content.contains("This is protected by the constraint."));
@@ -51,7 +51,7 @@ public class SubjectNotPresentOrTest extends AbstractFakeApplicationTest
     @Test
     public void testWithNoSubjectPresent()
     {
-        final Content html = subjectNotPresentOrContent().render(context(), handlers.apply("notPresent"));
+        final Content html = subjectNotPresentOrContent().render(handlers.apply("notPresent"));
         final String content = Helpers.contentAsString(html);
         Assert.assertTrue(content.contains("This is before the constraint."));
         Assert.assertTrue(content.contains("This is protected by the constraint."));

--- a/code/test/be/objectify/deadbolt/java/views/di/subject/SubjectNotPresentTest.java
+++ b/code/test/be/objectify/deadbolt/java/views/di/subject/SubjectNotPresentTest.java
@@ -40,7 +40,7 @@ public class SubjectNotPresentTest extends AbstractFakeApplicationTest
     @Test
     public void testWithSubjectPresent()
     {
-        final Content html = subjectNotPresentContent().render(context(), handlers.apply("present"));
+        final Content html = subjectNotPresentContent().render(handlers.apply("present"));
         final String content = Helpers.contentAsString(html);
         Assert.assertTrue(content.contains("This is before the constraint."));
         Assert.assertFalse(content.contains("This is protected by the constraint."));
@@ -50,7 +50,7 @@ public class SubjectNotPresentTest extends AbstractFakeApplicationTest
     @Test
     public void testWithNoSubjectPresent()
     {
-        final Content html = subjectNotPresentContent().render(context(), handlers.apply("notPresent"));
+        final Content html = subjectNotPresentContent().render(handlers.apply("notPresent"));
         final String content = Helpers.contentAsString(html);
         Assert.assertTrue(content.contains("This is before the constraint."));
         Assert.assertTrue(content.contains("This is protected by the constraint."));

--- a/code/test/be/objectify/deadbolt/java/views/di/subject/SubjectNotPresentTest.java
+++ b/code/test/be/objectify/deadbolt/java/views/di/subject/SubjectNotPresentTest.java
@@ -26,6 +26,7 @@ import org.junit.Assert;
 import org.junit.Test;
 import play.test.Helpers;
 import play.twirl.api.Content;
+import play.mvc.Http;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -40,7 +41,7 @@ public class SubjectNotPresentTest extends AbstractFakeApplicationTest
     @Test
     public void testWithSubjectPresent()
     {
-        final Content html = subjectNotPresentContent().render(handlers.apply("present"));
+        final Content html = subjectNotPresentContent().render(handlers.apply("present"), new Http.RequestBuilder().build());
         final String content = Helpers.contentAsString(html);
         Assert.assertTrue(content.contains("This is before the constraint."));
         Assert.assertFalse(content.contains("This is protected by the constraint."));
@@ -50,7 +51,7 @@ public class SubjectNotPresentTest extends AbstractFakeApplicationTest
     @Test
     public void testWithNoSubjectPresent()
     {
-        final Content html = subjectNotPresentContent().render(handlers.apply("notPresent"));
+        final Content html = subjectNotPresentContent().render(handlers.apply("notPresent"), new Http.RequestBuilder().build());
         final String content = Helpers.contentAsString(html);
         Assert.assertTrue(content.contains("This is before the constraint."));
         Assert.assertTrue(content.contains("This is protected by the constraint."));

--- a/code/test/be/objectify/deadbolt/java/views/di/subject/SubjectPresentOrTest.java
+++ b/code/test/be/objectify/deadbolt/java/views/di/subject/SubjectPresentOrTest.java
@@ -26,6 +26,7 @@ import org.junit.Assert;
 import org.junit.Test;
 import play.test.Helpers;
 import play.twirl.api.Content;
+import play.mvc.Http;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -40,7 +41,7 @@ public class SubjectPresentOrTest extends AbstractFakeApplicationTest
     @Test
     public void testWithSubjectPresent()
     {
-        final Content html = subjectPresentOrContent().render(handlers.apply("present"));
+        final Content html = subjectPresentOrContent().render(handlers.apply("present"), new Http.RequestBuilder().build());
         final String content = Helpers.contentAsString(html);
         Assert.assertTrue(content.contains("This is before the constraint."));
         Assert.assertTrue(content.contains("This is protected by the constraint."));
@@ -51,7 +52,7 @@ public class SubjectPresentOrTest extends AbstractFakeApplicationTest
     @Test
     public void testWithNoSubjectPresent()
     {
-        final Content html = subjectPresentOrContent().render(handlers.apply("notPresent"));
+        final Content html = subjectPresentOrContent().render(handlers.apply("notPresent"), new Http.RequestBuilder().build());
         final String content = Helpers.contentAsString(html);
         Assert.assertTrue(content.contains("This is before the constraint."));
         Assert.assertFalse(content.contains("This is protected by the constraint."));

--- a/code/test/be/objectify/deadbolt/java/views/di/subject/SubjectPresentOrTest.java
+++ b/code/test/be/objectify/deadbolt/java/views/di/subject/SubjectPresentOrTest.java
@@ -40,7 +40,7 @@ public class SubjectPresentOrTest extends AbstractFakeApplicationTest
     @Test
     public void testWithSubjectPresent()
     {
-        final Content html = subjectPresentOrContent().render(context(), handlers.apply("present"));
+        final Content html = subjectPresentOrContent().render(handlers.apply("present"));
         final String content = Helpers.contentAsString(html);
         Assert.assertTrue(content.contains("This is before the constraint."));
         Assert.assertTrue(content.contains("This is protected by the constraint."));
@@ -51,7 +51,7 @@ public class SubjectPresentOrTest extends AbstractFakeApplicationTest
     @Test
     public void testWithNoSubjectPresent()
     {
-        final Content html = subjectPresentOrContent().render(context(), handlers.apply("notPresent"));
+        final Content html = subjectPresentOrContent().render(handlers.apply("notPresent"));
         final String content = Helpers.contentAsString(html);
         Assert.assertTrue(content.contains("This is before the constraint."));
         Assert.assertFalse(content.contains("This is protected by the constraint."));

--- a/code/test/be/objectify/deadbolt/java/views/di/subject/SubjectPresentTest.java
+++ b/code/test/be/objectify/deadbolt/java/views/di/subject/SubjectPresentTest.java
@@ -40,7 +40,7 @@ public class SubjectPresentTest extends AbstractFakeApplicationTest
     @Test
     public void testWithSubjectPresent()
     {
-        final Content html = subjectPresentContent().render(context(), handlers.apply("present"));
+        final Content html = subjectPresentContent().render(handlers.apply("present"));
         final String content = Helpers.contentAsString(html);
         Assert.assertTrue(content.contains("This is before the constraint."));
         Assert.assertTrue(content.contains("This is protected by the constraint."));
@@ -50,7 +50,7 @@ public class SubjectPresentTest extends AbstractFakeApplicationTest
     @Test
     public void testWithNoSubjectPresent()
     {
-        final Content html = subjectPresentContent().render(context(), handlers.apply("notPresent"));
+        final Content html = subjectPresentContent().render(handlers.apply("notPresent"));
         final String content = Helpers.contentAsString(html);
         Assert.assertTrue(content.contains("This is before the constraint."));
         Assert.assertFalse(content.contains("This is protected by the constraint."));

--- a/code/test/be/objectify/deadbolt/java/views/di/subject/SubjectPresentTest.java
+++ b/code/test/be/objectify/deadbolt/java/views/di/subject/SubjectPresentTest.java
@@ -24,6 +24,7 @@ import be.objectify.deadbolt.java.views.html.di.subject.subjectPresentContent;
 import be.objectify.deadbolt.java.views.html.di.subjectPresent;
 import org.junit.Assert;
 import org.junit.Test;
+import play.mvc.Http;
 import play.test.Helpers;
 import play.twirl.api.Content;
 
@@ -40,7 +41,7 @@ public class SubjectPresentTest extends AbstractFakeApplicationTest
     @Test
     public void testWithSubjectPresent()
     {
-        final Content html = subjectPresentContent().render(handlers.apply("present"));
+        final Content html = subjectPresentContent().render(handlers.apply("present"), new Http.RequestBuilder().build());
         final String content = Helpers.contentAsString(html);
         Assert.assertTrue(content.contains("This is before the constraint."));
         Assert.assertTrue(content.contains("This is protected by the constraint."));
@@ -50,7 +51,7 @@ public class SubjectPresentTest extends AbstractFakeApplicationTest
     @Test
     public void testWithNoSubjectPresent()
     {
-        final Content html = subjectPresentContent().render(handlers.apply("notPresent"));
+        final Content html = subjectPresentContent().render(handlers.apply("notPresent"), new Http.RequestBuilder().build());
         final String content = Helpers.contentAsString(html);
         Assert.assertTrue(content.contains("This is before the constraint."));
         Assert.assertFalse(content.contains("This is protected by the constraint."));

--- a/code/test/be/objectify/deadbolt/java/views/di/subject/subjectNotPresentContent.scala.html
+++ b/code/test/be/objectify/deadbolt/java/views/di/subject/subjectNotPresentContent.scala.html
@@ -1,9 +1,9 @@
 @this(subjectNotPresent: be.objectify.deadbolt.java.views.html.di.subjectNotPresent)
-@(ctx: Http.Context, deadboltHandler: be.objectify.deadbolt.java.DeadboltHandler)
+@(deadboltHandler: be.objectify.deadbolt.java.DeadboltHandler)
 
 This is before the constraint.
 
-@subjectNotPresent(context = ctx, handler = deadboltHandler) {
+@subjectNotPresent(handler = deadboltHandler) {
     This is protected by the constraint.
 }
 

--- a/code/test/be/objectify/deadbolt/java/views/di/subject/subjectNotPresentContent.scala.html
+++ b/code/test/be/objectify/deadbolt/java/views/di/subject/subjectNotPresentContent.scala.html
@@ -1,5 +1,5 @@
 @this(subjectNotPresent: be.objectify.deadbolt.java.views.html.di.subjectNotPresent)
-@(deadboltHandler: be.objectify.deadbolt.java.DeadboltHandler)
+@(deadboltHandler: be.objectify.deadbolt.java.DeadboltHandler)(implicit request: play.mvc.Http.Request)
 
 This is before the constraint.
 

--- a/code/test/be/objectify/deadbolt/java/views/di/subject/subjectNotPresentOrContent.scala.html
+++ b/code/test/be/objectify/deadbolt/java/views/di/subject/subjectNotPresentOrContent.scala.html
@@ -1,9 +1,9 @@
 @this(subjectNotPresentOr: be.objectify.deadbolt.java.views.html.di.subjectNotPresentOr)
-@(ctx: Http.Context, deadboltHandler: be.objectify.deadbolt.java.DeadboltHandler)
+@(deadboltHandler: be.objectify.deadbolt.java.DeadboltHandler)
 
 This is before the constraint.
 
-@subjectNotPresentOr(context = ctx, handler = deadboltHandler) {
+@subjectNotPresentOr(handler = deadboltHandler) {
     This is protected by the constraint.
 } {
     This is default content in case the constraint denies access to the protected content.

--- a/code/test/be/objectify/deadbolt/java/views/di/subject/subjectNotPresentOrContent.scala.html
+++ b/code/test/be/objectify/deadbolt/java/views/di/subject/subjectNotPresentOrContent.scala.html
@@ -1,5 +1,5 @@
 @this(subjectNotPresentOr: be.objectify.deadbolt.java.views.html.di.subjectNotPresentOr)
-@(deadboltHandler: be.objectify.deadbolt.java.DeadboltHandler)
+@(deadboltHandler: be.objectify.deadbolt.java.DeadboltHandler)(implicit request: play.mvc.Http.Request)
 
 This is before the constraint.
 

--- a/code/test/be/objectify/deadbolt/java/views/di/subject/subjectPresentContent.scala.html
+++ b/code/test/be/objectify/deadbolt/java/views/di/subject/subjectPresentContent.scala.html
@@ -1,9 +1,9 @@
 @this(subjectPresent: be.objectify.deadbolt.java.views.html.di.subjectPresent)
-@(ctx: Http.Context, deadboltHandler: be.objectify.deadbolt.java.DeadboltHandler)
+@(deadboltHandler: be.objectify.deadbolt.java.DeadboltHandler)
 
 This is before the constraint.
 
-@subjectPresent(context = ctx, handler = deadboltHandler) {
+@subjectPresent(handler = deadboltHandler) {
     This is protected by the constraint.
 }
 

--- a/code/test/be/objectify/deadbolt/java/views/di/subject/subjectPresentContent.scala.html
+++ b/code/test/be/objectify/deadbolt/java/views/di/subject/subjectPresentContent.scala.html
@@ -1,5 +1,5 @@
 @this(subjectPresent: be.objectify.deadbolt.java.views.html.di.subjectPresent)
-@(deadboltHandler: be.objectify.deadbolt.java.DeadboltHandler)
+@(deadboltHandler: be.objectify.deadbolt.java.DeadboltHandler)(implicit request: play.mvc.Http.Request)
 
 This is before the constraint.
 

--- a/code/test/be/objectify/deadbolt/java/views/di/subject/subjectPresentOrContent.scala.html
+++ b/code/test/be/objectify/deadbolt/java/views/di/subject/subjectPresentOrContent.scala.html
@@ -1,5 +1,5 @@
 @this(subjectPresentOr: be.objectify.deadbolt.java.views.html.di.subjectPresentOr)
-@(deadboltHandler: be.objectify.deadbolt.java.DeadboltHandler)
+@(deadboltHandler: be.objectify.deadbolt.java.DeadboltHandler)(implicit request: play.mvc.Http.Request)
 
 This is before the constraint.
 

--- a/code/test/be/objectify/deadbolt/java/views/di/subject/subjectPresentOrContent.scala.html
+++ b/code/test/be/objectify/deadbolt/java/views/di/subject/subjectPresentOrContent.scala.html
@@ -1,9 +1,9 @@
 @this(subjectPresentOr: be.objectify.deadbolt.java.views.html.di.subjectPresentOr)
-@(ctx: Http.Context, deadboltHandler: be.objectify.deadbolt.java.DeadboltHandler)
+@(deadboltHandler: be.objectify.deadbolt.java.DeadboltHandler)
 
 This is before the constraint.
 
-@subjectPresentOr(context = ctx, handler = deadboltHandler) {
+@subjectPresentOr(handler = deadboltHandler) {
     This is protected by the constraint.
 } {
     This is default content in case the constraint denies access to the protected content.

--- a/test-app-filters/app/be/objectify/deadbolt/java/test/modules/CustomDeadboltFilterHook.java
+++ b/test-app-filters/app/be/objectify/deadbolt/java/test/modules/CustomDeadboltFilterHook.java
@@ -17,13 +17,14 @@ package be.objectify.deadbolt.java.test.modules;
 
 import be.objectify.deadbolt.java.filters.AuthorizedRoutes;
 import be.objectify.deadbolt.java.test.security.MyAuthorizedRoutes;
-import play.api.Configuration;
-import play.api.Environment;
-import play.api.inject.Binding;
-import play.api.inject.Module;
-import scala.collection.Seq;
+import com.typesafe.config.Config;
+import play.Environment;
+import play.inject.Binding;
+import play.inject.Module;
 
 import javax.inject.Singleton;
+import java.util.Arrays;
+import java.util.List;
 
 /**
  * @author Steve Chaloner (steve@objectify.be)
@@ -31,9 +32,9 @@ import javax.inject.Singleton;
 public class CustomDeadboltFilterHook extends Module
 {
     @Override
-    public Seq<Binding<?>> bindings(final Environment environment,
-                                    final Configuration configuration)
+    public List<Binding<?>> bindings(final Environment environment,
+                                     final Config config)
     {
-        return seq(bind(AuthorizedRoutes.class).to(MyAuthorizedRoutes.class).in(Singleton.class));
+        return Arrays.asList(bindClass(AuthorizedRoutes.class).to(MyAuthorizedRoutes.class).in(Singleton.class));
     }
 }

--- a/test-app-filters/app/be/objectify/deadbolt/java/test/modules/CustomDeadboltHook.java
+++ b/test-app-filters/app/be/objectify/deadbolt/java/test/modules/CustomDeadboltHook.java
@@ -26,13 +26,14 @@ import be.objectify.deadbolt.java.test.security.MyCustomTemplateFailureListener;
 import be.objectify.deadbolt.java.test.security.MyDeadboltHandler;
 import be.objectify.deadbolt.java.test.security.MyHandlerCache;
 import be.objectify.deadbolt.java.test.security.SomeOtherDeadboltHandler;
-import play.api.Configuration;
-import play.api.Environment;
-import play.api.inject.Binding;
-import play.api.inject.Module;
-import scala.collection.Seq;
+import com.typesafe.config.Config;
+import play.Environment;
+import play.inject.Binding;
+import play.inject.Module;
 
 import javax.inject.Singleton;
+import java.util.Arrays;
+import java.util.List;
 
 /**
  * @author Steve Chaloner (steve@objectify.be)
@@ -40,14 +41,14 @@ import javax.inject.Singleton;
 public class CustomDeadboltHook extends Module
 {
     @Override
-    public Seq<Binding<?>> bindings(final Environment environment,
-                                    final Configuration configuration)
+    public List<Binding<?>> bindings(final Environment environment,
+                                     final Config config)
     {
-        return seq(bind(TemplateFailureListener.class).to(MyCustomTemplateFailureListener.class).in(Singleton.class),
-                   bind(UserDao.class).to(DefaultUserDao.class).in(Singleton.class),
-                   bind(DeadboltHandler.class).qualifiedWith(HandlerQualifiers.MainHandler.class).to(MyDeadboltHandler.class).in(Singleton.class),
-                   bind(DeadboltHandler.class).qualifiedWith(HandlerQualifiers.SomeOtherHandler.class).to(SomeOtherDeadboltHandler.class).in(Singleton.class),
-                   bind(HandlerCache.class).to(MyHandlerCache.class).in(Singleton.class),
-                   bind(CompositeConstraints.class).toSelf().eagerly());
+        return Arrays.asList(bindClass(TemplateFailureListener.class).to(MyCustomTemplateFailureListener.class).in(Singleton.class),
+                             bindClass(UserDao.class).to(DefaultUserDao.class).in(Singleton.class),
+                             bindClass(DeadboltHandler.class).qualifiedWith(HandlerQualifiers.MainHandler.class).to(MyDeadboltHandler.class).in(Singleton.class),
+                             bindClass(DeadboltHandler.class).qualifiedWith(HandlerQualifiers.SomeOtherHandler.class).to(SomeOtherDeadboltHandler.class).in(Singleton.class),
+                             bindClass(HandlerCache.class).to(MyHandlerCache.class).in(Singleton.class),
+                             bindClass(CompositeConstraints.class).toSelf().eagerly());
     }
 }

--- a/test-app-filters/app/be/objectify/deadbolt/java/test/security/CompositeDynamicResourceHandler.java
+++ b/test-app-filters/app/be/objectify/deadbolt/java/test/security/CompositeDynamicResourceHandler.java
@@ -15,7 +15,7 @@
  */
 package be.objectify.deadbolt.java.test.security;
 
-import be.objectify.deadbolt.java.ConfigKeys;
+import be.objectify.deadbolt.java.Constants;
 import be.objectify.deadbolt.java.DeadboltHandler;
 import be.objectify.deadbolt.java.DynamicResourceHandler;
 import org.slf4j.Logger;
@@ -79,7 +79,7 @@ public class CompositeDynamicResourceHandler implements DynamicResourceHandler
                                                                                 .stream()
                                                                                 .filter(perm -> perm.getValue().contains("zombie"))
                                                                                 .count() > 0)
-                                                         .orElseGet(() -> (Boolean) requestHeader.attrs().getOptional(ConfigKeys.PATTERN_INVERT)
+                                                         .orElseGet(() -> (Boolean) requestHeader.attrs().getOptional(Constants.PATTERN_INVERT)
                                                                                                                       .orElse(false)));
     }
 }

--- a/test-app-filters/app/be/objectify/deadbolt/java/test/security/CompositeDynamicResourceHandler.java
+++ b/test-app-filters/app/be/objectify/deadbolt/java/test/security/CompositeDynamicResourceHandler.java
@@ -46,7 +46,7 @@ public class CompositeDynamicResourceHandler implements DynamicResourceHandler
     public CompletionStage<Boolean> isAllowed(final String name,
                                               final Optional<String> meta,
                                               final DeadboltHandler deadboltHandler,
-                                              final Http.Context ctx)
+                                              final Http.RequestHeader requestHeader)
     {
         final DynamicResourceHandler delegate = delegates.get(name);
         final CompletionStage<Boolean> result;
@@ -61,7 +61,7 @@ public class CompositeDynamicResourceHandler implements DynamicResourceHandler
             result = delegate.isAllowed(name,
                                         meta,
                                         deadboltHandler,
-                                        ctx);
+                                        requestHeader);
         }
         return result;
     }
@@ -70,16 +70,16 @@ public class CompositeDynamicResourceHandler implements DynamicResourceHandler
     public CompletionStage<Boolean> checkPermission(final String permissionValue,
                                                     final Optional<String> meta,
                                                     final DeadboltHandler deadboltHandler,
-                                                    final Http.Context ctx)
+                                                    final Http.RequestHeader requestHeader)
     {
         // this can be completely arbitrary, but to keep things simple for testing we're
         // just checking for zombies...just like I do every night before I go to bed
-        return deadboltHandler.getSubject(ctx)
+        return deadboltHandler.getSubject(requestHeader)
                               .thenApply(option -> option.map(subject -> subject.getPermissions()
                                                                                 .stream()
                                                                                 .filter(perm -> perm.getValue().contains("zombie"))
                                                                                 .count() > 0)
-                                                         .orElseGet(() -> (Boolean) ctx.args.getOrDefault(ConfigKeys.PATTERN_INVERT,
-                                                                                                          false)));
+                                                         .orElseGet(() -> (Boolean) requestHeader.attrs().getOptional(ConfigKeys.PATTERN_INVERT)
+                                                                                                                      .orElse(false)));
     }
 }

--- a/test-app-filters/app/be/objectify/deadbolt/java/test/security/MyDeadboltHandler.java
+++ b/test-app-filters/app/be/objectify/deadbolt/java/test/security/MyDeadboltHandler.java
@@ -16,7 +16,7 @@
 package be.objectify.deadbolt.java.test.security;
 
 import be.objectify.deadbolt.java.AbstractDeadboltHandler;
-import be.objectify.deadbolt.java.ConfigKeys;
+import be.objectify.deadbolt.java.Constants;
 import be.objectify.deadbolt.java.DynamicResourceHandler;
 import be.objectify.deadbolt.java.models.Permission;
 import be.objectify.deadbolt.java.models.Subject;
@@ -82,6 +82,6 @@ public class MyDeadboltHandler extends AbstractDeadboltHandler
     @Override
     public String handlerName()
     {
-        return ConfigKeys.DEFAULT_HANDLER_KEY;
+        return Constants.DEFAULT_HANDLER_KEY;
     }
 }

--- a/test-app-filters/app/be/objectify/deadbolt/java/test/security/MyDeadboltHandler.java
+++ b/test-app-filters/app/be/objectify/deadbolt/java/test/security/MyDeadboltHandler.java
@@ -55,20 +55,20 @@ public class MyDeadboltHandler extends AbstractDeadboltHandler
     }
 
     @Override
-    public CompletionStage<Optional<? extends Subject>> getSubject(final Http.Context context)
+    public CompletionStage<Optional<? extends Subject>> getSubject(final Http.RequestHeader requestHeader)
     {
-        final Optional<Http.Cookie> maybeUserCookie = Optional.ofNullable(context.request().cookie("user"));
+        final Optional<Http.Cookie> maybeUserCookie = Optional.ofNullable(requestHeader.cookie("user"));
         return CompletableFuture.supplyAsync(() -> maybeUserCookie.flatMap(cookie -> userDao.getByUserName(cookie.value())));
     }
 
     @Override
-    public CompletionStage<Optional<Result>> beforeAuthCheck(final Http.Context context, final Optional<String> content)
+    public CompletionStage<Optional<Result>> beforeAuthCheck(final Http.RequestHeader requestHeader, final Optional<String> content)
     {
         return CompletableFuture.completedFuture(Optional.empty());
     }
 
     @Override
-    public CompletionStage<Optional<DynamicResourceHandler>> getDynamicResourceHandler(final Http.Context context)
+    public CompletionStage<Optional<DynamicResourceHandler>> getDynamicResourceHandler(final Http.RequestHeader requestHeader)
     {
         return CompletableFuture.supplyAsync(() -> Optional.of(dynamicHandler));
     }

--- a/test-app-filters/app/be/objectify/deadbolt/java/test/security/NiceNameDynamicResourceHandler.java
+++ b/test-app-filters/app/be/objectify/deadbolt/java/test/security/NiceNameDynamicResourceHandler.java
@@ -34,9 +34,9 @@ public class NiceNameDynamicResourceHandler implements DynamicResourceHandler
     public CompletionStage<Boolean> isAllowed(final String name,
                                               final Optional<String> meta,
                                               final DeadboltHandler deadboltHandler,
-                                              final Http.Context ctx)
+                                              final Http.RequestHeader requestHeadertx)
     {
-        return deadboltHandler.getSubject(ctx)
+        return deadboltHandler.getSubject(requestHeadertx)
                               .thenApply(option -> option.isPresent() && option.get().getIdentifier()
                                                                                .contains("greet"));
     }
@@ -45,7 +45,7 @@ public class NiceNameDynamicResourceHandler implements DynamicResourceHandler
     public CompletionStage<Boolean> checkPermission(final String permissionValue,
                                                     final Optional<String> meta,
                                                     final DeadboltHandler deadboltHandler,
-                                                    final Http.Context ctx)
+                                                    final Http.RequestHeader requestHeader)
     {
         return CompletableFuture.completedFuture(false);
     }

--- a/test-app-filters/app/be/objectify/deadbolt/java/test/security/SomeOtherDeadboltHandler.java
+++ b/test-app-filters/app/be/objectify/deadbolt/java/test/security/SomeOtherDeadboltHandler.java
@@ -34,19 +34,19 @@ import java.util.concurrent.CompletionStage;
 public class SomeOtherDeadboltHandler extends AbstractDeadboltHandler
 {
     @Override
-    public CompletionStage<Optional<? extends Subject>> getSubject(final Http.Context context)
+    public CompletionStage<Optional<? extends Subject>> getSubject(final Http.RequestHeader requestHeader)
     {
         return CompletableFuture.completedFuture(Optional.empty());
     }
 
     @Override
-    public CompletionStage<Optional<Result>> beforeAuthCheck(final Http.Context context, final Optional<String> content)
+    public CompletionStage<Optional<Result>> beforeAuthCheck(final Http.RequestHeader requestHeader, final Optional<String> content)
     {
         return CompletableFuture.completedFuture(Optional.empty());
     }
 
     @Override
-    public CompletionStage<Optional<DynamicResourceHandler>> getDynamicResourceHandler(final Http.Context context)
+    public CompletionStage<Optional<DynamicResourceHandler>> getDynamicResourceHandler(final Http.RequestHeader requestHeader)
     {
         return CompletableFuture.completedFuture(Optional.empty());
     }

--- a/test-app-filters/build.sbt
+++ b/test-app-filters/build.sbt
@@ -6,14 +6,17 @@ scalaVersion := "2.12.7"
 
 testOptions += Tests.Argument(TestFrameworks.JUnit, "-v", "-a")
 
+javacOptions += "-Xlint:deprecation"
+scalacOptions += "-deprecation"
+
 libraryDependencies ++= Seq(
   guice,
   "be.objectify" %% "deadbolt-java" % "2.7.0-SNAPSHOT",
   "com.jayway.restassured" % "rest-assured" % "2.4.0" % "test"
 )
 
-resolvers += Resolver.sonatypeRepo("snapshots")
-
 lazy val root = (project in file(".")).enablePlugins(PlayJava)
+
+resolvers += Resolver.sonatypeRepo("snapshots")
 
 sbt.Keys.fork in Test := false

--- a/test-app-filters/build.sbt
+++ b/test-app-filters/build.sbt
@@ -2,7 +2,7 @@ name := """test-app-filters"""
 
 version := "2.7.0-SNAPSHOT"
 
-scalaVersion := "2.12.6"
+scalaVersion := "2.12.7"
 
 testOptions += Tests.Argument(TestFrameworks.JUnit, "-v", "-a")
 

--- a/test-app-filters/project/build.properties
+++ b/test-app-filters/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.1.6
+sbt.version=1.2.6

--- a/test-app-filters/project/plugins.sbt
+++ b/test-app-filters/project/plugins.sbt
@@ -1,3 +1,3 @@
-addSbtPlugin("com.typesafe.play" % "sbt-plugin" % System.getProperty("playTestVersion", "2.7.0-M1"))
+addSbtPlugin("com.typesafe.play" % "sbt-plugin" % System.getProperty("playTestVersion", "2.7.0-RC3"))
 
 resolvers += Resolver.sonatypeRepo("snapshots")

--- a/test-app/app/be/objectify/deadbolt/java/test/modules/CustomDeadboltHook.java
+++ b/test-app/app/be/objectify/deadbolt/java/test/modules/CustomDeadboltHook.java
@@ -26,13 +26,14 @@ import be.objectify.deadbolt.java.test.security.MyCustomTemplateFailureListener;
 import be.objectify.deadbolt.java.test.security.MyDeadboltHandler;
 import be.objectify.deadbolt.java.test.security.MyHandlerCache;
 import be.objectify.deadbolt.java.test.security.SomeOtherDeadboltHandler;
-import play.api.Configuration;
-import play.api.Environment;
-import play.api.inject.Binding;
-import play.api.inject.Module;
-import scala.collection.Seq;
+import com.typesafe.config.Config;
+import play.Environment;
+import play.inject.Binding;
+import play.inject.Module;
 
 import javax.inject.Singleton;
+import java.util.Arrays;
+import java.util.List;
 
 /**
  * @author Steve Chaloner (steve@objectify.be)
@@ -40,14 +41,14 @@ import javax.inject.Singleton;
 public class CustomDeadboltHook extends Module
 {
     @Override
-    public Seq<Binding<?>> bindings(final Environment environment,
-                                    final Configuration configuration)
+    public List<Binding<?>> bindings(final Environment environment,
+                                     final Config config)
     {
-        return seq(bind(TemplateFailureListener.class).to(MyCustomTemplateFailureListener.class).in(Singleton.class),
-                   bind(UserDao.class).to(DefaultUserDao.class).in(Singleton.class),
-                   bind(DeadboltHandler.class).qualifiedWith(HandlerQualifiers.MainHandler.class).to(MyDeadboltHandler.class).in(Singleton.class),
-                   bind(DeadboltHandler.class).qualifiedWith(HandlerQualifiers.SomeOtherHandler.class).to(SomeOtherDeadboltHandler.class).in(Singleton.class),
-                   bind(HandlerCache.class).to(MyHandlerCache.class).in(Singleton.class),
-                   bind(CompositeConstraints.class).toSelf().eagerly());
+        return Arrays.asList(bindClass(TemplateFailureListener.class).to(MyCustomTemplateFailureListener.class).in(Singleton.class),
+                             bindClass(UserDao.class).to(DefaultUserDao.class).in(Singleton.class),
+                             bindClass(DeadboltHandler.class).qualifiedWith(HandlerQualifiers.MainHandler.class).to(MyDeadboltHandler.class).in(Singleton.class),
+                             bindClass(DeadboltHandler.class).qualifiedWith(HandlerQualifiers.SomeOtherHandler.class).to(SomeOtherDeadboltHandler.class).in(Singleton.class),
+                             bindClass(HandlerCache.class).to(MyHandlerCache.class).in(Singleton.class),
+                             bindClass(CompositeConstraints.class).toSelf().eagerly());
     }
 }

--- a/test-app/app/be/objectify/deadbolt/java/test/security/CompositeDynamicResourceHandler.java
+++ b/test-app/app/be/objectify/deadbolt/java/test/security/CompositeDynamicResourceHandler.java
@@ -15,7 +15,7 @@
  */
 package be.objectify.deadbolt.java.test.security;
 
-import be.objectify.deadbolt.java.ConfigKeys;
+import be.objectify.deadbolt.java.Constants;
 import be.objectify.deadbolt.java.DeadboltHandler;
 import be.objectify.deadbolt.java.DynamicResourceHandler;
 import org.slf4j.Logger;
@@ -79,7 +79,7 @@ public class CompositeDynamicResourceHandler implements DynamicResourceHandler
                                                                                 .stream()
                                                                                 .filter(perm -> perm.getValue().contains("zombie"))
                                                                                 .count() > 0)
-                                                         .orElseGet(() -> (Boolean) requestHeader.attrs().getOptional(ConfigKeys.PATTERN_INVERT)
+                                                         .orElseGet(() -> (Boolean) requestHeader.attrs().getOptional(Constants.PATTERN_INVERT)
                                                                                                                       .orElse(false)));
     }
 }

--- a/test-app/app/be/objectify/deadbolt/java/test/security/CompositeDynamicResourceHandler.java
+++ b/test-app/app/be/objectify/deadbolt/java/test/security/CompositeDynamicResourceHandler.java
@@ -46,7 +46,7 @@ public class CompositeDynamicResourceHandler implements DynamicResourceHandler
     public CompletionStage<Boolean> isAllowed(final String name,
                                               final Optional<String> meta,
                                               final DeadboltHandler deadboltHandler,
-                                              final Http.Context ctx)
+                                              final Http.RequestHeader requestHeader)
     {
         final DynamicResourceHandler delegate = delegates.get(name);
         final CompletionStage<Boolean> result;
@@ -61,7 +61,7 @@ public class CompositeDynamicResourceHandler implements DynamicResourceHandler
             result = delegate.isAllowed(name,
                                         meta,
                                         deadboltHandler,
-                                        ctx);
+                                        requestHeader);
         }
         return result;
     }
@@ -70,16 +70,16 @@ public class CompositeDynamicResourceHandler implements DynamicResourceHandler
     public CompletionStage<Boolean> checkPermission(final String permissionValue,
                                                     final Optional<String> meta,
                                                     final DeadboltHandler deadboltHandler,
-                                                    final Http.Context ctx)
+                                                    final Http.RequestHeader requestHeader)
     {
         // this can be completely arbitrary, but to keep things simple for testing we're
         // just checking for zombies...just like I do every night before I go to bed
-        return deadboltHandler.getSubject(ctx)
+        return deadboltHandler.getSubject(requestHeader)
                               .thenApply(option -> option.map(subject -> subject.getPermissions()
                                                                                 .stream()
                                                                                 .filter(perm -> perm.getValue().contains("zombie"))
                                                                                 .count() > 0)
-                                                         .orElseGet(() -> (Boolean) ctx.args.getOrDefault(ConfigKeys.PATTERN_INVERT,
-                                                                                                          false)));
+                                                         .orElseGet(() -> (Boolean) requestHeader.attrs().getOptional(ConfigKeys.PATTERN_INVERT)
+                                                                                                                      .orElse(false)));
     }
 }

--- a/test-app/app/be/objectify/deadbolt/java/test/security/MyDeadboltHandler.java
+++ b/test-app/app/be/objectify/deadbolt/java/test/security/MyDeadboltHandler.java
@@ -60,20 +60,20 @@ public class MyDeadboltHandler extends AbstractDeadboltHandler
     }
 
     @Override
-    public CompletionStage<Optional<? extends Subject>> getSubject(final Http.Context context)
+    public CompletionStage<Optional<? extends Subject>> getSubject(final Http.RequestHeader requestHeader)
     {
-        final Optional<Http.Cookie> maybeUserCookie = Optional.ofNullable(context.request().cookie("user"));
+        final Optional<Http.Cookie> maybeUserCookie = Optional.ofNullable(requestHeader.cookie("user"));
         return CompletableFuture.supplyAsync(() -> maybeUserCookie.flatMap(cookie -> userDao.getByUserName(cookie.value())));
     }
 
     @Override
-    public CompletionStage<Optional<Result>> beforeAuthCheck(final Http.Context context, final Optional<String> content)
+    public CompletionStage<Optional<Result>> beforeAuthCheck(final Http.RequestHeader requestHeader, final Optional<String> content)
     {
         return CompletableFuture.completedFuture(Optional.empty());
     }
 
     @Override
-    public CompletionStage<Optional<DynamicResourceHandler>> getDynamicResourceHandler(final Http.Context context)
+    public CompletionStage<Optional<DynamicResourceHandler>> getDynamicResourceHandler(final Http.RequestHeader requestHeader)
     {
         return CompletableFuture.supplyAsync(() -> Optional.of(dynamicHandler));
     }
@@ -90,13 +90,13 @@ public class MyDeadboltHandler extends AbstractDeadboltHandler
     }
 
     @Override
-    public void onAuthSuccess(Http.Context context,
+    public void onAuthSuccess(Http.RequestHeader requestHeader,
                               String constraintType,
                               ConstraintPoint constraintPoint)
     {
         LOGGER.info("[{} - {}] - authorization succeeded for [{}]",
                     constraintPoint,
                     constraintType,
-                    context.args);
+                    requestHeader.attrs());
     }
 }

--- a/test-app/app/be/objectify/deadbolt/java/test/security/MyDeadboltHandler.java
+++ b/test-app/app/be/objectify/deadbolt/java/test/security/MyDeadboltHandler.java
@@ -15,7 +15,7 @@
  */
 package be.objectify.deadbolt.java.test.security;
 
-import be.objectify.deadbolt.java.ConfigKeys;
+import be.objectify.deadbolt.java.Constants;
 import be.objectify.deadbolt.java.ConstraintPoint;
 import be.objectify.deadbolt.java.models.Permission;
 import be.objectify.deadbolt.java.models.Subject;
@@ -86,7 +86,7 @@ public class MyDeadboltHandler extends AbstractDeadboltHandler
     @Override
     public String handlerName()
     {
-        return ConfigKeys.DEFAULT_HANDLER_KEY;
+        return Constants.DEFAULT_HANDLER_KEY;
     }
 
     @Override

--- a/test-app/app/be/objectify/deadbolt/java/test/security/NiceNameDynamicResourceHandler.java
+++ b/test-app/app/be/objectify/deadbolt/java/test/security/NiceNameDynamicResourceHandler.java
@@ -34,9 +34,9 @@ public class NiceNameDynamicResourceHandler implements DynamicResourceHandler
     public CompletionStage<Boolean> isAllowed(final String name,
                                               final Optional<String> meta,
                                               final DeadboltHandler deadboltHandler,
-                                              final Http.Context ctx)
+                                              final Http.RequestHeader requestHeader)
     {
-        return deadboltHandler.getSubject(ctx)
+        return deadboltHandler.getSubject(requestHeader)
                               .thenApply(option -> option.isPresent() && option.get().getIdentifier()
                                                                                .contains("greet"));
     }
@@ -45,7 +45,7 @@ public class NiceNameDynamicResourceHandler implements DynamicResourceHandler
     public CompletionStage<Boolean> checkPermission(final String permissionValue,
                                                     final Optional<String> meta,
                                                     final DeadboltHandler deadboltHandler,
-                                                    final Http.Context ctx)
+                                                    final Http.RequestHeader requestHeader)
     {
         return CompletableFuture.completedFuture(false);
     }

--- a/test-app/app/be/objectify/deadbolt/java/test/security/SomeOtherDeadboltHandler.java
+++ b/test-app/app/be/objectify/deadbolt/java/test/security/SomeOtherDeadboltHandler.java
@@ -39,31 +39,31 @@ public class SomeOtherDeadboltHandler extends AbstractDeadboltHandler
     private static final Logger LOGGER = LoggerFactory.getLogger(SomeOtherDeadboltHandler.class);
 
     @Override
-    public CompletionStage<Optional<? extends Subject>> getSubject(final Http.Context context)
+    public CompletionStage<Optional<? extends Subject>> getSubject(final Http.RequestHeader requestHeader)
     {
         return CompletableFuture.completedFuture(Optional.empty());
     }
 
     @Override
-    public CompletionStage<Optional<Result>> beforeAuthCheck(final Http.Context context, final Optional<String> content)
+    public CompletionStage<Optional<Result>> beforeAuthCheck(final Http.RequestHeader requestHeader, final Optional<String> content)
     {
         return CompletableFuture.completedFuture(Optional.empty());
     }
 
     @Override
-    public CompletionStage<Optional<DynamicResourceHandler>> getDynamicResourceHandler(final Http.Context context)
+    public CompletionStage<Optional<DynamicResourceHandler>> getDynamicResourceHandler(final Http.RequestHeader requestHeader)
     {
         return CompletableFuture.completedFuture(Optional.empty());
     }
 
     @Override
-    public void onAuthSuccess(Http.Context context,
+    public void onAuthSuccess(Http.RequestHeader requestHeader,
                               String constraintType,
                               ConstraintPoint constraintPoint)
     {
         LOGGER.info("[{} - {}] - authorization succeeded for [{}]",
                     constraintPoint,
                     constraintType,
-                    context.args);
+                    requestHeader.attrs());
     }
 }

--- a/test-app/build.sbt
+++ b/test-app/build.sbt
@@ -2,7 +2,7 @@ name := """test-app"""
 
 version := "2.7.0-SNAPSHOT"
 
-scalaVersion := "2.12.6"
+scalaVersion := "2.12.7"
 
 testOptions += Tests.Argument(TestFrameworks.JUnit, "-v", "-a")
 

--- a/test-app/build.sbt
+++ b/test-app/build.sbt
@@ -6,6 +6,9 @@ scalaVersion := "2.12.7"
 
 testOptions += Tests.Argument(TestFrameworks.JUnit, "-v", "-a")
 
+javacOptions += "-Xlint:deprecation"
+scalacOptions += "-deprecation"
+
 libraryDependencies ++= Seq(
   guice,
   "be.objectify" %% "deadbolt-java" % "2.7.0-SNAPSHOT",
@@ -16,4 +19,4 @@ lazy val root = (project in file(".")).enablePlugins(PlayJava)
 
 resolvers += Resolver.sonatypeRepo("snapshots")
 
-sbt.Keys.fork in (Test) := false
+sbt.Keys.fork in Test := false

--- a/test-app/project/build.properties
+++ b/test-app/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.1.6
+sbt.version=1.2.6

--- a/test-app/project/plugins.sbt
+++ b/test-app/project/plugins.sbt
@@ -1,3 +1,3 @@
-addSbtPlugin("com.typesafe.play" % "sbt-plugin" % System.getProperty("playTestVersion", "2.7.0-M1"))
+addSbtPlugin("com.typesafe.play" % "sbt-plugin" % System.getProperty("playTestVersion", "2.7.0-RC3"))
 
 resolvers += Resolver.sonatypeRepo("snapshots")


### PR DESCRIPTION
_[Play 2.7.0-RC3 released!](https://discuss.lightbend.com/t/play-2-7-0-rc3-released/2715)_

The biggest change probably is that `Http.Context` and the thread-local `Http.Context.current` is deprecated. Because deadbolt makes use of `ctx.args` to store data, we have to move away from it by using `Http.RequestHeader` and it's request attributes instead:
https://www.playframework.com/documentation/2.7.0-RC3/JavaHttpContextMigration27

What changes for users is that they will get `Http.RequestHeaders` passed now instead of `Http.Context` e.g. in the deadbolt handler methods.
Also, the Deadbolt twirl templates expect an implicit requestheader to be present in the implicit scope now. That however is not a breaking change immediately, because Play's [`TemplateMagicForJava`](https://github.com/playframework/playframework/blob/2.7.0-RC3/framework/src/play-java/src/main/scala/play/core/TemplateMagicForJava.scala#L36-L38) takes care of this by provding you that implicit requestheader by getting it from the context thread-local. Also see:
https://www.playframework.com/documentation/2.7.0-RC3/JavaHttpContextMigration27#Some-template-tags-need-an-implicit-Request,-Messages-or-Lang-instance

Another thing is I finally moved the default configs to the `reference.conf` file (instead of having it in a `ConfigKeys` class)